### PR TITLE
Typo fix in rules and guidelines

### DIFF
--- a/inc/guidelines.pending.hdr
+++ b/inc/guidelines.pending.hdr
@@ -25,7 +25,7 @@ While the IOCCC is not open yet, there is a tentative opening date for the next 
 
 Comments and suggestions on these preliminary guidelines are welcome.  See the
 [FAQ](../faq.html#feedback) for how to suggest, correct or provide feedback
-about thse guidelines.
+about these guidelines.
 
 <!-- END: the next line ends content from: inc/guidelines.pending.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->

--- a/inc/rules.pending.hdr
+++ b/inc/rules.pending.hdr
@@ -25,7 +25,7 @@ While the IOCCC is not open now, there is a tentative opening date for the next 
 
 Comments and suggestions on these preliminary rules are welcome.  See the
 [FAQ](../faq.html#feedback) for how to suggest, correct or provide feedback
-about thse rules.
+about these rules.
 
 <!-- END: the next line ends content from: inc/rules.pending.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -443,7 +443,7 @@ FAQ on “<a href="../quick-start.html#enter">how to enter the IOCCC</a>”.</p>
 <p>While the IOCCC is not open yet, there is a tentative opening date for the next IOCCC.</p>
 <p>Comments and suggestions on these preliminary guidelines are welcome. See the
 <a href="../faq.html#feedback">FAQ</a> for how to suggest, correct or provide feedback
-about thse guidelines.</p>
+about these guidelines.</p>
 <!-- END: the next line ends content from: inc/guidelines.pending.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 <h1 id="th-international-obfuscated-c-code-contest-official-guidelines">28th International Obfuscated C Code Contest Official Guidelines</h1>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -25,7 +25,7 @@ While the IOCCC is not open yet, there is a tentative opening date for the next 
 
 Comments and suggestions on these preliminary guidelines are welcome.  See the
 [FAQ](../faq.html#feedback) for how to suggest, correct or provide feedback
-about thse guidelines.
+about these guidelines.
 
 <!-- END: the next line ends content from: inc/guidelines.pending.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->

--- a/next/rules.html
+++ b/next/rules.html
@@ -443,7 +443,7 @@ FAQ on “<a href="../quick-start.html#enter">how to enter the IOCCC</a>”.</p>
 <p>While the IOCCC is not open now, there is a tentative opening date for the next IOCCC.</p>
 <p>Comments and suggestions on these preliminary rules are welcome. See the
 <a href="../faq.html#feedback">FAQ</a> for how to suggest, correct or provide feedback
-about thse rules.</p>
+about these rules.</p>
 <!-- END: the next line ends content from: inc/rules.pending.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->
 <h1 id="th-international-obfuscated-c-code-contest-official-rules">28th International Obfuscated C Code Contest Official Rules</h1>

--- a/next/rules.md
+++ b/next/rules.md
@@ -25,7 +25,7 @@ While the IOCCC is not open now, there is a tentative opening date for the next 
 
 Comments and suggestions on these preliminary rules are welcome.  See the
 [FAQ](../faq.html#feedback) for how to suggest, correct or provide feedback
-about thse rules.
+about these rules.
 
 <!-- END: the next line ends content from: inc/rules.pending.hdr -->
 <!-- This is the last line modified by the tool: bin/gen-status.sh -->


### PR DESCRIPTION
This includes the include files inc/guidelines.pending.hdr and inc/rules.pending.hdr.

Rebuilt html files as well.

This does not include the other pending fixes and it does not include the updates about mkiocccentry now allowing subdirectories. That'll come in another commit either later today or if not then hopefully this weekend.