### PR TITLE
Typo fix in 2020/ferguson2/index.html

### DIFF
--- a/1984/mullender/Makefile
+++ b/1984/mullender/Makefile
@@ -137,7 +137,7 @@ ${PROG}: ${PROG}.c
 	@echo
 	@echo "and then running:"
 	@echo
-	@echo "    ./ ${ALT_TARGET}"
+	@echo "    ./${ALT_TARGET}"
 	@echo
 	${CC} ${CFLAGS} $< -o $@ ${LDFLAGS}
 

--- a/2020/ferguson2/README.md
+++ b/2020/ferguson2/README.md
@@ -120,7 +120,7 @@ There is a good deal of useful documentation that is provided with this entry:
 
 
 * [enigma.txt][]
-    - NOTE: see [recode.html][] (or [recode.html](recode.html) for details about how to decrypt this!
+    - **NOTE**: see [recode.html][] for details about how to decrypt this!
 
 * [testing-procedure][]
         - How the author tested the code and why it was necessary to do it in the way it was

--- a/2020/ferguson2/index.html
+++ b/2020/ferguson2/index.html
@@ -517,7 +517,7 @@ out! Can you figure out why this works this way?</p>
 </ul></li>
 <li><a href="enigma.txt">enigma.txt</a>
 <ul>
-<li>NOTE: see <a href="recode.html">recode.html</a> (or <a href="recode.html">recode.html</a> for details about how to decrypt this!</li>
+<li><strong>NOTE</strong>: see <a href="recode.html">recode.html</a> for details about how to decrypt this!</li>
 </ul></li>
 <li><a href="testing-procedure.html">testing-procedure</a>
 <ul>

--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.19 2025-06-10</strong>.</p>
+<p>This is FAQ version <strong>28.2.20 2025-06-11</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -457,6 +457,8 @@
 <li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
 <li><strong>Q 1.9</strong>: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
 <li><strong>Q 1.10</strong>: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a></li>
+<li><strong>Q 1.11</strong>: <a class="normal" href="#download_submission">Can I download my submission tarball from the submit server?</a></li>
+<li><strong>Q 1.12</strong>: <a class="normal" href="#del_submission">Can I delete a submission from the submit server?</a></li>
 </ul>
 <h2 id="ioccc-judging-process">2. <a href="#judging_process">IOCCC Judging process</a></h2>
 <ul>
@@ -1560,6 +1562,22 @@ instance, you can do:</p>
 first so you do not have to do so.</p>
 <p>If for some reason your <code>rm</code> command cannot be found or does not exist you can
 specify the path by the <code>-r rm</code> option.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="download_submission">
+<h3 id="q-1.11-can-i-download-my-submission-tarball-from-the-submit-server">Q 1.11: Can I download my submission tarball from the submit server?</h3>
+</div>
+<p>We do not support this. If you need to verify your submission, then
+you can re-upload (while the contest is in open state) and verify the SHA256
+checksum listed in the submission slot.</p>
+<p>Jump to: <a href="#">top</a></p>
+<div id="del_submission">
+<h3 id="q-1.11-can-i-delete-a-submission-from-the-submit-server">Q 1.11: Can I delete a submission from the submit server?</h3>
+</div>
+<p>We do not support this. Instead, please create an empty prog.c, copy the <a href="next/Makefile.example">example
+Makefile</a> to your Makefile and add to the remarks.md:</p>
+<blockquote>
+<p>Please ignore this submission.</p>
+</blockquote>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.html
+++ b/faq.html
@@ -425,7 +425,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.18 2025-05-26</strong>.</p>
+<p>This is FAQ version <strong>28.2.19 2025-06-10</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -453,7 +453,7 @@
 <li><strong>Q 1.4</strong>: <a class="normal" href="#subdirectories">How may I use subdirectories in my submission if Rule 17 disallows them?</a></li>
 <li><strong>Q 1.5</strong>: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a></li>
 <li><strong>Q 1.6</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
-<li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a></li>
+<li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a></li>
 <li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
 <li><strong>Q 1.9</strong>: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
 <li><strong>Q 1.10</strong>: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a></li>

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.2.18 2025-05-26**.
+This is FAQ version **28.2.19 2025-06-10**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -27,7 +27,7 @@ This is FAQ version **28.2.18 2025-05-26**.
 - **Q 1.4**: <a class="normal" href="#subdirectories">How may I use subdirectories in my submission if Rule 17 disallows them?</a>
 - **Q 1.5**: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a>
 - **Q 1.6**: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a>
-- **Q 1.7**: <a class="normal" href="#ai">May I use AI, Virtual coding assistants, or similar tools to write my submission?</a>
+- **Q 1.7**: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a>
 - **Q 1.8**: <a class="normal" href="#rule17">What are the details behind Rule 17?</a>
 - **Q 1.9**: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a>
 - **Q 1.10**: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a>

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.2.19 2025-06-10**.
+This is FAQ version **28.2.20 2025-06-11**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -31,6 +31,8 @@ This is FAQ version **28.2.19 2025-06-10**.
 - **Q 1.8**: <a class="normal" href="#rule17">What are the details behind Rule 17?</a>
 - **Q 1.9**: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a>
 - **Q 1.10**: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a>
+- **Q 1.11**: <a class="normal" href="#download_submission">Can I download my submission tarball from the submit server?</a>
+- **Q 1.12**: <a class="normal" href="#del_submission">Can I delete a submission from the submit server?</a>
 
 
 ## 2. [IOCCC Judging process](#judging_process)
@@ -1364,7 +1366,6 @@ FAQ on "[the answers file](#answers_file)".
 
 Jump to: [top](#)
 
-
 <div id="submission_dir">
 ### Q 1.10: How can I avoid having to move or delete my submission directory for the same workdir?
 </div>
@@ -1385,6 +1386,28 @@ specify the path by the `-r rm` option.
 
 
 Jump to: [top](#)
+
+<div id="download_submission">
+### Q 1.11: Can I download my submission tarball from the submit server?
+</div>
+
+We do not support this. If you need to verify your submission, then
+you can re-upload (while the contest is in open state) and verify the SHA256
+checksum listed in the submission slot.
+
+Jump to: [top](#)
+
+<div id="del_submission">
+### Q 1.11: Can I delete a submission from the submit server?
+</div>
+
+We do not support this. Instead, please create an empty prog.c, copy the [example
+Makefile](next/Makefile.example) to your Makefile and add to the remarks.md:
+
+> Please ignore this submission.
+
+Jump to: [top](#)
+
 
 
 <hr style="width:50%;text-align:left;margin-left:0">


### PR DESCRIPTION

Likely an artefact from before the scripts generated html files for the
website - I had two links, one for markdown, one for html, but now only 
html is needed for the links.