### PR TITLE
sgit -e 's/web site/website/g'

### DIFF
--- a/2001/README.md
+++ b/2001/README.md
@@ -26,7 +26,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2001/index.html
+++ b/2001/index.html
@@ -445,7 +445,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2004/README.md
+++ b/2004/README.md
@@ -25,7 +25,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2004/index.html
+++ b/2004/index.html
@@ -445,7 +445,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries. The <a href="gavin/index.html">Best of
 Show</a> is a fine example of obfuscation. But don’t ignore the

--- a/2005/README.md
+++ b/2005/README.md
@@ -28,7 +28,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2005/index.html
+++ b/2005/index.html
@@ -447,7 +447,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries.</p>
 <p>In particular:</p>

--- a/2006/README.md
+++ b/2006/README.md
@@ -28,7 +28,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2006/index.html
+++ b/2006/index.html
@@ -447,7 +447,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2011/README.md
+++ b/2011/README.md
@@ -26,7 +26,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2011/index.html
+++ b/2011/index.html
@@ -446,7 +446,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>There were some outstanding entries that did not win. Unfortunately
 some very good entries lost because they:</p>

--- a/2012/README.md
+++ b/2012/README.md
@@ -25,7 +25,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2012/index.html
+++ b/2012/index.html
@@ -445,7 +445,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will be impressed with this year’s winning entries. We had
 a very difficult time picking a single best from among the other entries

--- a/2013/README.md
+++ b/2013/README.md
@@ -25,7 +25,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2013/index.html
+++ b/2013/index.html
@@ -445,7 +445,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>This year, 9 won 15 awards. For the first time in the history of the contest,

--- a/2014/README.md
+++ b/2014/README.md
@@ -25,7 +25,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the entries

--- a/2014/index.html
+++ b/2014/index.html
@@ -445,7 +445,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-entries">Remarks on some of the entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>This year, 2014:</p>

--- a/2015/README.md
+++ b/2015/README.md
@@ -26,7 +26,7 @@ The IOCCC website once had a number of
 [international mirrors](https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html).
 As of 2020 Dec 29, [GitHub](https://www.github.com) serves as the distributed server farm for the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) that GitHub renders as
-[Official IOCCC web site - www.ioccc.org](https://www.ioccc.org).
+[Official IOCCC website - www.ioccc.org](https://www.ioccc.org).
 
 
 ## Remarks on some of the winning entries

--- a/2015/index.html
+++ b/2015/index.html
@@ -446,7 +446,7 @@ The primary website can be found at <a href="https://www.ioccc.org">www.ioccc.or
 <a href="https://web.archive.org/web/20201030210517/https://www.ioccc.org/mirror.html">international mirrors</a>.
 As of 2020 Dec 29, <a href="https://www.github.com">GitHub</a> serves as the distributed server farm for the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> that GitHub renders as
-<a href="https://www.ioccc.org">Official IOCCC web site - www.ioccc.org</a>.</p>
+<a href="https://www.ioccc.org">Official IOCCC website - www.ioccc.org</a>.</p>
 <h2 id="remarks-on-some-of-the-winning-entries">Remarks on some of the winning entries</h2>
 <p>We believe you will again be impressed with this year’s winning entries.</p>
 <p>The fraction of worthy entries was higher than usual.</p>

--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.12 2025-02-28</strong>.</p>
+<p>This is FAQ version <strong>28.2.13 2025-03-01</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -3633,7 +3633,7 @@ because any modications will be overridden when the <a href="bin/index.html">set
 (often <code>README.md</code>) and/or sometimes JSON files (such as <code>.entry.json</code> or
 the <code>author/author_handle.json</code> JSON files)</p>
 <p>See the
-FAQ on “<a href="#fix_website">fix web site</a>”
+FAQ on “<a href="#fix_website">fix website</a>”
 for information on submitting fixes to the IOCCC website.</p>
 <p>See the
 FAQ on “<a href="#fix_author">update IOCCC author information</a>”
@@ -6147,16 +6147,22 @@ posting was <strong>I</strong>nternational <strong>O</strong>bfuscated <strong>C
 <p>The posting said ‘<em>1st annual</em>’, so in 1985 we held the <a href="years.html#1985">2nd IOCCC contest</a>
 and the tradition continues as the longest running contest on the Internet.</p>
 <p>P.S. Part of the inspiration for making the IOCCC a contest goes to the
-<a href="http://www.bulwer-lytton.com/">Bulwer-Lytton fiction contest</a>.</p>
+<a href="http://www.bulwer-lytton.com/">Bulwer-Lytton fiction contest</a> (hence the
+reference to that (in)famous dark and stormy night all the way back in 1830 when
+Landon was just a wee lad).</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="missing_years">
 <h3 id="q-11.1-why-are-some-years-missing-ioccc-entries">Q 11.1: Why are some years missing IOCCC entries?</h3>
 </div>
-<p>Some years, such as 1997, 1999, 2002-2003, 2007-2010, 2016-2017, 2021-2023, no IOCCC was held.</p>
+<p>There were some years, such as 1997, 1999, 2002-2003, 2007-2010, 2016-2017,
+2021-2023 (or 2024, see below), when no IOCCC was held.</p>
 <p>While we try to hold the IOCCC every year, sometime the other demands on the IOCCC judges
 do not permit us to hold a new IOCCC.</p>
-<p>The pause during the 2021-2023 period was due to the IOCCC judges developing tools to
-make it much more likely for the IOCCC to be held on a yearly basis later on.</p>
+<p>The pause during 2021 through the end of 2024 (when IOCCC28 officially entered
+pending status) was due to the development of tools (for submission, the server
+and the website generation) and the JSON parser (for the tools, the contest and
+the website) to make it easier and much more likely for the IOCCC to be held on
+a yearly basis.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="website">
 <div id="website_history">

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.2.12 2025-02-28**.
+This is FAQ version **28.2.13 2025-03-01**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -3868,7 +3868,7 @@ Now we will describe each field of each file in the manifest:
     the `author/author_handle.json` JSON files)
 
     See the
-    FAQ on "[fix web site](#fix_website)"
+    FAQ on "[fix website](#fix_website)"
     for information on submitting fixes to the IOCCC website.
 
     See the
@@ -7601,7 +7601,9 @@ The posting said '_1st annual_', so in 1985 we held the [2nd IOCCC contest](year
 and the tradition continues as the longest running contest on the Internet.
 
 P.S. Part of the inspiration for making the IOCCC a contest goes to the
-[Bulwer-Lytton fiction contest](http://www.bulwer-lytton.com/).
+[Bulwer-Lytton fiction contest](http://www.bulwer-lytton.com/) (hence the
+reference to that (in)famous dark and stormy night all the way back in 1830 when
+Landon was just a wee lad).
 
 Jump to: [top](#)
 
@@ -7610,13 +7612,17 @@ Jump to: [top](#)
 ### Q 11.1: Why are some years missing IOCCC entries?
 </div>
 
-Some years, such as 1997, 1999, 2002-2003, 2007-2010, 2016-2017, 2021-2023, no IOCCC was held.
+There were some years, such as 1997, 1999, 2002-2003, 2007-2010, 2016-2017,
+2021-2023 (or 2024, see below), when no IOCCC was held.
 
 While we try to hold the IOCCC every year, sometime the other demands on the IOCCC judges
 do not permit us to hold a new IOCCC.
 
-The pause during the 2021-2023 period was due to the IOCCC judges developing tools to
-make it much more likely for the IOCCC to be held on a yearly basis later on.
+The pause during 2021 through the end of 2024 (when IOCCC28 officially entered
+pending status) was due to the development of tools (for submission, the server
+and the website generation) and the JSON parser (for the tools, the contest and
+the website) to make it easier and much more likely for the IOCCC to be held on
+a yearly basis.
 
 Jump to: [top](#)
 

--- a/index.html
+++ b/index.html
@@ -479,7 +479,7 @@ are all encouraged to stop by and say hello.</p>
 <p>To join, click this link:
 <a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a>.</p>
 <h1 id="important-disclaimer">Important Disclaimer</h1>
-<p>IOCCC code is for <strong>educational and entertainment purposes only</strong>. We do <strong>NOT</strong> recommend installing any winning IOCCC entry code. Use code found the IOCCC repo and in the IOCCC web site <strong>at your own risk!</strong></p>
+<p>IOCCC code is for <strong>educational and entertainment purposes only</strong>. We do <strong>NOT</strong> recommend installing any winning IOCCC entry code. Use code found the IOCCC repo and in the IOCCC website <strong>at your own risk!</strong></p>
 <p>The <a href="index.html">IOCCC</a> and the <a href="judges.html">IOCCC judges</a> DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THEY BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.</p>
 <!--
 

--- a/index.md
+++ b/index.md
@@ -77,7 +77,7 @@ To join, click this link:
 
 # Important Disclaimer
 
-IOCCC code is for **educational and entertainment purposes only**. We do **NOT** recommend installing any winning IOCCC entry code. Use code found the IOCCC repo and in the IOCCC web site **at your own risk!**
+IOCCC code is for **educational and entertainment purposes only**. We do **NOT** recommend installing any winning IOCCC entry code. Use code found the IOCCC repo and in the IOCCC website **at your own risk!**
 
 The [IOCCC](index.html) and the [IOCCC judges](judges.html) DISCLAIM ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THEY BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 

--- a/ioccc.css
+++ b/ioccc.css
@@ -612,6 +612,7 @@ transition: all .3s ease;
     text-align: left;
     background-color: whitesmoke;
     left: -100%;
+    z-index:100;
 }
 
 .topbar-items .item:hover .sub-item{

--- a/news.html
+++ b/news.html
@@ -494,7 +494,7 @@ section.</p>
 <h3 id="good-news-everyone--">Good News Everyone! :-)</h3>
 <p>After a 4 year effort by a <a href="thanks-for-help.html">number of people</a>,
 with over 6168+ commits, the <strong>Great Fork Merge</strong> has been completed
-and the <a href="index.html">Official IOCCC web site</a> has been updated!</p>
+and the <a href="index.html">Official IOCCC website</a> has been updated!</p>
 <p>A significant number of improvements have been made to the
 <a href="years.html">IOCCC winning entries</a>.
 Many of the fixes and improvements involve the ability of reasonable modern
@@ -504,8 +504,8 @@ information on how to compile.
 See the <a href="faq.html#changes">FAQ Section 8</a>
 for details on changes made to the entries.</p>
 <p>We hope you enjoy the new and improved
-<a href="index.html">Official IOCCC web site</a>.
-This web site is backed by the
+<a href="index.html">Official IOCCC website</a>.
+This website is backed by the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner GitHub repo</a>.
 See <a href="faq.html#help">FAQ Section 9</a> for
 how you can help <a href="faq.html#fix_website">improve / fix the website</a>,

--- a/news.md
+++ b/news.md
@@ -108,7 +108,7 @@ section.
 
 After a 4 year effort by a [number of people](thanks-for-help.html),
 with over 6168+ commits, the **Great Fork Merge** has been completed
-and the [Official IOCCC web site](index.html) has been updated!
+and the [Official IOCCC website](index.html) has been updated!
 
 A significant number of improvements have been made to the
 [IOCCC winning entries](years.html).
@@ -120,8 +120,8 @@ See the [FAQ Section 8](faq.html#changes)
 for details on changes made to the entries.
 
 We hope you enjoy the new and improved
-[Official IOCCC web site](index.html).
-This web site is backed by the
+[Official IOCCC website](index.html).
+This website is backed by the
 [IOCCC winner GitHub repo](https://github.com/ioccc-src/winner).
 See [FAQ Section 9](faq.html#help) for
 how you can help [improve / fix the website](faq.html#fix_website),


### PR DESCRIPTION

A choice was made a while back to use website and not web site so 
changed all new references of 'web site' to 'website':

    sgit -e 's/web site/website/g' '*.md' '*.html'

As this also occurs in the FAQ and there were some minor mods (just 
textual, including some fun, not a new FAQ) these are included too.
