### PR TITLE
Minor fixes in FAQ and guidelines

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -694,9 +694,9 @@ mandatory <code>prog.c</code>, <code>Makefile</code> and <code>remarks.md</code>
 <p>The <code>workdir</code> <strong>MUST</strong> already exist, as a directory, and it is an error if it
 is not a directory that can be written to. In <strong>this</strong> directory your <strong>submission
 directory</strong> will be created, with the name based on your IOCCC registration
-username, which is <strong>in the form of a UUID</strong>, and submission number; see the
-<a href="next/rules.html">rules</a> for more details on this, and in particular <a href="next/rules.html#rule17">Rule
-17</a>.</p>
+username, which is <strong>in the form of a UUID</strong>, and submission number along with
+the timestamp; see the <a href="next/rules.html">rules</a> for more details on this, and in
+particular <a href="next/rules.html#rule17">Rule 17</a>.</p>
 <p><strong>IMPORTANT NOTE</strong>: if you run the program outside the repo directory
 (specifying the absolute or relative path to the tool) and you have not
 installed the tools then you will have to specify the options for the tools that
@@ -1409,8 +1409,7 @@ register</a> and <a href="next/rules.html#rule17">Rule 17</a> for more details).
 and you will be asked to correct it until it is.</li>
 </ul></li>
 <li>Make the submission directory under <code>topdir</code> in the form of
-<code>workdir/submit.USERNAME-SLOT.TIMESTAMP</code> (the timestamp is calculated by
-<code>mkiocccentry(1)</code> so you do not have to worry about this).
+<code>workdir/submit.USERNAME-SLOT</code>.
 <ul>
 <li>If this directory already exists it is an error.</li>
 </ul></li>
@@ -1473,7 +1472,7 @@ with <code>.</code>.</li>
 and files to be made/copied, and if the user says it is not OK the program will abort.</li>
 </ul></li>
 <li>Make any directories if necessary (under
-<code>workdir/submit.USERNAME-SLOT.TIMESTAMP</code> i.e. the submission directory).
+<code>workdir/submit.USERNAME-SLOT</code> i.e. the submission directory).
 <ul>
 <li>Directories <strong>MUST</strong> be and are made with mode <code>0755</code>.</li>
 <li>If any directory is not this mode <code>txzchk(1)</code> will flag it.</li>
@@ -1485,7 +1484,7 @@ submission directory.
 <li>All other files <strong>MUST</strong> be and are copied as mode <code>0444</code>.</li>
 <li>Anything else will be flagged by <code>txzchk(1)</code>.</li>
 </ul></li>
-<li><code>cd submit.USERNAME-SLOT.TIMESTAMP</code> (i.e. switch to submission directory).</li>
+<li><code>cd submit.USERNAME-SLOT</code> (i.e. switch to submission directory).</li>
 <li><code>make -f Makefile clobber</code>.
 <ul>
 <li>If this fails it is not an error but you are warned about it (it is an error only if the <code>Makefile</code>
@@ -1543,7 +1542,8 @@ obtained and compiled the latest version of all the tools and you either are
 in the repo’s directory, you pass the options to give the path to the tools
 or you have installed the latest tools!</li>
 </ul></li>
-<li>Create the tarball.</li>
+<li>Create the tarball with the name in the form of
+<code>submit.USERNAME-SLOT.TIMESTAMP</code>.</li>
 <li>Run <code>txzchk(1)</code> on the tarball.</li>
 </ol>
 <p>If any of the steps fail or if the user says something is not okay, it aborts.

--- a/faq.md
+++ b/faq.md
@@ -315,9 +315,9 @@ mandatory `prog.c`, `Makefile` and `remarks.md`.
 The `workdir` **MUST** already exist, as a directory, and it is an error if it
 is not a directory that can be written to. In **this** directory your **submission
 directory** will be created, with the name based on your IOCCC registration
-username, which is **in the form of a UUID**, and submission number; see the
-[rules](next/rules.html) for more details on this, and in particular [Rule
-17](next/rules.html#rule17).
+username, which is **in the form of a UUID**, and submission number along with
+the timestamp; see the [rules](next/rules.html) for more details on this, and in
+particular [Rule 17](next/rules.html#rule17).
 
 **IMPORTANT NOTE**: if you run the program outside the repo directory
 (specifying the absolute or relative path to the tool) and you have not
@@ -1225,8 +1225,7 @@ register](next/register.html) and [Rule 17](next/rules.html#rule17) for more det
     [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h))
     and you will be asked to correct it until it is.
 2. Make the submission directory under `topdir` in the form of
-`workdir/submit.USERNAME-SLOT.TIMESTAMP` (the timestamp is calculated by
-`mkiocccentry(1)` so you do not have to worry about this).
+`workdir/submit.USERNAME-SLOT`.
     * If this directory already exists it is an error.
 3. Change to the `topdir`.
 4. Traverse the directory, creating lists of ignored/forbidden
@@ -1283,7 +1282,7 @@ with files, copy those files to their respective directory). Note the following:
     * The user is asked to verify each list, including the lists of directories
     and files to be made/copied, and if the user says it is not OK the program will abort.
 6. Make any directories if necessary (under
-`workdir/submit.USERNAME-SLOT.TIMESTAMP` i.e. the submission directory).
+`workdir/submit.USERNAME-SLOT` i.e. the submission directory).
     * Directories **MUST** be and are made with mode `0755`.
     * If any directory is not this mode `txzchk(1)` will flag it.
 7. The non-ignored files are copied to their respective directories under the
@@ -1291,7 +1290,7 @@ submission directory.
     * `try.sh` and `try.alt.sh` **MUST** be and are copied as mode `0555`.
     * All other files **MUST** be and are copied as mode `0444`.
     * Anything else will be flagged by `txzchk(1)`.
-8. `cd submit.USERNAME-SLOT.TIMESTAMP` (i.e. switch to submission directory).
+8. `cd submit.USERNAME-SLOT` (i.e. switch to submission directory).
 9. `make -f Makefile clobber`.
     * If this fails it is not an error but you are warned about it (it is an error only if the `Makefile`
     does not exist); even so, see [Rule 20](next/rules.html#rule20).
@@ -1341,7 +1340,8 @@ is okay.
     obtained and compiled the latest version of all the tools and you either are
     in the repo's directory, you pass the options to give the path to the tools
     or you have installed the latest tools!
-19. Create the tarball.
+19. Create the tarball with the name in the form of
+`submit.USERNAME-SLOT.TIMESTAMP`.
 20. Run `txzchk(1)` on the tarball.
 
 If any of the steps fail or if the user says something is not okay, it aborts.

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -461,7 +461,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 </div>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.36 2025-02-03</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.37 2025-02-10</strong>.
 </p>
 <p class="leftbar">
 The <a href="guidelines.md" download="guidelines.md">markdown form of these guidelines</a>
@@ -618,7 +618,7 @@ cause problems. Additionally, if you do not have the most recent version when
 submitting a tarball it will be rejected for not having the right versions of
 the tools. This is why you <strong>MUST</strong> make sure you have the most recent
 version of all the tools and you either run it from the repo directory itself OR
-you install them (<code>make install</code> as via <code>sudo</code> or as root).
+you install them (<code>make install</code> as root or via <code>sudo</code>).
 </p>
 <p class="leftbar">
 <a href="rules.html#rule17">Rule 17</a> has been <strong>significantly modified</strong>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -49,7 +49,7 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.36 2025-02-03**.
+These [IOCCC guidelines](guidelines.html) are version **28.37 2025-02-10**.
 </p>
 
 <p class="leftbar">
@@ -243,7 +243,7 @@ cause problems. Additionally, if you do not have the most recent version when
 submitting a tarball it will be rejected for not having the right versions of
 the tools. This is why you **MUST** make sure you have the most recent
 version of all the tools and you either run it from the repo directory itself OR
-you install them (`make install` as via `sudo` or as root).
+you install them (`make install` as root or via `sudo`).
 </p>
 
 <p class="leftbar">


### PR DESCRIPTION
The FAQ stated (due to a mistake in the issue in the mkiocccentry repo) that the submission directory (under workdir) has the timestamp in it but that is not true. Instead the tarball filename has the timestamp.

Typo fix in guidelines.