### PR TITLE
Fix comments in all rule of Makefile.example

### DIFF
--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -158,11 +158,11 @@ DATA=
 #################
 
 all: data ${TARGET}
-	# NOTE: only try.sh and try.alt.sh scripts will be made executable in
-	# the tarball so if you need any scripts that are executable, make sure
-	# to use ${CHMOD} +x on them like:
-	#
-	#   ${CHMOD} +x foo.sh
+	@# NOTE: only try.sh and try.alt.sh scripts will be made executable in
+	@# the tarball so if you need any scripts that are executable, make sure
+	@# to use ${CHMOD} +x on them like:
+	@#
+	@#   ${CHMOD} +x foo.sh
 
 .PHONY: all data try clean clobber install
 


### PR DESCRIPTION
Without the @ before the comments (which are informative and to be removed by contestants) it shows the comments when running 'make'. Even worse is without doing $${CHMOD} it would not evaluate to anything so it looked bizarre.

Thus the @ was added to the comments like the rest of the file (comments in rules).