### PR TITLE
Update 2012/kang/hint.*.

### DIFF
--- a/2012/kang/hint.html
+++ b/2012/kang/hint.html
@@ -67,6 +67,7 @@ are same.</li>
 <li>It supports every non-negative integer less than 10<sup>15</sup>-1. It uses
 the small scale (i.e. American): <code>billion</code> is 10<sup>9</sup> and <code>trillion</code> is
 10<sup>12</sup>.</li>
+<li>Sometimes, it can magically correct typos.</li>
 </ul>
 
 
@@ -83,7 +84,8 @@ the small scale (i.e. American): <code>billion</code> is 10<sup>9</sup> and <cod
 <p>This program is quite portable, only requiring the following:</p>
 
 <ul>
-<li>The signature <code>int main(int, int)</code> should be accepted by the linker.</li>
+<li>The signature <code>int main(int, int)</code> should be accepted by the linker. (Original
+version only)</li>
 <li><code>char</code> should be at least 8 bits long (as dictated by the standard), <code>int</code>
 should be at least 32 bits long, <code>long long</code> should be at least 64 bits long.</li>
 <li>Both the compiler and execution environment should use an ASCII-compatible
@@ -97,7 +99,7 @@ character set and two&rsquo;s complement representation.</li>
 (it has to be negative per the standard) and both signed and unsigned <code>char</code>,
 for example. Furthermore it is endian-independent.</p>
 
-<h2>Obfuscations</h2>
+<h2>Obfuscations (SPOILERS!)</h2>
 
 <p>Many obfuscations used are typical for standard IOCCC entries:</p>
 
@@ -172,12 +174,10 @@ and the biggest constant 6177 is not arbitrarily chosen.</p>
 
 <h2>Acknowledgement</h2>
 
-<p>[Removed for proper judgement: I&rsquo;ll fill this section if I do win.]</p>
-
-<p>[Note: If you think you&rsquo;ve seen this program elsewhere, you are probably right;
-I&rsquo;m submitting a program I have published years ago (and I have written myself,
-of course). Neither rules nor guidelines disallow such a resubmission, so I guess
-it&rsquo;s fine.]</p>
+<p>The cleaner (size-optimized) version of this program was originally published
+in my website in July 2011. Sun Park and others have reviewed it and let me
+aware of possible improvements. I&rsquo;d also like to thank Seo Sanghyeon for
+proof-reading remarks.</p>
 
 <hr />
 

--- a/2012/kang/hint.text
+++ b/2012/kang/hint.text
@@ -52,6 +52,7 @@ It accepts a variety of spelt numbers:
 * It supports every non-negative integer less than 10<sup>15</sup>-1. It uses
   the small scale (i.e. American): `billion` is 10<sup>9</sup> and `trillion` is
   10<sup>12</sup>.
+* Sometimes, it can magically correct typos.
 
 It does *not* accept some spelt numbers, which I found mostly irrelevant:
 
@@ -62,7 +63,8 @@ It does *not* accept some spelt numbers, which I found mostly irrelevant:
 
 This program is quite portable, only requiring the following:
 
-* The signature `int main(int, int)` should be accepted by the linker.
+* The signature `int main(int, int)` should be accepted by the linker. (Original
+  version only)
 * `char` should be at least 8 bits long (as dictated by the standard), `int`
   should be at least 32 bits long, `long long` should be at least 64 bits long.
 * Both the compiler and execution environment should use an ASCII-compatible
@@ -76,7 +78,7 @@ The design of the program explicitly allows for `EOF` which does not equal to -1
 (it has to be negative per the standard) and both signed and unsigned `char`,
 for example. Furthermore it is endian-independent.
 
-## Obfuscations
+## Obfuscations (SPOILERS!)
 
 Many obfuscations used are typical for standard IOCCC entries:
 
@@ -142,12 +144,10 @@ and the biggest constant 6177 is not arbitrarily chosen.
 
 ## Acknowledgement
 
-[Removed for proper judgement: I'll fill this section if I do win.]
-
-[Note: If you think you've seen this program elsewhere, you are probably right;
-I'm submitting a program I have published years ago (and I have written myself,
-of course). Neither rules nor guidelines disallow such a resubmission, so I guess
-it's fine.]
+The cleaner (size-optimized) version of this program was originally published
+in my website in July 2011. Sun Park and others have reviewed it and let me
+aware of possible improvements. I'd also like to thank Seo Sanghyeon for
+proof-reading remarks.
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
These changes were originally sent to Simon Cooper on 2012-10-01. They got applied to the website but for an unknown reason changes were reverted and it remained in that way for a long time. Nowadays the IOCCC website is hosted by GitHub pages so it's time to reintroduce these changes.

For the completeness `2012/2012.tar.bz2` and `all/all.tar.bz2` should be also updated. I've tried to update them, but I believe judges already have a script to produce those files so this PR doesn't include updates to them.