### PR TITLE
Typo fix in 2011/akari/.entry.json

### DIFF
--- a/2011/akari/.entry.json
+++ b/2011/akari/.entry.json
@@ -6,7 +6,7 @@
     "dir" : "akari",
     "entry_id" : "2011_akari",
     "title" : "2011.akari",
-    "abstract" : "Downsampler with 3 embeded programs",
+    "abstract" : "Downsampler with 3 embedded programs",
     "author_set" : [
         {
             "author_handle" : "Don_Yang"

--- a/2011/akari/index.html
+++ b/2011/akari/index.html
@@ -406,7 +406,7 @@
   </a>
   <h1>The International Obfuscated C Code Contest</h1>
   <h2>2011/akari - Best of Show - Most Shrinkable</h2>
-  <h3>Downsampler with 3 embeded programs</h3>
+  <h3>Downsampler with 3 embedded programs</h3>
 </div>
 
 <!-- END: this line ends content from: inc/header.default.html -->


### PR DESCRIPTION
Changed 'embeded' to 'embedded'.