### PR TITLE
Clarify a statement in next/Makefile.example

### DIFF
--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -142,7 +142,7 @@ TARGET= ${PROG}
 #
 # or so.
 #
-# Please remove these lines either way.
+# Please remove these comments either way.
 #
 ALT_OBJ=
 ALT_TARGET=


### PR DESCRIPTION
One should not remove the ALT_OBJ or ALT_TARGET lines but rather the comments about them (that explain to submitters how to use them).