### PR TITLE
GH-138 tromp (tetris) fix.

### DIFF
--- a/1989/tromp/Makefile
+++ b/1989/tromp/Makefile
@@ -66,7 +66,7 @@ CDEFINE=
 
 # Include files that are needed to compile
 #
-CINCLUDE=
+CINCLUDE= -include signal.h -include sys/time.h
 
 # Optimization
 #


### PR DESCRIPTION
Add missing include files to Makefile CINCLUDE resolves SIGILL on NetBSD 10.1 for both `tromp` and `tromp.alt`.