### PR TITLE
Updated FAQ per recent mkiocccentry issues

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -484,7 +484,7 @@
 <li><strong>Q 3.9</strong>: <a class="normal" href="#entry_id_faq">What is an <code>entry_id</code>?</a></li>
 <li><strong>Q 3.10</strong>: <a class="normal" href="#entry_json">What is a <code>.entry.json</code> file and how is it used?</a></li>
 <li><strong>Q 3.11</strong>: <a class="normal" href="#jparse">How can I validate any JSON document?</a></li>
-<li><strong>Q 3.12</strong>: <a class="normal" href="#versions">What are required versions and how are they checked?</a></li>
+<li><strong>Q 3.12</strong>: <a class="normal" href="#install">How can I install the <code>mkiocccentry(1)</code> and related tools?</a></li>
 </ul>
 <h2 id="compiling-ioccc-entries">4. <a href="#compiling">Compiling IOCCC entries</a></h2>
 <ul>
@@ -2273,13 +2273,11 @@ information about the author or authors of the submission, in JSON format.</p>
 <ul>
 <li>The current version of the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.auth.json</code> version for <strong>THIS</strong>
-IOCCC’s <code>.auth.json</code>, defined as <code>AUTH_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>.auth.json</code> version, defined as
+<code>AUTH_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2304,39 +2302,28 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <ul>
 <li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
+defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry(1)</code> that was used to validate the submission
+<li>The version of <code>chkentry</code> that was used to validate the submission
 directory, including the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
+as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk(1)</code> that <code>txzchk(1)</code> uses to validate the filename of
+<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version in order for it
+to be valid. If this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2402,7 +2389,7 @@ See
 <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements" class="uri">https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements</a>
 for a list of valid codes.</li>
 </ul>
-<p><strong>NOTE:</strong> in <code>mkiocccentry(1)</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
+<p><strong>NOTE:</strong> in <code>mkiocccentry</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
 <li><p><code>email</code> (<code>null</code> or double quoted string)</p>
 <ul>
 <li>The <strong>email</strong> of this author in the form of <code>x@y</code>, or <code>null</code> if not provided.</li>
@@ -2575,14 +2562,11 @@ for more information.</p>
 <ul>
 <li>The current version of the <code>.info.json</code> files.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.info.json</code> version for
-<strong>THIS</strong> IOCCC’s <code>.info.json</code>, defined as <code>INFO_VERSION</code>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>.info.json</code> version, defined as
+<code>INFO_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2605,66 +2589,51 @@ in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>mkiocccentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>mkiocccentry(1)</code> that formed this <code>.auth.json</code> file.</li>
+<li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
+defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>iocccsize_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>iocccsize(1)</code> that was used for this <code>.info.json</code> file.</li>
+<li>The version of <code>iocccsize</code> that was used for this <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>iocccsize(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>iocccsize(1)</code>, defined as <code>IOCCCSIZE_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>iocccentry</code> version,
+defined as <code>IOCCCSIZE_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry(1)</code> that was used to validate the submission
+<li>The version of <code>chkentry</code> that was used to validate the submission
 directory, including the <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
+as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk(1)</code> that <code>txzchk</code> uses to validate the filename of
+<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version, defined
+as <code>FNAMCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>txzchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>txzchk(1)</code> used to validate the xz compressed tarball.</li>
+<li>The version of <code>txzchk</code> used to validate the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>txzchk(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>txzchk(1)</code>, defined as <code>TXZCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>txzchk</code> version, defined
+as <code>TXZCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2755,7 +2724,9 @@ violated but this is <code>true</code> then you stand a good chance of having yo
 submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p></li>
 <li><p><code>highbit_warning</code> (boolean)</p>
 <ul>
-<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
+<li><code>true</code> if <code>iocccsize</code> detects a high bit (unescaped octets with the high
+bit set - octet value &gt;= 128); see <a href="next/rules.html#rule13">Rule 13</a>, else
+<code>false</code>.</li>
 </ul></li>
 <li><p><code>nul_warning</code> (boolean)</p>
 <ul>
@@ -2820,7 +2791,7 @@ for more information.</p></li>
 <ul>
 <li><code>true</code> if the <code>Makefile</code> file has a <code>clobber</code> rule, else <code>false</code>.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have a <code>clobber</code> rule and this
+<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>clobber</code> rule and this
 boolean is <code>true</code> then you stand a good chance of having your submission
 rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
@@ -3874,34 +3845,6 @@ repo</a> but we recommend you compile and
 install via the <code>mkiocccentry</code> repo because it has the dependencies built in,
 and because the <code>mkiocccentry</code> copy is that which is used by the current IOCCC,
 as the two can be different at times.</p>
-<p>Jump to: <a href="#">top</a></p>
-<div id="versions">
-<h3 id="q-3.12-what-are-required-versions-and-how-are-they-checked">Q 3.12: What are required versions and how are they checked?</h3>
-</div>
-<p>For each contest the tools used must be a correct version. This correct version
-can be in a range: a valid version is &gt;= the minimum version of a tool or file
-format that is specific to a particular IOCCC and which is not greater than the
-maximum version for that specific IOCCC. A required version is therefore a
-range, where as long as the version is between the min and max, that is &gt;= min
-and &lt;= max, and as long as it’s not a blacklisted version (the so-called
-poisonous versions), it is okay.</p>
-<p>The concept of a poisonous version exists in the case that a version has to be
-blacklisted for some problem. The file
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-includes a list of versions, their minimum values and their maximum values.</p>
-<p>As an example, at the time of writing this, during IOCCC28, the minimum version
-of <code>mkiocccentry(1)</code> is <code>2.0.1 2025-03-02</code>. If however a fix was needed that
-necessitated a version change, the macro
-<code>MIN_MKIOCCCENTRY_VERSION</code> would be changed to that value, rather than map
-directly to <code>MKIOCCCENTRY_VERSION</code>. The maximum, <code>MAX_MKIOCCCENTRY_VERSION</code>, is
-defined as <code>MKIOCCCENTRY_VERSION</code> but to help distinguish that it is also the
-maximum, we use a separate macro.</p>
-<p>So as long as the version you use is &gt;= this minimum and is &lt;= the maximum, and
-as long as it is not in the poisonous list, you are okay. The poisonous versions
-lists can be found in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c">soup/entry_util.c</a>.</p>
-<p>But as long as you are using the official version you should be fine as the
-contest would not open with an invalid version.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.13 2025-03-01</strong>.</p>
+<p>This is FAQ version <strong>28.2.14 2025-03-09</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -454,6 +454,7 @@
 <li><strong>Q 1.6</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
 <li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a></li>
 <li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
+<li><strong>Q 1.9</strong>: <a class="normal" href="#uuid_file">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
 </ul>
 <h2 id="ioccc-judging-process">2. <a href="#judging_proceess">IOCCC Judging process</a></h2>
 <ul>
@@ -483,7 +484,7 @@
 <li><strong>Q 3.9</strong>: <a class="normal" href="#entry_id_faq">What is an <code>entry_id</code>?</a></li>
 <li><strong>Q 3.10</strong>: <a class="normal" href="#entry_json">What is a <code>.entry.json</code> file and how is it used?</a></li>
 <li><strong>Q 3.11</strong>: <a class="normal" href="#jparse">How can I validate any JSON document?</a></li>
-<li><strong>Q 3.12</strong>: <a class="normal" href="#install">How can I install the <code>mkiocccentry(1)</code> and related tools?</a></li>
+<li><strong>Q 3.12</strong>: <a class="normal" href="#versions">What are required versions and how are they checked?</a></li>
 </ul>
 <h2 id="compiling-ioccc-entries">4. <a href="#compiling">Compiling IOCCC entries</a></h2>
 <ul>
@@ -1495,6 +1496,23 @@ do this <strong>AFTER</strong> the <a href="status.html">contest status</a> has 
 <a href="#open">open</a>.
 </p>
 <p>Jump to: <a href="#">top</a></p>
+<div id="uuid_file">
+<h3 id="q-1.9-how-can-i-avoid-re-entering-my-uuid-to-mkiocccentry">Q 1.9: How can I avoid re-entering my UUID to mkiocccentry?</h3>
+</div>
+<p>Because some people might want to submit more than one submission, an option to
+read the UUID from a file exists, so that you don’t have to repeatedly copy and
+paste the UUID in. If the file is not a regular readable file or it does not
+have a valid UUID, you will be prompted as if you had not used the option. If
+you use the <code>-i answers</code> feature this will not be used as the UUID is included
+in the answers file.</p>
+<p>To use this feature all you have to do is put the UUID in a text file, in a
+single line, with no spaces before or after it, and then run:</p>
+<pre><code>    mkiocccentry -u uuid workdir topdir</code></pre>
+<p>where <code>uuid</code> is the file containing your UUID, <code>workdir</code> is the workdir and
+<code>topdir</code> is the topdir.</p>
+<p>See also the
+FAQ on “<a href="#answers_file">the answers file</a>”.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
 <div id="judging_process">
@@ -1864,6 +1882,15 @@ will be asked to verify country code prior to being asked the other questions.
 If you fail to enter other author information correctly you will be prompted
 right away to fix it. Afterwards, when the author information is collected, it
 will ask you to confirm. This procedure happens for each author.</p>
+<p>In the case of <code>-i answers</code> option being used, you will not have to put in most
+information but you will have to confirm the lists of files and directories are
+correct, unless you use <code>-Y</code> (which we do not recommend).</p>
+<p>If <code>topdir</code> is not a readable (<code>+r</code>), searchable (<code>+x</code>) directory it is an error.</p>
+<p>If <code>workdir</code> is not a writable (<code>+w</code>), searchable (<code>+x</code>) directory it is an error.</p>
+<p>If <code>workdir</code> is in <code>topdir</code> the program will not descend into it (the workdir).</p>
+<p>If <code>topdir</code> is the same (by device and inode) as <code>workdir</code> it is an error.
+If somehow <code>topdir</code> or <code>workdir</code> is found under the submission directory (by
+device and inode) it is an error (and you should report it as a bug.</p>
 <p>In more detail the <code>mkiocccentry(1)</code> tool performs the below steps.</p>
 <ol start="0" type="1">
 <li>Ask the user for a submission ID (see the <a href="next/register.html">how to register</a>
@@ -1872,13 +1899,15 @@ the importance of this).
 <ul>
 <li>If this is an invalid UUID (malformed), you will be asked to correct it
 until it is.</li>
+<li>If the <code>-u uuid</code> option is used and the UUID in the file <code>uuid</code> is not malformed,
+the user will not be prompted for a UUID.</li>
 </ul></li>
 <li>Ask the user for the submission slot (the submission number; see <a href="next/register.html">how to
 register</a> and <a href="next/rules.html#rule17">Rule 17</a> for more details).
 <ul>
 <li>If this is out of range (see <code>MAX_SUBMIT_SLOT</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>)
-and you will be asked to correct it until it is.</li>
+you will be asked to correct it until it is.</li>
 </ul></li>
 <li>Make the submission directory under <code>topdir</code> in the form of
 <code>workdir/submit.USERNAME-SLOT</code>.
@@ -2244,11 +2273,13 @@ information about the author or authors of the submission, in JSON format.</p>
 <ul>
 <li>The current version of the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>.auth.json</code> version, defined as
-<code>AUTH_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.auth.json</code> version for <strong>THIS</strong>
+IOCCC’s <code>.auth.json</code>, defined as <code>AUTH_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2273,28 +2304,39 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <ul>
 <li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
-defined as <code>MKIOCCCENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code>
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry</code> that was used to validate the submission
+<li>The version of <code>chkentry(1)</code> that was used to validate the submission
 directory, including the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
-as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
+<li>The version of <code>fnamchk(1)</code> that <code>txzchk(1)</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version in order for it
-to be valid. If this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2360,7 +2402,7 @@ See
 <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements" class="uri">https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements</a>
 for a list of valid codes.</li>
 </ul>
-<p><strong>NOTE:</strong> in <code>mkiocccentry</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
+<p><strong>NOTE:</strong> in <code>mkiocccentry(1)</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
 <li><p><code>email</code> (<code>null</code> or double quoted string)</p>
 <ul>
 <li>The <strong>email</strong> of this author in the form of <code>x@y</code>, or <code>null</code> if not provided.</li>
@@ -2533,11 +2575,14 @@ for more information.</p>
 <ul>
 <li>The current version of the <code>.info.json</code> files.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>.info.json</code> version, defined as
-<code>INFO_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.info.json</code> version for
+<strong>THIS</strong> IOCCC’s <code>.info.json</code>, defined as <code>INFO_VERSION</code>
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2560,51 +2605,66 @@ in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>mkiocccentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
+<li>The version of <code>mkiocccentry(1)</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
-defined as <code>MKIOCCCENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>iocccsize_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>iocccsize</code> that was used for this <code>.info.json</code> file.</li>
+<li>The version of <code>iocccsize(1)</code> that was used for this <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>iocccentry</code> version,
-defined as <code>IOCCCSIZE_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>iocccsize(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>iocccsize(1)</code>, defined as <code>IOCCCSIZE_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry</code> that was used to validate the submission
+<li>The version of <code>chkentry(1)</code> that was used to validate the submission
 directory, including the <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
-as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
+<li>The version of <code>fnamchk(1)</code> that <code>txzchk</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version, defined
-as <code>FNAMCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>txzchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>txzchk</code> used to validate the xz compressed tarball.</li>
+<li>The version of <code>txzchk(1)</code> used to validate the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>txzchk</code> version, defined
-as <code>TXZCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>txzchk(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>txzchk(1)</code>, defined as <code>TXZCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2695,9 +2755,7 @@ violated but this is <code>true</code> then you stand a good chance of having yo
 submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p></li>
 <li><p><code>highbit_warning</code> (boolean)</p>
 <ul>
-<li><code>true</code> if <code>iocccsize</code> detects a high bit (unescaped octets with the high
-bit set - octet value &gt;= 128); see <a href="next/rules.html#rule13">Rule 13</a>, else
-<code>false</code>.</li>
+<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
 </ul></li>
 <li><p><code>nul_warning</code> (boolean)</p>
 <ul>
@@ -2711,11 +2769,8 @@ bit set - octet value &gt;= 128); see <a href="next/rules.html#rule13">Rule 13</
 </ul></li>
 <li><p><code>wordbuf_warning</code> (boolean)</p>
 <ul>
-<li><code>true</code> if <code>prog.c</code> triggered a word buffer overflow (see <code>iocccsize</code>),
-else <code>false</code>.</li>
-</ul>
-<p><strong>IMPORTANT:</strong> this does <strong>NOT</strong> mean that your code has been checked for buffer
-overflows in general.</p></li>
+<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
+</ul></li>
 <li><p><code>ungetc_warning</code> (boolean)</p>
 <ul>
 <li><code>true</code> if <code>prog.c</code> triggered an <code>ungetc(3)</code> error, else <code>false</code>.</li>
@@ -2733,11 +2788,11 @@ FAQ on “<a href="#makefile">Makefile</a>”
 for more information.</p></li>
 <li><p><code>first_rule_is_all</code> (boolean)</p>
 <ul>
-<li><code>true</code> if the first rule in the <code>Makefile</code> file is <code>all</code>, else <code>false</code>.</li>
+<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>all</code> rule or it is not
-first and this boolean is <code>true</code> then you stand a good chance of having your
-submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
+<p><strong>IMPORTANT:</strong>: if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>all</code> rule then
+you stand a good chance of having your submission rejected for violating
+<a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
 FAQ on “<a href="#makefile">Makefile</a>”
 for more information.</p></li>
@@ -2746,8 +2801,7 @@ for more information.</p></li>
 <li><code>true</code> if the <code>Makefile</code> file has an <code>all</code> rule, else <code>false</code>.</li>
 </ul>
 <p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>all</code> rule and this
-boolean is <code>true</code>, or if it does <strong>NOT</strong> have an <code>all</code> rule but
-<code>first_rule_is_all</code> is <code>true</code> then you stand a good chance of having your
+boolean is <code>true</code> then you stand a good chance of having your
 submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
 FAQ on “<a href="#makefile">Makefile</a>”
@@ -2766,7 +2820,7 @@ for more information.</p></li>
 <ul>
 <li><code>true</code> if the <code>Makefile</code> file has a <code>clobber</code> rule, else <code>false</code>.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>clobber</code> rule and this
+<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have a <code>clobber</code> rule and this
 boolean is <code>true</code> then you stand a good chance of having your submission
 rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
@@ -2913,8 +2967,9 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 problems with it or the submission directory, <strong>it is an error</strong>. If there is an
 error the tarball will <strong>NOT</strong> be formed by <code>mkiocccentry</code>; otherwise the
 <code>txzchk(1)</code> tool will be executed on the tarball.</p>
-<p>The <a href="judges.html">Judges</a> <strong>WILL</strong> use <code>chkentry(1)</code> on this file during the
-judging process and if it does not pass your submission <strong>WILL BE</strong> rejected.</p>
+<p>When the <a href="judges.html">Judges</a> use <code>chkentry(1)</code> on your submission directory,
+if this JSON file is invalid JSON or does not match the requirements outlined
+above, or if any other is found, your submission <strong>WILL BE</strong> rejected.</p>
 <p>An obvious example where <code>chkentry</code> would fail to validate <code>.info.json</code> is if
 there is a mismatch of type in the JSON file with what is expected, for
 instance, if in <code>.info.json</code> the <code>no_comment</code> that we chose to not comment on is
@@ -3819,6 +3874,34 @@ repo</a> but we recommend you compile and
 install via the <code>mkiocccentry</code> repo because it has the dependencies built in,
 and because the <code>mkiocccentry</code> copy is that which is used by the current IOCCC,
 as the two can be different at times.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="versions">
+<h3 id="q-3.12-what-are-required-versions-and-how-are-they-checked">Q 3.12: What are required versions and how are they checked?</h3>
+</div>
+<p>For each contest the tools used must be a correct version. This correct version
+can be in a range: a valid version is &gt;= the minimum version of a tool or file
+format that is specific to a particular IOCCC and which is not greater than the
+maximum version for that specific IOCCC. A required version is therefore a
+range, where as long as the version is between the min and max, that is &gt;= min
+and &lt;= max, and as long as it’s not a blacklisted version (the so-called
+poisonous versions), it is okay.</p>
+<p>The concept of a poisonous version exists in the case that a version has to be
+blacklisted for some problem. The file
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
+includes a list of versions, their minimum values and their maximum values.</p>
+<p>As an example, at the time of writing this, during IOCCC28, the minimum version
+of <code>mkiocccentry(1)</code> is <code>2.0.1 2025-03-02</code>. If however a fix was needed that
+necessitated a version change, the macro
+<code>MIN_MKIOCCCENTRY_VERSION</code> would be changed to that value, rather than map
+directly to <code>MKIOCCCENTRY_VERSION</code>. The maximum, <code>MAX_MKIOCCCENTRY_VERSION</code>, is
+defined as <code>MKIOCCCENTRY_VERSION</code> but to help distinguish that it is also the
+maximum, we use a separate macro.</p>
+<p>So as long as the version you use is &gt;= this minimum and is &lt;= the maximum, and
+as long as it is not in the poisonous list, you are okay. The poisonous versions
+lists can be found in
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c">soup/entry_util.c</a>.</p>
+<p>But as long as you are using the official version you should be fine as the
+contest would not open with an invalid version.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.md
+++ b/faq.md
@@ -58,7 +58,7 @@ This is FAQ version **28.2.14 2025-03-09**.
 - **Q 3.9**: <a class="normal" href="#entry_id_faq">What is an `entry_id`?</a>
 - **Q 3.10**: <a class="normal" href="#entry_json">What is a `.entry.json` file and how is it used?</a>
 - **Q 3.11**: <a class="normal" href="#jparse">How can I validate any JSON document?</a>
-- **Q 3.12**: <a class="normal" href="#versions">What are required versions and how are they checked?</a>
+- **Q 3.12**: <a class="normal" href="#install">How can I install the `mkiocccentry(1)` and related tools?</a>
 
 
 ## 4. [Compiling IOCCC entries](#compiling)
@@ -2189,14 +2189,11 @@ In order of the file's contents we describe each required field, below:
 - `IOCCC_auth_version` (double quoted string)
     * The current version of the `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `.auth.json` version for **THIS**
-    IOCCC's `.auth.json`, defined as `AUTH_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `.auth.json` version, defined as
+    `AUTH_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/).
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
+    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
+    this is not the case your submission **WILL BE** rejected!
 
 - `IOCCC_contest` (double quoted string)
     * Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).
@@ -2222,42 +2219,28 @@ In order of the file's contents we describe each required field, below:
 - `mkiocccentry_version` (double quoted string)
     * The version of `mkiocccentry` that formed this `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `mkiocccentry(1)` version for **THIS**
-    IOCCC's `mkiocccentry(1)`, defined as `MKIOCCCENTRY_VERSION`
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `mkiocccentry` version,
+    defined as `MKIOCCCENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/).
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
+    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
+    this is not the case your submission **WILL BE** rejected!
 
 - `chkentry_version` (double quoted string)
-    * The version of `chkentry(1)` that was used to validate the submission
+    * The version of `chkentry` that was used to validate the submission
     directory, including the `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `chkentry(1)` version for **THIS**
-    IOCCC's `chkentry(1)`, defined as `CHKENTRY_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chkentry` version, defined
+    as `CHKENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `fnamchk_version` (double quoted string)
-    * The version of `fnamchk(1)` that `txzchk(1)` uses to validate the filename of
+    * The version of `fnamchk` that `txzchk` uses to validate the filename of
     the xz compressed tarball.
 
-    **IMPORTANT:** this **MUST** be a valid `fnamchk(1)` version for **THIS**
-    IOCCC's `fnamchk(1)`, defined as `FNAMCHK_VERSION` in
-    [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
-    this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `fnamchk` version in order for it
+    to be valid. If this is not the case your submission **WILL BE** rejected!
 
 - `IOCCC_contest_id` (double quoted string)
     * The IOCCC contestant ID used as a username in the form of **in the form of
@@ -2321,7 +2304,7 @@ author(s) of the submission:
      <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements>
      for a list of valid codes.
 
-    **NOTE:** in `mkiocccentry(1)` use `XX` if you want your location to be anonymous.
+    **NOTE:** in `mkiocccentry` use `XX` if you want your location to be anonymous.
 
 - `email` (`null` or double quoted string)
     * The **email** of this author in the form of `x@y`, or `null` if not provided.
@@ -2491,15 +2474,11 @@ In order of the file's contents we describe each required field, below:
 - `IOCCC_info_version` (double quoted string)
     * The current version of the `.info.json` files.
 
-    **IMPORTANT:** this **MUST** be a valid `.info.json` version for
-    **THIS** IOCCC's `.info.json`, defined as `INFO_VERSION`
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `.info.json` version, defined as
+    `INFO_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `IOCCC_contest` (double quoted string)
     * Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).
@@ -2523,71 +2502,51 @@ In order of the file's contents we describe each required field, below:
     this is not the case your submission **WILL BE** rejected!
 
 - `mkiocccentry_version` (double quoted string)
-    * The version of `mkiocccentry(1)` that formed this `.auth.json` file.
+    * The version of `mkiocccentry` that formed this `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `mkiocccentry(1)` version for  **THIS**
-    IOCCC's `mkiocccentry(1)`, defined as `MKIOCCCENTRY_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `mkiocccentry` version,
+    defined as `MKIOCCCENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `iocccsize_version` (double quoted string)
-    * The version of `iocccsize(1)` that was used for this `.info.json` file.
+    * The version of `iocccsize` that was used for this `.info.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `iocccsize(1)` version for **THIS**
-    IOCCC's `iocccsize(1)`, defined as `IOCCCSIZE_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `iocccentry` version,
+    defined as `IOCCCSIZE_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `chkentry_version` (double quoted string)
-    * The version of `chkentry(1)` that was used to validate the submission
+    * The version of `chkentry` that was used to validate the submission
     directory, including the `.info.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `chkentry(1)` version for **THIS**
-    IOCCC's `chkentry(1)`, defined as `CHKENTRY_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chkentry` version, defined
+    as `CHKENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `fnamchk_version` (double quoted string)
-    * The version of `fnamchk(1)` that `txzchk` uses to validate the filename of
+    * The version of `fnamchk` that `txzchk` uses to validate the filename of
     the xz compressed tarball.
 
-    **IMPORTANT:** this **MUST** be a valid `fnamchk(1)` version for **THIS**
-    IOCCC's `fnamchk(1)`, defined as `FNAMCHK_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `fnamchk` version, defined
+    as `FNAMCHK_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `txzchk_version` (double quoted string)
-    * The version of `txzchk(1)` used to validate the xz compressed tarball.
+    * The version of `txzchk` used to validate the xz compressed tarball.
 
-    **IMPORTANT:** this **MUST** be a valid `txzchk(1)` version for **THIS**
-    IOCCC's `txzchk(1)`, defined as `TXZCHK_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `txzchk` version, defined
+    as `TXZCHK_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `IOCCC_contest_id` (double quoted string)
     * The IOCCC contestant ID used as a username in the form of **in the form of
@@ -2676,7 +2635,9 @@ In order of the file's contents we describe each required field, below:
     submission rejected for violating [Rule 17](next/rules.html#rule17)!
 
 - `highbit_warning` (boolean)
-    * This is ignored and will be removed for IOCCC29 and beyond.
+    * `true` if `iocccsize` detects a high bit (unescaped octets with the high
+    bit set - octet value >= 128); see [Rule 13](next/rules.html#rule13), else
+    `false`.
 
 - `nul_warning` (boolean)
     * `true` if `iocccsize` detects a NUL character in the `prog.c`, else
@@ -2740,7 +2701,7 @@ In order of the file's contents we describe each required field, below:
 - `found_clobber_rule` (boolean)
     * `true` if the `Makefile` file has a `clobber` rule, else `false`.
 
-    **IMPORTANT:** if the `Makefile` file does **NOT** have a `clobber` rule and this
+    **IMPORTANT:** if the `Makefile` file does **NOT** have an `clobber` rule and this
     boolean is `true` then you stand a good chance of having your submission
     rejected for violating [Rule 17](next/rules.html#rule17)!
 
@@ -4162,41 +4123,6 @@ as the two can be different at times.
 
 Jump to: [top](#)
 
-<div id="versions">
-### Q 3.12: What are required versions and how are they checked?
-</div>
-
-For each contest the tools used must be a correct version. This correct version
-can be in a range: a valid version is >= the minimum version of a tool or file
-format that is specific to a particular IOCCC and which is not greater than the
-maximum version for that specific IOCCC. A required version is therefore a
-range, where as long as the version is between the min and max, that is >= min
-and <= max, and as long as it's not a blacklisted version (the so-called
-poisonous versions), it is okay.
-
-The concept of a poisonous version exists in the case that a version has to be
-blacklisted for some problem. The file
-[soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-includes a list of versions, their minimum values and their maximum values.
-
-As an example, at the time of writing this, during IOCCC28, the minimum version
-of `mkiocccentry(1)` is `2.0.1 2025-03-02`. If however a fix was needed that
-necessitated a version change, the macro
-`MIN_MKIOCCCENTRY_VERSION` would be changed to that value, rather than map
-directly to ` MKIOCCCENTRY_VERSION`. The maximum, `MAX_MKIOCCCENTRY_VERSION`, is
-defined as `MKIOCCCENTRY_VERSION` but to help distinguish that it is also the
-maximum, we use a separate macro.
-
-So as long as the version you use is >= this minimum and is <= the maximum, and
-as long as it is not in the poisonous list, you are okay. The poisonous versions
-lists can be found in
-[soup/entry_util.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c).
-
-But as long as you are using the official version you should be fine as the
-contest would not open with an invalid version.
-
-
-Jump to: [top](#)
 
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">


### PR DESCRIPTION
The warnings highbit_warning, wordbuf_warning and first_rule_is_all are no longer used and will be removed for IOCCC29 and beyond. Thus the tools no longer care about them.

There were other additions to mkiocccentry like the useful -u uuid option to read in your UUID from a file so you don't have to copy paste it per submission. Although that would be useful in the guidelines to do that would require the version update which is problematic in an open contest. Thus it can be added for IOCCC29 after this one.

IMPORTANT NOTE: you do NOT have to update the tools unless you want to! The submit server will no longer flag submissions with those booleans set to true and when the judges run the tools they won't flag them either. So if you are just fine with what you're doing, and if the recent fixes do not have an impact on your work you are perfectly fine using the current versions you have as version requirements are no longer a single value but >= the  minimum. Of course you might still wish to check that you weren't flagged for some other issue but you no longer have to worry about those three warnings.