### PR TITLE
Update 2011/hou/hou.c to accommodate for modern __LINE__ behavior change

### DIFF
--- a/2011/hou/hou.c
+++ b/2011/hou/hou.c
@@ -3,7 +3,7 @@
 #define clear 1;if(c>=11){c=0;sscanf(_,"%lf%c",&r,&c);while(*++_-c);}\
   else if(argc>=4&&!main(4-(*_++=='('),argv))_++;g:c+=
 #define puts(d,e) return 0;}{double a;int b;char c=(argc<4?d)&15;\
-  b=(*_%__LINE__+7)%9*(3*e>>c&1);c+=
+  b=(*_%21+7)%9*(3*e>>c&1);c+=
 #define I(d) (r);if(argc<4&&*#d==*_){a=r;r=usage?r*a:r+a;goto g;}c=c
 #define return if(argc==2)printf("%f\n",r);return argc>=4+
 #define usage main(4-__LINE__/26,argv)


### PR DESCRIPTION
As the original author, I tried to use this as example in a C class and embarrassed myself from this bug 😭. Since `2011/hou/hou.c` looks identical to `2011/hou/hou.orig.c`, it could be that the judges are aware of this but accidentally committed the wrong file as the fixed version. Here is my less smart but correctly running patch.
