### PR TITLE
Fix CSS .topbar-items .sub-item class

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -612,6 +612,7 @@ transition: all .3s ease;
     text-align: left;
     background-color: whitesmoke;
     left: -100%;
+    z-index:100;
 }
 
 .topbar-items .item:hover .sub-item{


### PR DESCRIPTION
It needs z-index: 100; or else depending on the screen width the menu might not be visible (the IOCCC image is over it).