### PR TITLE
Fix Makefile.example - add missing variables

### DIFF
--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -18,6 +18,8 @@ SHELL= bash
 #######################
 
 CC= cc
+CLANG= clang
+GCC= gcc
 GINDENT= gindent
 MV= mv
 RM= rm


### PR DESCRIPTION
Winning entries include var.mk and that sets the variables CLANG and GCC. Without this the findstring check in the Makefile (on ${CC}) matches the first one and uses the wrong warning options.

This commit resolves this problem.