### PR TITLE
Fix clobber rule in 1992/gson

### DIFF
--- a/1992/gson/Makefile
+++ b/1992/gson/Makefile
@@ -170,7 +170,7 @@ clean:
 clobber: clean
 	${RM} -f ${TARGET} ${ALT_TARGET}
 	${RM} -rf *.dSYM
-	${RM} -f og words
+	${RM} -f words
 
 
 ######################################


### PR DESCRIPTION
The rule removed the file 'og' but this file does not exist. The closest thing to that is 'ag' but that's removed from a previous line in the rule.