### PR TITLE
Typo fix in 1984/mullender/Makefile

### DIFF
--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -137,7 +137,7 @@ ${PROG}: ${PROG}.c
 	@echo
 	@echo "and then running:"
 	@echo
-	@echo "    ./ ${ALT_TARGET}"
+	@echo "    ./${ALT_TARGET}"
 	@echo
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 


### PR DESCRIPTION
This typo ended up with a wrong command (in an echo telling what to do with modern systems - there was a space between the / and what translates to mullender.alt).