### PR TITLE
Fix make clobber in next/Makefile.example

### DIFF
--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -211,7 +211,7 @@ clean:
 	fi
 
 clobber: clean
-	${RM} -f ${TARGET} ${ALT_TARGET} *.dSYM
+	${RM} -rf ${TARGET} ${ALT_TARGET} *.dSYM
 	@-if [[ -e sandwich ]]; then \
 	    ${RM} -f sandwich; \
 	    echo 'ate sandwich'; \


### PR DESCRIPTION
*.dSYM is a directory so the ${RM} -f needs -r too.