### PR TITLE
Make important fix in FAQ about git fetch

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -676,7 +676,7 @@ have an mkiocccentry tool directory:</p>
     cd mkiocccentry</code></pre>
 <p>If you already have an mkiocccentry tool directory:</p>
 <pre><code>    cd mkiocccentry
-    git fetch
+    git fetch --all --tags
     git rebase</code></pre>
 <p>Jump to: <a href="#">top</a></p>
 <div id="compiling_mkiocccentry">

--- a/faq.md
+++ b/faq.md
@@ -278,7 +278,7 @@ If you already have an mkiocccentry tool directory:
 
 ``` <!---sh-->
     cd mkiocccentry
-    git fetch
+    git fetch --all --tags
     git rebase
 ```
 


### PR DESCRIPTION
After my final commit and merge in mkiocccentry pre-release a pull did not get the tag. I had to do:

    git fetch --all --tags

instead. So to make sure everyone has the correct tag I have added this to the FAQ (replacing the 'git fetch' by itself).

Regenerated faq.html.