### PR TITLE
Make IOCCC status text consistent with JSON status

### DIFF
--- a/bin/status2html.sh
+++ b/bin/status2html.sh
@@ -114,7 +114,7 @@ shopt -s globstar	# enable ** to match all files and zero or more directories an
 
 # set variables referenced in the usage message
 #
-export VERSION="1.4.4 2024-12-29"
+export VERSION="1.4.5 2024-12-31"
 NAME=$(basename "$0")
 export NAME
 export V_FLAG=0
@@ -440,7 +440,7 @@ esac
     # write status of the contest
     #
     case "$CONTEST_STATUS" in
-    pending) echo "# The IOCCC is not yet open"
+    pending) echo "# The IOCCC is pending"
 	echo
         echo "While the IOCCC is not open now, there is a tentative opening date for the next IOCCC."
         echo

--- a/inc/guidelines.pending.hdr
+++ b/inc/guidelines.pending.hdr
@@ -19,9 +19,9 @@ about these guidelines. You might also find the FAQ in general useful, especiall
 FAQ on "[how to enter the IOCCC](../faq.html#enter)".
 
 
-# The IOCCC is not yet open
+# The IOCCC is pending
 
-While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.
+While the IOCCC is not open yet, there is a tentative opening date for the next IOCCC.
 
 Comments and suggestions on these preliminary guidelines are welcome.  See the
 [FAQ](../faq.html#feedback) for how to suggest, correct or provide feedback

--- a/inc/rules.pending.hdr
+++ b/inc/rules.pending.hdr
@@ -19,7 +19,7 @@ about these rules. You might also find the FAQ in general useful, especially the
 FAQ on "[how to enter the IOCCC](../faq.html#enter)".
 
 
-# The IOCCC is not yet open
+# The IOCCC is pending
 
 While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.
 

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -439,8 +439,8 @@ as well as our
 FAQ on “<a href="../faq.html#question">about asking questions</a>”
 about these guidelines. You might also find the FAQ in general useful, especially the
 FAQ on “<a href="../faq.html#enter">how to enter the IOCCC</a>”.</p>
-<h1 id="the-ioccc-is-not-yet-open">The IOCCC is not yet open</h1>
-<p>While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.</p>
+<h1 id="the-ioccc-is-pending">The IOCCC is pending</h1>
+<p>While the IOCCC is not open yet, there is a tentative opening date for the next IOCCC.</p>
 <p>Comments and suggestions on these preliminary guidelines are welcome. See the
 <a href="../faq.html#feedback">FAQ</a> for how to suggest, correct or provide feedback
 about thse guidelines.</p>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -19,9 +19,9 @@ about these guidelines. You might also find the FAQ in general useful, especiall
 FAQ on "[how to enter the IOCCC](../faq.html#enter)".
 
 
-# The IOCCC is not yet open
+# The IOCCC is pending
 
-While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.
+While the IOCCC is not open yet, there is a tentative opening date for the next IOCCC.
 
 Comments and suggestions on these preliminary guidelines are welcome.  See the
 [FAQ](../faq.html#feedback) for how to suggest, correct or provide feedback

--- a/next/rules.html
+++ b/next/rules.html
@@ -439,7 +439,7 @@ as well as our
 FAQ on “<a href="../faq.html#question">about asking questions</a>”
 about these rules. You might also find the FAQ in general useful, especially the
 FAQ on “<a href="../faq.html#enter">how to enter the IOCCC</a>”.</p>
-<h1 id="the-ioccc-is-not-yet-open">The IOCCC is not yet open</h1>
+<h1 id="the-ioccc-is-pending">The IOCCC is pending</h1>
 <p>While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.</p>
 <p>Comments and suggestions on these preliminary rules are welcome. See the
 <a href="../faq.html#feedback">FAQ</a> for how to suggest, correct or provide feedback
@@ -942,7 +942,7 @@ The above mentioned tools will help you verify that your submission
 conforms to <a href="#rule17">Rule 17</a>.
 </p>
 <p class="leftbar">
-Each above mentioned tools has a <code>-h</code> option that provides command
+Each above mentioned tool has a <code>-h</code> option that provides command
 line help. For additional details, see the tools’ man pages and the
 <a href="guidelines.html">guidelines</a>.
 </p>

--- a/next/rules.md
+++ b/next/rules.md
@@ -19,7 +19,7 @@ about these rules. You might also find the FAQ in general useful, especially the
 FAQ on "[how to enter the IOCCC](../faq.html#enter)".
 
 
-# The IOCCC is not yet open
+# The IOCCC is pending
 
 While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.
 
@@ -711,7 +711,7 @@ conforms to [Rule 17](#rule17).
 </p>
 
 <p class="leftbar">
-Each above mentioned tools has a `-h` option that provides command
+Each above mentioned tool has a `-h` option that provides command
 line help.  For additional details, see the tools' man pages and the
 [guidelines](guidelines.html).
 </p>


### PR DESCRIPTION
The status showed 'The IOCCC is not yet open' to indicate it is in pending status. But it would be better to match the actual status itself especially as the status.html file explains pending status, not 'not yet open'. At a quick glance it is easy to miss especially for those of us who have worked on the repo for a long time and in particular those who worked on the status.html file a lot.

This updated files in inc/, bin/ and next/ but I cheated and used sgit to do this. I then rebuilt the html files. A previous minor grammar problem in rules was fixed as well.