### PR TITLE
Update FAQ and guidelines about new options

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.14 2025-03-09</strong>.</p>
+<p>This is FAQ version <strong>28.2.15 2025-03-10</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -454,7 +454,8 @@
 <li><strong>Q 1.6</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
 <li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a></li>
 <li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
-<li><strong>Q 1.9</strong>: <a class="normal" href="#uuid_file">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
+<li><strong>Q 1.9</strong>: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
+<li><strong>Q 1.10</strong>: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a></li>
 </ul>
 <h2 id="ioccc-judging-process">2. <a href="#judging_proceess">IOCCC Judging process</a></h2>
 <ul>
@@ -1057,11 +1058,15 @@ the questions, you can use the <code>-d</code> option (which is an alias for <co
 where <code>21701</code> is the seed) to have the tool make up pseudo-randomly selected
 answers.</p>
 <p>Please note that the tool will <strong>NOT</strong> delete the directory it makes so if you
-do have to try again you’ll have to remove it.</p>
+do have to try again you’ll have to remove it (you can have it delete it if you
+use the <code>-x</code> option though).</p>
 <p>An example use of this option is:</p>
 <pre><code>    mkiocccentry -d workdir topdir</code></pre>
 <p>This will run the tests that <code>mkiocccentry(1)</code>, write the JSON files, use
 <code>chkentry(1)</code>, package the tarball and run <code>txzchk(1)</code> on it.</p>
+<p>If you don’t want to deal with the having to move or delete the submission
+directory, you could instead do:</p>
+<pre><code>    mkiocccentry -x -d workdir topdir</code></pre>
 <p>See also the
 FAQ on “<a href="#mkiocccentry">mkiocccentry</a>”,
 the
@@ -1496,8 +1501,10 @@ do this <strong>AFTER</strong> the <a href="status.html">contest status</a> has 
 <a href="#open">open</a>.
 </p>
 <p>Jump to: <a href="#">top</a></p>
+<div id="uuid">
 <div id="uuid_file">
 <h3 id="q-1.9-how-can-i-avoid-re-entering-my-uuid-to-mkiocccentry">Q 1.9: How can I avoid re-entering my UUID to mkiocccentry?</h3>
+</div>
 </div>
 <p>Because some people might want to submit more than one submission, an option to
 read the UUID from a file exists, so that you don’t have to repeatedly copy and
@@ -1505,13 +1512,29 @@ paste the UUID in. If the file is not a regular readable file or it does not
 have a valid UUID, you will be prompted as if you had not used the option. If
 you use the <code>-i answers</code> feature this will not be used as the UUID is included
 in the answers file.</p>
-<p>To use this feature all you have to do is put the UUID in a text file, in a
-single line, with no spaces before or after it, and then run:</p>
+<p>There are two ways to do this - it is purely a matter of preference. The first
+way is to put your UUID in a text file (the UUID by itself on a single line)
+with no spaces before or after it, and then run:</p>
 <pre><code>    mkiocccentry -u uuid workdir topdir</code></pre>
 <p>where <code>uuid</code> is the file containing your UUID, <code>workdir</code> is the workdir and
 <code>topdir</code> is the topdir.</p>
+<p>The second way is to specify the UUID on the command line itself. For instance
+if your UUID was <code>test</code> (for test mode) you could do:</p>
+<pre><code>    mkiocccentry -U test workdir topdir</code></pre>
 <p>See also the
 FAQ on “<a href="#answers_file">the answers file</a>”.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="submission_dir">
+<h3 id="q-1.10-how-can-i-avoid-having-to-move-or-delete-my-submission-directory-for-the-same-workdir">Q 1.10: How can I avoid having to move or delete my submission directory for the same workdir?</h3>
+</div>
+<p>If you wish to not have to worry about removing or moving the submission
+directory under the workdir, you may use the <code>-x</code> option to <code>mkiocccentry</code>. For
+instance, you can do:</p>
+<pre><code>    mkiocccentry -x workdir topdir</code></pre>
+<p>and if the submission directory under workdir already exists it will be removed
+first so you do not have to do so.</p>
+<p>If for some reason your <code>rm</code> command cannot be found or does not exist you can
+specify the path by the <code>-r rm</code> option.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
@@ -1899,8 +1922,12 @@ the importance of this).
 <ul>
 <li>If this is an invalid UUID (malformed), you will be asked to correct it
 until it is.</li>
-<li>If the <code>-u uuid</code> option is used and the UUID in the file <code>uuid</code> is not malformed,
+<li>If the <code>-u uuidfile</code> option is used and the UUID in the file <code>uuidfile</code> is not malformed,
 the user will not be prompted for a UUID.</li>
+<li>If the <code>-U uuidstr</code> option is used and the UUID is not malformed, the user
+will not be prompted for a UUID.</li>
+<li>The <code>-u</code> and <code>-U</code> options may not be used with any option that reads from
+an answers file (<code>-i answers</code>, <code>-d</code>, <code>-s seed</code>).</li>
 </ul></li>
 <li>Ask the user for the submission slot (the submission number; see <a href="next/register.html">how to
 register</a> and <a href="next/rules.html#rule17">Rule 17</a> for more details).
@@ -1912,7 +1939,10 @@ you will be asked to correct it until it is.</li>
 <li>Make the submission directory under <code>topdir</code> in the form of
 <code>workdir/submit.USERNAME-SLOT</code>.
 <ul>
-<li>If this directory already exists it is an error.</li>
+<li>If this directory already exists it is an error, unless the <code>-x</code> option is
+used, in which case it’ll be deleted.</li>
+<li>If for some reason the default <code>rm</code> paths do not work, you may use <code>-r rm</code>
+to specify the path to a working <code>rm</code> command.</li>
 </ul></li>
 <li>Change to the <code>topdir</code>.</li>
 <li>Traverse the directory, creating lists of ignored/forbidden

--- a/faq.html
+++ b/faq.html
@@ -484,7 +484,7 @@
 <li><strong>Q 3.9</strong>: <a class="normal" href="#entry_id_faq">What is an <code>entry_id</code>?</a></li>
 <li><strong>Q 3.10</strong>: <a class="normal" href="#entry_json">What is a <code>.entry.json</code> file and how is it used?</a></li>
 <li><strong>Q 3.11</strong>: <a class="normal" href="#jparse">How can I validate any JSON document?</a></li>
-<li><strong>Q 3.12</strong>: <a class="normal" href="#versions">What are required versions and how are they checked?</a></li>
+<li><strong>Q 3.12</strong>: <a class="normal" href="#install">How can I install the <code>mkiocccentry(1)</code> and related tools?</a></li>
 </ul>
 <h2 id="compiling-ioccc-entries">4. <a href="#compiling">Compiling IOCCC entries</a></h2>
 <ul>
@@ -2273,13 +2273,11 @@ information about the author or authors of the submission, in JSON format.</p>
 <ul>
 <li>The current version of the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.auth.json</code> version for <strong>THIS</strong>
-IOCCC’s <code>.auth.json</code>, defined as <code>AUTH_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>.auth.json</code> version, defined as
+<code>AUTH_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2304,39 +2302,28 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <ul>
 <li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
+defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry(1)</code> that was used to validate the submission
+<li>The version of <code>chkentry</code> that was used to validate the submission
 directory, including the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
+as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk(1)</code> that <code>txzchk(1)</code> uses to validate the filename of
+<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version in order for it
+to be valid. If this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2402,7 +2389,7 @@ See
 <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements" class="uri">https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements</a>
 for a list of valid codes.</li>
 </ul>
-<p><strong>NOTE:</strong> in <code>mkiocccentry(1)</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
+<p><strong>NOTE:</strong> in <code>mkiocccentry</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
 <li><p><code>email</code> (<code>null</code> or double quoted string)</p>
 <ul>
 <li>The <strong>email</strong> of this author in the form of <code>x@y</code>, or <code>null</code> if not provided.</li>
@@ -2575,14 +2562,11 @@ for more information.</p>
 <ul>
 <li>The current version of the <code>.info.json</code> files.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.info.json</code> version for
-<strong>THIS</strong> IOCCC’s <code>.info.json</code>, defined as <code>INFO_VERSION</code>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>.info.json</code> version, defined as
+<code>INFO_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2605,66 +2589,51 @@ in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>mkiocccentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>mkiocccentry(1)</code> that formed this <code>.auth.json</code> file.</li>
+<li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
+defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>iocccsize_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>iocccsize(1)</code> that was used for this <code>.info.json</code> file.</li>
+<li>The version of <code>iocccsize</code> that was used for this <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>iocccsize(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>iocccsize(1)</code>, defined as <code>IOCCCSIZE_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>iocccentry</code> version,
+defined as <code>IOCCCSIZE_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry(1)</code> that was used to validate the submission
+<li>The version of <code>chkentry</code> that was used to validate the submission
 directory, including the <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
+as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk(1)</code> that <code>txzchk</code> uses to validate the filename of
+<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version, defined
+as <code>FNAMCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>txzchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>txzchk(1)</code> used to validate the xz compressed tarball.</li>
+<li>The version of <code>txzchk</code> used to validate the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>txzchk(1)</code> version for <strong>THIS</strong>
-IOCCC’s <code>txzchk(1)</code>, defined as <code>TXZCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>txzchk</code> version, defined
+as <code>TXZCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p>
-<p>See the
-FAQ on “<a href="#versions">version requirements</a>”
-for more details on what this means.</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2755,7 +2724,9 @@ violated but this is <code>true</code> then you stand a good chance of having yo
 submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p></li>
 <li><p><code>highbit_warning</code> (boolean)</p>
 <ul>
-<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
+<li><code>true</code> if <code>iocccsize</code> detects a high bit (unescaped octets with the high
+bit set - octet value &gt;= 128); see <a href="next/rules.html#rule13">Rule 13</a>, else
+<code>false</code>.</li>
 </ul></li>
 <li><p><code>nul_warning</code> (boolean)</p>
 <ul>
@@ -2820,7 +2791,7 @@ for more information.</p></li>
 <ul>
 <li><code>true</code> if the <code>Makefile</code> file has a <code>clobber</code> rule, else <code>false</code>.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have a <code>clobber</code> rule and this
+<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>clobber</code> rule and this
 boolean is <code>true</code> then you stand a good chance of having your submission
 rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
@@ -3874,34 +3845,6 @@ repo</a> but we recommend you compile and
 install via the <code>mkiocccentry</code> repo because it has the dependencies built in,
 and because the <code>mkiocccentry</code> copy is that which is used by the current IOCCC,
 as the two can be different at times.</p>
-<p>Jump to: <a href="#">top</a></p>
-<div id="versions">
-<h3 id="q-3.12-what-are-required-versions-and-how-are-they-checked">Q 3.12: What are required versions and how are they checked?</h3>
-</div>
-<p>For each contest the tools used must be a correct version. This correct version
-can be in a range: a valid version is &gt;= the minimum version of a tool or file
-format that is specific to a particular IOCCC and which is not greater than the
-maximum version for that specific IOCCC. A required version is therefore a
-range, where as long as the version is between the min and max, that is &gt;= min
-and &lt;= max, and as long as it’s not a blacklisted version (the so-called
-poisonous versions), it is okay.</p>
-<p>The concept of a poisonous version exists in the case that a version has to be
-blacklisted for some problem. The file
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-includes a list of versions, their minimum values and their maximum values.</p>
-<p>As an example, at the time of writing this, during IOCCC28, the minimum version
-of <code>mkiocccentry(1)</code> is <code>2.0.1 2025-03-02</code>. If however a fix was needed that
-necessitated a version change, the macro
-<code>MIN_MKIOCCCENTRY_VERSION</code> would be changed to that value, rather than map
-directly to <code>MKIOCCCENTRY_VERSION</code>. The maximum, <code>MAX_MKIOCCCENTRY_VERSION</code>, is
-defined as <code>MKIOCCCENTRY_VERSION</code> but to help distinguish that it is also the
-maximum, we use a separate macro.</p>
-<p>So as long as the version you use is &gt;= this minimum and is &lt;= the maximum, and
-as long as it is not in the poisonous list, you are okay. The poisonous versions
-lists can be found in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c">soup/entry_util.c</a>.</p>
-<p>But as long as you are using the official version you should be fine as the
-contest would not open with an invalid version.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.13 2025-03-01</strong>.</p>
+<p>This is FAQ version <strong>28.2.14 2025-03-09</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -454,6 +454,7 @@
 <li><strong>Q 1.6</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
 <li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a></li>
 <li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
+<li><strong>Q 1.9</strong>: <a class="normal" href="#uuid_file">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
 </ul>
 <h2 id="ioccc-judging-process">2. <a href="#judging_proceess">IOCCC Judging process</a></h2>
 <ul>
@@ -483,7 +484,7 @@
 <li><strong>Q 3.9</strong>: <a class="normal" href="#entry_id_faq">What is an <code>entry_id</code>?</a></li>
 <li><strong>Q 3.10</strong>: <a class="normal" href="#entry_json">What is a <code>.entry.json</code> file and how is it used?</a></li>
 <li><strong>Q 3.11</strong>: <a class="normal" href="#jparse">How can I validate any JSON document?</a></li>
-<li><strong>Q 3.12</strong>: <a class="normal" href="#install">How can I install the <code>mkiocccentry(1)</code> and related tools?</a></li>
+<li><strong>Q 3.12</strong>: <a class="normal" href="#versions">What are required versions and how are they checked?</a></li>
 </ul>
 <h2 id="compiling-ioccc-entries">4. <a href="#compiling">Compiling IOCCC entries</a></h2>
 <ul>
@@ -1495,6 +1496,23 @@ do this <strong>AFTER</strong> the <a href="status.html">contest status</a> has 
 <a href="#open">open</a>.
 </p>
 <p>Jump to: <a href="#">top</a></p>
+<div id="uuid_file">
+<h3 id="q-1.9-how-can-i-avoid-re-entering-my-uuid-to-mkiocccentry">Q 1.9: How can I avoid re-entering my UUID to mkiocccentry?</h3>
+</div>
+<p>Because some people might want to submit more than one submission, an option to
+read the UUID from a file exists, so that you don’t have to repeatedly copy and
+paste the UUID in. If the file is not a regular readable file or it does not
+have a valid UUID, you will be prompted as if you had not used the option. If
+you use the <code>-i answers</code> feature this will not be used as the UUID is included
+in the answers file.</p>
+<p>To use this feature all you have to do is put the UUID in a text file, in a
+single line, with no spaces before or after it, and then run:</p>
+<pre><code>    mkiocccentry -u uuid workdir topdir</code></pre>
+<p>where <code>uuid</code> is the file containing your UUID, <code>workdir</code> is the workdir and
+<code>topdir</code> is the topdir.</p>
+<p>See also the
+FAQ on “<a href="#answers_file">the answers file</a>”.</p>
+<p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
 <div id="judging_process">
@@ -1864,6 +1882,15 @@ will be asked to verify country code prior to being asked the other questions.
 If you fail to enter other author information correctly you will be prompted
 right away to fix it. Afterwards, when the author information is collected, it
 will ask you to confirm. This procedure happens for each author.</p>
+<p>In the case of <code>-i answers</code> option being used, you will not have to put in most
+information but you will have to confirm the lists of files and directories are
+correct, unless you use <code>-Y</code> (which we do not recommend).</p>
+<p>If <code>topdir</code> is not a readable (<code>+r</code>), searchable (<code>+x</code>) directory it is an error.</p>
+<p>If <code>workdir</code> is not a writable (<code>+w</code>), searchable (<code>+x</code>) directory it is an error.</p>
+<p>If <code>workdir</code> is in <code>topdir</code> the program will not descend into it (the workdir).</p>
+<p>If <code>topdir</code> is the same (by device and inode) as <code>workdir</code> it is an error.
+If somehow <code>topdir</code> or <code>workdir</code> is found under the submission directory (by
+device and inode) it is an error (and you should report it as a bug.</p>
 <p>In more detail the <code>mkiocccentry(1)</code> tool performs the below steps.</p>
 <ol start="0" type="1">
 <li>Ask the user for a submission ID (see the <a href="next/register.html">how to register</a>
@@ -1872,13 +1899,15 @@ the importance of this).
 <ul>
 <li>If this is an invalid UUID (malformed), you will be asked to correct it
 until it is.</li>
+<li>If the <code>-u uuid</code> option is used and the UUID in the file <code>uuid</code> is not malformed,
+the user will not be prompted for a UUID.</li>
 </ul></li>
 <li>Ask the user for the submission slot (the submission number; see <a href="next/register.html">how to
 register</a> and <a href="next/rules.html#rule17">Rule 17</a> for more details).
 <ul>
 <li>If this is out of range (see <code>MAX_SUBMIT_SLOT</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>)
-and you will be asked to correct it until it is.</li>
+you will be asked to correct it until it is.</li>
 </ul></li>
 <li>Make the submission directory under <code>topdir</code> in the form of
 <code>workdir/submit.USERNAME-SLOT</code>.
@@ -2244,11 +2273,13 @@ information about the author or authors of the submission, in JSON format.</p>
 <ul>
 <li>The current version of the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>.auth.json</code> version, defined as
-<code>AUTH_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.auth.json</code> version for <strong>THIS</strong>
+IOCCC’s <code>.auth.json</code>, defined as <code>AUTH_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2273,28 +2304,39 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <ul>
 <li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
-defined as <code>MKIOCCCENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code>
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
-in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>.</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry</code> that was used to validate the submission
+<li>The version of <code>chkentry(1)</code> that was used to validate the submission
 directory, including the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
-as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
+<li>The version of <code>fnamchk(1)</code> that <code>txzchk(1)</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version in order for it
-to be valid. If this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
+in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2360,7 +2402,7 @@ See
 <a href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements" class="uri">https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements</a>
 for a list of valid codes.</li>
 </ul>
-<p><strong>NOTE:</strong> in <code>mkiocccentry</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
+<p><strong>NOTE:</strong> in <code>mkiocccentry(1)</code> use <code>XX</code> if you want your location to be anonymous.</p></li>
 <li><p><code>email</code> (<code>null</code> or double quoted string)</p>
 <ul>
 <li>The <strong>email</strong> of this author in the form of <code>x@y</code>, or <code>null</code> if not provided.</li>
@@ -2533,11 +2575,14 @@ for more information.</p>
 <ul>
 <li>The current version of the <code>.info.json</code> files.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>.info.json</code> version, defined as
-<code>INFO_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>.info.json</code> version for
+<strong>THIS</strong> IOCCC’s <code>.info.json</code>, defined as <code>INFO_VERSION</code>
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest</code> (double quoted string)</p>
 <ul>
 <li>Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).</li>
@@ -2560,51 +2605,66 @@ in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>mkiocccentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>mkiocccentry</code> that formed this <code>.auth.json</code> file.</li>
+<li>The version of <code>mkiocccentry(1)</code> that formed this <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>mkiocccentry</code> version,
-defined as <code>MKIOCCCENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>mkiocccentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>mkiocccentry(1)</code>, defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>iocccsize_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>iocccsize</code> that was used for this <code>.info.json</code> file.</li>
+<li>The version of <code>iocccsize(1)</code> that was used for this <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>iocccentry</code> version,
-defined as <code>IOCCCSIZE_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>iocccsize(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>iocccsize(1)</code>, defined as <code>IOCCCSIZE_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>chkentry_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry</code> that was used to validate the submission
+<li>The version of <code>chkentry(1)</code> that was used to validate the submission
 directory, including the <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
-as <code>CHKENTRY_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>chkentry(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>chkentry(1)</code>, defined as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>fnamchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>fnamchk</code> that <code>txzchk</code> uses to validate the filename of
+<li>The version of <code>fnamchk(1)</code> that <code>txzchk</code> uses to validate the filename of
 the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>fnamchk</code> version, defined
-as <code>FNAMCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>fnamchk(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>fnamchk(1)</code>, defined as <code>FNAMCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>txzchk_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>txzchk</code> used to validate the xz compressed tarball.</li>
+<li>The version of <code>txzchk(1)</code> used to validate the xz compressed tarball.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> match <strong>THIS</strong> IOCCC’s <code>txzchk</code> version, defined
-as <code>TXZCHK_VERSION</code> in
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be a valid <code>txzchk(1)</code> version for <strong>THIS</strong>
+IOCCC’s <code>txzchk(1)</code>, defined as <code>TXZCHK_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
+this is not the case your submission <strong>WILL BE</strong> rejected!</p>
+<p>See the
+FAQ on “<a href="#versions">version requirements</a>”
+for more details on what this means.</p></li>
 <li><p><code>IOCCC_contest_id</code> (double quoted string)</p>
 <ul>
 <li>The IOCCC contestant ID used as a username in the form of <strong>in the form of
@@ -2695,9 +2755,7 @@ violated but this is <code>true</code> then you stand a good chance of having yo
 submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p></li>
 <li><p><code>highbit_warning</code> (boolean)</p>
 <ul>
-<li><code>true</code> if <code>iocccsize</code> detects a high bit (unescaped octets with the high
-bit set - octet value &gt;= 128); see <a href="next/rules.html#rule13">Rule 13</a>, else
-<code>false</code>.</li>
+<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
 </ul></li>
 <li><p><code>nul_warning</code> (boolean)</p>
 <ul>
@@ -2711,11 +2769,8 @@ bit set - octet value &gt;= 128); see <a href="next/rules.html#rule13">Rule 13</
 </ul></li>
 <li><p><code>wordbuf_warning</code> (boolean)</p>
 <ul>
-<li><code>true</code> if <code>prog.c</code> triggered a word buffer overflow (see <code>iocccsize</code>),
-else <code>false</code>.</li>
-</ul>
-<p><strong>IMPORTANT:</strong> this does <strong>NOT</strong> mean that your code has been checked for buffer
-overflows in general.</p></li>
+<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
+</ul></li>
 <li><p><code>ungetc_warning</code> (boolean)</p>
 <ul>
 <li><code>true</code> if <code>prog.c</code> triggered an <code>ungetc(3)</code> error, else <code>false</code>.</li>
@@ -2733,11 +2788,11 @@ FAQ on “<a href="#makefile">Makefile</a>”
 for more information.</p></li>
 <li><p><code>first_rule_is_all</code> (boolean)</p>
 <ul>
-<li><code>true</code> if the first rule in the <code>Makefile</code> file is <code>all</code>, else <code>false</code>.</li>
+<li>This is ignored and will be removed for IOCCC29 and beyond.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>all</code> rule or it is not
-first and this boolean is <code>true</code> then you stand a good chance of having your
-submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
+<p><strong>IMPORTANT:</strong>: if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>all</code> rule then
+you stand a good chance of having your submission rejected for violating
+<a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
 FAQ on “<a href="#makefile">Makefile</a>”
 for more information.</p></li>
@@ -2746,8 +2801,7 @@ for more information.</p></li>
 <li><code>true</code> if the <code>Makefile</code> file has an <code>all</code> rule, else <code>false</code>.</li>
 </ul>
 <p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>all</code> rule and this
-boolean is <code>true</code>, or if it does <strong>NOT</strong> have an <code>all</code> rule but
-<code>first_rule_is_all</code> is <code>true</code> then you stand a good chance of having your
+boolean is <code>true</code> then you stand a good chance of having your
 submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
 FAQ on “<a href="#makefile">Makefile</a>”
@@ -2766,7 +2820,7 @@ for more information.</p></li>
 <ul>
 <li><code>true</code> if the <code>Makefile</code> file has a <code>clobber</code> rule, else <code>false</code>.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have an <code>clobber</code> rule and this
+<p><strong>IMPORTANT:</strong> if the <code>Makefile</code> file does <strong>NOT</strong> have a <code>clobber</code> rule and this
 boolean is <code>true</code> then you stand a good chance of having your submission
 rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>See the
@@ -2913,8 +2967,9 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 problems with it or the submission directory, <strong>it is an error</strong>. If there is an
 error the tarball will <strong>NOT</strong> be formed by <code>mkiocccentry</code>; otherwise the
 <code>txzchk(1)</code> tool will be executed on the tarball.</p>
-<p>The <a href="judges.html">Judges</a> <strong>WILL</strong> use <code>chkentry(1)</code> on this file during the
-judging process and if it does not pass your submission <strong>WILL BE</strong> rejected.</p>
+<p>When the <a href="judges.html">Judges</a> use <code>chkentry(1)</code> on your submission directory,
+if this JSON file is invalid JSON or does not match the requirements outlined
+above, or if any other is found, your submission <strong>WILL BE</strong> rejected.</p>
 <p>An obvious example where <code>chkentry</code> would fail to validate <code>.info.json</code> is if
 there is a mismatch of type in the JSON file with what is expected, for
 instance, if in <code>.info.json</code> the <code>no_comment</code> that we chose to not comment on is
@@ -3819,6 +3874,34 @@ repo</a> but we recommend you compile and
 install via the <code>mkiocccentry</code> repo because it has the dependencies built in,
 and because the <code>mkiocccentry</code> copy is that which is used by the current IOCCC,
 as the two can be different at times.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="versions">
+<h3 id="q-3.12-what-are-required-versions-and-how-are-they-checked">Q 3.12: What are required versions and how are they checked?</h3>
+</div>
+<p>For each contest the tools used must be a correct version. This correct version
+can be in a range: a valid version is &gt;= the minimum version of a tool or file
+format that is specific to a particular IOCCC and which is not greater than the
+maximum version for that specific IOCCC. A required version is therefore a
+range, where as long as the version is between the min and max, that is &gt;= min
+and &lt;= max, and as long as it’s not a blacklisted version (the so-called
+poisonous versions), it is okay.</p>
+<p>The concept of a poisonous version exists in the case that a version has to be
+blacklisted for some problem. The file
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
+includes a list of versions, their minimum values and their maximum values.</p>
+<p>As an example, at the time of writing this, during IOCCC28, the minimum version
+of <code>mkiocccentry(1)</code> is <code>2.0.1 2025-03-02</code>. If however a fix was needed that
+necessitated a version change, the macro
+<code>MIN_MKIOCCCENTRY_VERSION</code> would be changed to that value, rather than map
+directly to <code>MKIOCCCENTRY_VERSION</code>. The maximum, <code>MAX_MKIOCCCENTRY_VERSION</code>, is
+defined as <code>MKIOCCCENTRY_VERSION</code> but to help distinguish that it is also the
+maximum, we use a separate macro.</p>
+<p>So as long as the version you use is &gt;= this minimum and is &lt;= the maximum, and
+as long as it is not in the poisonous list, you are okay. The poisonous versions
+lists can be found in
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c">soup/entry_util.c</a>.</p>
+<p>But as long as you are using the official version you should be fine as the
+contest would not open with an invalid version.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.2.14 2025-03-09**.
+This is FAQ version **28.2.15 2025-03-10**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -28,7 +28,8 @@ This is FAQ version **28.2.14 2025-03-09**.
 - **Q 1.6**: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a>
 - **Q 1.7**: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a>
 - **Q 1.8**: <a class="normal" href="#rule17">What are the details behind Rule 17?</a>
-- **Q 1.9**: <a class="normal" href="#uuid_file">How can I avoid re-entering my UUID to mkiocccentry?</a>
+- **Q 1.9**: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a>
+- **Q 1.10**: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a>
 
 
 ## 2. [IOCCC Judging process](#judging_proceess)
@@ -785,7 +786,8 @@ where `21701` is the seed) to have the tool make up pseudo-randomly selected
 answers.
 
 Please note that the tool will **NOT** delete the directory it makes so if you
-do have to try again you'll have to remove it.
+do have to try again you'll have to remove it (you can have it delete it if you
+use the `-x` option though).
 
 An example use of this option is:
 
@@ -795,6 +797,13 @@ An example use of this option is:
 
 This will run the tests that `mkiocccentry(1)`, write the JSON files, use
 `chkentry(1)`, package the tarball and run `txzchk(1)` on it.
+
+If you don't want to deal with the having to move or delete the submission
+directory, you could instead do:
+
+``` <!---sh-->
+    mkiocccentry -x -d workdir topdir
+```
 
 See also the
 FAQ on "[mkiocccentry](#mkiocccentry)",
@@ -1267,8 +1276,11 @@ do this **AFTER** the [contest status](status.html) has changed to
 
 Jump to: [top](#)
 
+
+<div id="uuid">
 <div id="uuid_file">
 ### Q 1.9: How can I avoid re-entering my UUID to mkiocccentry?
+</div>
 </div>
 
 Because some people might want to submit more than one submission, an option to
@@ -1278,8 +1290,9 @@ have a valid UUID, you will be prompted as if you had not used the option. If
 you use the `-i answers` feature this will not be used as the UUID is included
 in the answers file.
 
-To use this feature all you have to do is put the UUID in a text file, in a
-single line, with no spaces before or after it, and then run:
+There are two ways to do this - it is purely a matter of preference. The first
+way is to put your UUID in a text file (the UUID by itself on a single line)
+with no spaces before or after it, and then run:
 
 ``` <!---sh-->
     mkiocccentry -u uuid workdir topdir
@@ -1288,11 +1301,38 @@ single line, with no spaces before or after it, and then run:
 where `uuid` is the file containing your UUID, `workdir` is the workdir and
 `topdir` is the topdir.
 
+The second way is to specify the UUID on the command line itself. For instance
+if your UUID was `test` (for test mode) you could do:
+
+``` <!---sh-->
+    mkiocccentry -U test workdir topdir
+```
+
+
 See also the
 FAQ on "[the answers file](#answers_file)".
 
 Jump to: [top](#)
 
+<div id="submission_dir">
+### Q 1.10: How can I avoid having to move or delete my submission directory for the same workdir?
+</div>
+
+If you wish to not have to worry about removing or moving the submission
+directory under the workdir, you may use the `-x` option to `mkiocccentry`. For
+instance, you can do:
+
+``` <!---sh-->
+    mkiocccentry -x workdir topdir
+```
+
+and if the submission directory under workdir already exists it will be removed
+first so you do not have to do so.
+
+If for some reason your `rm` command cannot be found or does not exist you can
+specify the path by the `-r rm` option.
+
+Jump to: [top](#)
 
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
@@ -1788,8 +1828,12 @@ for more details on how to obtain this and [Rule 17](next/rules.html#rule17) for
 the importance of this).
     * If this is an invalid UUID (malformed), you will be asked to correct it
     until it is.
-    * If the `-u uuid` option is used and the UUID in the file `uuid` is not malformed,
+    * If the `-u uuidfile` option is used and the UUID in the file `uuidfile` is not malformed,
     the user will not be prompted for a UUID.
+    * If the `-U uuidstr` option is used and the UUID is not malformed, the user
+    will not be prompted for a UUID.
+    * The `-u` and `-U` options may not be used with any option that reads from
+    an answers file (`-i answers`, `-d`, `-s seed`).
 1. Ask the user for the submission slot (the submission number; see [how to
 register](next/register.html) and [Rule 17](next/rules.html#rule17) for more details).
     * If this is out of range (see `MAX_SUBMIT_SLOT` in
@@ -1797,7 +1841,10 @@ register](next/register.html) and [Rule 17](next/rules.html#rule17) for more det
     you will be asked to correct it until it is.
 2. Make the submission directory under `topdir` in the form of
 `workdir/submit.USERNAME-SLOT`.
-    * If this directory already exists it is an error.
+    * If this directory already exists it is an error, unless the `-x` option is
+    used, in which case it'll be deleted.
+    * If for some reason the default `rm` paths do not work, you may use `-r rm`
+    to specify the path to a working `rm` command.
 3. Change to the `topdir`.
 4. Traverse the directory, creating lists of ignored/forbidden
 files/directories/symlinks as well as a list directories to make and a list of

--- a/faq.md
+++ b/faq.md
@@ -58,7 +58,7 @@ This is FAQ version **28.2.14 2025-03-09**.
 - **Q 3.9**: <a class="normal" href="#entry_id_faq">What is an `entry_id`?</a>
 - **Q 3.10**: <a class="normal" href="#entry_json">What is a `.entry.json` file and how is it used?</a>
 - **Q 3.11**: <a class="normal" href="#jparse">How can I validate any JSON document?</a>
-- **Q 3.12**: <a class="normal" href="#versions">What are required versions and how are they checked?</a>
+- **Q 3.12**: <a class="normal" href="#install">How can I install the `mkiocccentry(1)` and related tools?</a>
 
 
 ## 4. [Compiling IOCCC entries](#compiling)
@@ -2189,14 +2189,11 @@ In order of the file's contents we describe each required field, below:
 - `IOCCC_auth_version` (double quoted string)
     * The current version of the `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `.auth.json` version for **THIS**
-    IOCCC's `.auth.json`, defined as `AUTH_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `.auth.json` version, defined as
+    `AUTH_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/).
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
+    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
+    this is not the case your submission **WILL BE** rejected!
 
 - `IOCCC_contest` (double quoted string)
     * Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).
@@ -2222,42 +2219,28 @@ In order of the file's contents we describe each required field, below:
 - `mkiocccentry_version` (double quoted string)
     * The version of `mkiocccentry` that formed this `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `mkiocccentry(1)` version for **THIS**
-    IOCCC's `mkiocccentry(1)`, defined as `MKIOCCCENTRY_VERSION`
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `mkiocccentry` version,
+    defined as `MKIOCCCENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/).
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
+    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
+    this is not the case your submission **WILL BE** rejected!
 
 - `chkentry_version` (double quoted string)
-    * The version of `chkentry(1)` that was used to validate the submission
+    * The version of `chkentry` that was used to validate the submission
     directory, including the `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `chkentry(1)` version for **THIS**
-    IOCCC's `chkentry(1)`, defined as `CHKENTRY_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chkentry` version, defined
+    as `CHKENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `fnamchk_version` (double quoted string)
-    * The version of `fnamchk(1)` that `txzchk(1)` uses to validate the filename of
+    * The version of `fnamchk` that `txzchk` uses to validate the filename of
     the xz compressed tarball.
 
-    **IMPORTANT:** this **MUST** be a valid `fnamchk(1)` version for **THIS**
-    IOCCC's `fnamchk(1)`, defined as `FNAMCHK_VERSION` in
-    [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-    in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
-    this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `fnamchk` version in order for it
+    to be valid. If this is not the case your submission **WILL BE** rejected!
 
 - `IOCCC_contest_id` (double quoted string)
     * The IOCCC contestant ID used as a username in the form of **in the form of
@@ -2321,7 +2304,7 @@ author(s) of the submission:
      <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements>
      for a list of valid codes.
 
-    **NOTE:** in `mkiocccentry(1)` use `XX` if you want your location to be anonymous.
+    **NOTE:** in `mkiocccentry` use `XX` if you want your location to be anonymous.
 
 - `email` (`null` or double quoted string)
     * The **email** of this author in the form of `x@y`, or `null` if not provided.
@@ -2491,15 +2474,11 @@ In order of the file's contents we describe each required field, below:
 - `IOCCC_info_version` (double quoted string)
     * The current version of the `.info.json` files.
 
-    **IMPORTANT:** this **MUST** be a valid `.info.json` version for
-    **THIS** IOCCC's `.info.json`, defined as `INFO_VERSION`
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `.info.json` version, defined as
+    `INFO_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `IOCCC_contest` (double quoted string)
     * Which contest number this is (e.g. 1 for 1984, 2 for 1985, 27 for 2020).
@@ -2523,71 +2502,51 @@ In order of the file's contents we describe each required field, below:
     this is not the case your submission **WILL BE** rejected!
 
 - `mkiocccentry_version` (double quoted string)
-    * The version of `mkiocccentry(1)` that formed this `.auth.json` file.
+    * The version of `mkiocccentry` that formed this `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `mkiocccentry(1)` version for  **THIS**
-    IOCCC's `mkiocccentry(1)`, defined as `MKIOCCCENTRY_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `mkiocccentry` version,
+    defined as `MKIOCCCENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `iocccsize_version` (double quoted string)
-    * The version of `iocccsize(1)` that was used for this `.info.json` file.
+    * The version of `iocccsize` that was used for this `.info.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `iocccsize(1)` version for **THIS**
-    IOCCC's `iocccsize(1)`, defined as `IOCCCSIZE_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `iocccentry` version,
+    defined as `IOCCCSIZE_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `chkentry_version` (double quoted string)
-    * The version of `chkentry(1)` that was used to validate the submission
+    * The version of `chkentry` that was used to validate the submission
     directory, including the `.info.json` file.
 
-    **IMPORTANT:** this **MUST** be a valid `chkentry(1)` version for **THIS**
-    IOCCC's `chkentry(1)`, defined as `CHKENTRY_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chkentry` version, defined
+    as `CHKENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `fnamchk_version` (double quoted string)
-    * The version of `fnamchk(1)` that `txzchk` uses to validate the filename of
+    * The version of `fnamchk` that `txzchk` uses to validate the filename of
     the xz compressed tarball.
 
-    **IMPORTANT:** this **MUST** be a valid `fnamchk(1)` version for **THIS**
-    IOCCC's `fnamchk(1)`, defined as `FNAMCHK_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `fnamchk` version, defined
+    as `FNAMCHK_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `txzchk_version` (double quoted string)
-    * The version of `txzchk(1)` used to validate the xz compressed tarball.
+    * The version of `txzchk` used to validate the xz compressed tarball.
 
-    **IMPORTANT:** this **MUST** be a valid `txzchk(1)` version for **THIS**
-    IOCCC's `txzchk(1)`, defined as `TXZCHK_VERSION` in
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `txzchk` version, defined
+    as `TXZCHK_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
-
-    See the
-    FAQ on "[version requirements](#versions)"
-    for more details on what this means.
 
 - `IOCCC_contest_id` (double quoted string)
     * The IOCCC contestant ID used as a username in the form of **in the form of
@@ -2676,7 +2635,9 @@ In order of the file's contents we describe each required field, below:
     submission rejected for violating [Rule 17](next/rules.html#rule17)!
 
 - `highbit_warning` (boolean)
-    * This is ignored and will be removed for IOCCC29 and beyond.
+    * `true` if `iocccsize` detects a high bit (unescaped octets with the high
+    bit set - octet value >= 128); see [Rule 13](next/rules.html#rule13), else
+    `false`.
 
 - `nul_warning` (boolean)
     * `true` if `iocccsize` detects a NUL character in the `prog.c`, else
@@ -2740,7 +2701,7 @@ In order of the file's contents we describe each required field, below:
 - `found_clobber_rule` (boolean)
     * `true` if the `Makefile` file has a `clobber` rule, else `false`.
 
-    **IMPORTANT:** if the `Makefile` file does **NOT** have a `clobber` rule and this
+    **IMPORTANT:** if the `Makefile` file does **NOT** have an `clobber` rule and this
     boolean is `true` then you stand a good chance of having your submission
     rejected for violating [Rule 17](next/rules.html#rule17)!
 
@@ -4162,41 +4123,6 @@ as the two can be different at times.
 
 Jump to: [top](#)
 
-<div id="versions">
-### Q 3.12: What are required versions and how are they checked?
-</div>
-
-For each contest the tools used must be a correct version. This correct version
-can be in a range: a valid version is >= the minimum version of a tool or file
-format that is specific to a particular IOCCC and which is not greater than the
-maximum version for that specific IOCCC. A required version is therefore a
-range, where as long as the version is between the min and max, that is >= min
-and <= max, and as long as it's not a blacklisted version (the so-called
-poisonous versions), it is okay.
-
-The concept of a poisonous version exists in the case that a version has to be
-blacklisted for some problem. The file
-[soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
-includes a list of versions, their minimum values and their maximum values.
-
-As an example, at the time of writing this, during IOCCC28, the minimum version
-of `mkiocccentry(1)` is `2.0.1 2025-03-02`. If however a fix was needed that
-necessitated a version change, the macro
-`MIN_MKIOCCCENTRY_VERSION` would be changed to that value, rather than map
-directly to ` MKIOCCCENTRY_VERSION`. The maximum, `MAX_MKIOCCCENTRY_VERSION`, is
-defined as `MKIOCCCENTRY_VERSION` but to help distinguish that it is also the
-maximum, we use a separate macro.
-
-So as long as the version you use is >= this minimum and is <= the maximum, and
-as long as it is not in the poisonous list, you are okay. The poisonous versions
-lists can be found in
-[soup/entry_util.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c).
-
-But as long as you are using the official version you should be fine as the
-contest would not open with an invalid version.
-
-
-Jump to: [top](#)
 
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -464,7 +464,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 </div>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.44 2025-03-04</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.45 2025-03-10</strong>.
 </p>
 <p class="leftbar">
 The markdown form of these guidelines <a href="guidelines.md"
@@ -532,6 +532,11 @@ The reason for the times of day are so that key IOCCC events are <strong>calcula
 to be a <strong>fun</strong>ctional UTC time. :-)
 </p>
 <p class="leftbar">
+<strong>NOTE</strong>: the updates to these guidelines on 2025-03-10 explained the new <code>-u uuidfile</code> and <code>-U uuidstr</code> options and are <strong>NOT</strong> important to read, in order
+to follow the guidelines. The options are in a release <strong>AFTER THIS</strong> IOCCC’s
+official release and not updating the toolkit is <strong>PERFECTLY</strong> okay.
+</p>
+<p class="leftbar">
 Until the contest status becomes <strong><a href="../faq.html#open">open</a></strong>,
 the <a href="rules.html">IOCCC rules</a>,
 <a href="guidelines.html">IOCCC guidelines</a> and the tools in the
@@ -595,7 +600,7 @@ previously uploaded submission by rebuilding your submission with the
 <a href="https://submit.ioccc.org">submit server</a>.
 </p>
 <p class="leftbar">
-<strong>HINT:</strong> So that you do not have to repeatedly answer all the
+<strong>HINT:</strong> so that you do not have to repeatedly answer all the
 questions, the <code>mkiocccentry(1)</code> tool has the options <code>-a answers</code>, <code>-A answers</code>
 and <code>-i answers</code>, where <code>-a</code> will write to an answers file (if it does not
 already exist), <code>-A</code> <strong>WILL OVERWRITE THE FILE</strong> and <code>-i</code> will read the answers from
@@ -607,6 +612,14 @@ most if not all <code>y/n</code> questions - you just don’t have to input the 
 submission, the abstract, the author details etc. If you really wish to
 circumvent this you can use the <code>-Y</code> option but we do not recommend this because
 if your update breaks a rule or there is some problem, you might not see it.
+</p>
+<p class="leftbar">
+To help with not having to repeatedly enter a UUID, whether for the same
+submission or multiple submissions, you can use the <code>-u uuidfile</code> or <code>-U UUID</code>
+option. See the
+FAQ on “<a href="../faq.html#uuid">how to avoid re-entering your UUID</a>”
+for more details. Note that the <code>-i answers</code> option cannot be used with the UUID
+options as the answers file includes the UUID.
 </p>
 <p class="leftbar">
 The overall size limit (see <a href="rules.html#rule2a">Rule 2a</a>) on <code>prog.c</code> has been

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -53,7 +53,7 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.44 2025-03-04**.
+These [IOCCC guidelines](guidelines.html) are version **28.45 2025-03-10**.
 </p>
 
 <p class="leftbar">
@@ -143,6 +143,13 @@ to be a **fun**ctional UTC time.  :-)
 </p>
 
 <p class="leftbar">
+**NOTE**: the updates to these guidelines on 2025-03-10 explained the new `-u
+uuidfile` and `-U uuidstr` options and are **NOT** important to read, in order
+to follow the guidelines. The options are in a release **AFTER THIS** IOCCC's
+official release and not updating the toolkit is **PERFECTLY** okay.
+</p>
+
+<p class="leftbar">
 Until the contest status becomes **[open](../faq.html#open)**,
 the [IOCCC rules](rules.html),
 [IOCCC guidelines](guidelines.html) and the tools in the
@@ -214,7 +221,7 @@ previously uploaded submission by rebuilding your submission with the
 </p>
 
 <p class="leftbar">
-**HINT:** So that you do not have to repeatedly answer all the
+**HINT:** so that you do not have to repeatedly answer all the
 questions, the `mkiocccentry(1)` tool has the options `-a answers`, `-A answers`
 and `-i answers`, where `-a` will write to an answers file (if it does not
 already exist), `-A` **WILL OVERWRITE THE FILE** and `-i` will read the answers from
@@ -227,6 +234,15 @@ most if not all `y/n` questions - you just don't have to input the name of the
 submission, the abstract, the author details etc. If you really wish to
 circumvent this you can use the `-Y` option but we do not recommend this because
 if your update breaks a rule or there is some problem, you might not see it.
+</p>
+
+<p class="leftbar">
+To help with not having to repeatedly enter a UUID, whether for the same
+submission or multiple submissions, you can use the `-u uuidfile` or `-U UUID`
+option. See the
+FAQ on "[how to avoid re-entering your UUID](../faq.html#uuid)"
+for more details. Note that the `-i answers` option cannot be used with the UUID
+options as the answers file includes the UUID.
 </p>
 
 <p class="leftbar">


### PR DESCRIPTION

The new options to mkiocccentry are -x to delete the submission
directory if if it already exists and the -u uuidfile and -U uuidstr
options.

NOTE: it is NOT required to update the tools for this IOCCC and you do
NOT have to read the updated guidelines to follow the guidelines for
this IOCCC.
