### PR TITLE
Fix title for FAQ 1.7 in TOC

### DIFF
--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -137,7 +137,7 @@ ${PROG}: ${PROG}.c
 	@echo
 	@echo "and then running:"
 	@echo
-	@echo "    ./ ${ALT_TARGET}"
+	@echo "    ./${ALT_TARGET}"
 	@echo
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.18 2025-05-26</strong>.</p>
+<p>This is FAQ version <strong>28.2.19 2025-06-10</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -453,7 +453,7 @@
 <li><strong>Q 1.4</strong>: <a class="normal" href="#subdirectories">How may I use subdirectories in my submission if Rule 17 disallows them?</a></li>
 <li><strong>Q 1.5</strong>: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a></li>
 <li><strong>Q 1.6</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
-<li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a></li>
+<li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a></li>
 <li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
 <li><strong>Q 1.9</strong>: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
 <li><strong>Q 1.10</strong>: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a></li>

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.2.18 2025-05-26**.
+This is FAQ version **28.2.19 2025-06-10**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -27,7 +27,7 @@ This is FAQ version **28.2.18 2025-05-26**.
 - **Q 1.4**: <a class="normal" href="#subdirectories">How may I use subdirectories in my submission if Rule 17 disallows them?</a>
 - **Q 1.5**: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a>
 - **Q 1.6**: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a>
-- **Q 1.7**: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a>
+- **Q 1.7**: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a>
 - **Q 1.8**: <a class="normal" href="#rule17">What are the details behind Rule 17?</a>
 - **Q 1.9**: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a>
 - **Q 1.10**: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a>


### PR DESCRIPTION

It was missing 'LLM' as well.