### PR TITLE
Fix typo in 2024/ferguson1

### DIFF
--- a/2024/ferguson1/README.md
+++ b/2024/ferguson1/README.md
@@ -39,16 +39,16 @@
 ## Judges' remarks:
 
 You will have to go to "Fun-Damentals" to understand the logic flow of
-this game.  While you jump as many as 134 times to travel from `main()`
-to an successful `exit(666)` you may have a devil of a time trying to
+this game. While you jump as many as 134 times to travel from `main()`
+to a successful `exit(666)` you may have a devil of a time trying to
 figure out how this program actually does what it does.
 
 Before you set off on your adventure to decode this program's logic, make
 sure you have enough food, ammo, clothes, oxen, and programming supplies.
 You’ll be driving for 2170 miles through a wild wilderness inspired
-by Oregon, so you’ll need to be prepared for anything!  Regardless of
+by Oregon, so you’ll need to be prepared for anything! Regardless of
 how well prepared you are, you will have a devil of a time jumping around
-inside this C code.  :-)
+inside this C code. :-)
 
 
 ## Author's remarks:

--- a/2024/ferguson1/index.html
+++ b/2024/ferguson1/index.html
@@ -486,7 +486,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>You will have to go to “Fun-Damentals” to understand the logic flow of
 this game. While you jump as many as 134 times to travel from <code>main()</code>
-to an successful <code>exit(666)</code> you may have a devil of a time trying to
+to a successful <code>exit(666)</code> you may have a devil of a time trying to
 figure out how this program actually does what it does.</p>
 <p>Before you set off on your adventure to decode this program’s logic, make
 sure you have enough food, ammo, clothes, oxen, and programming supplies.

--- a/author/Cody_Boone_Ferguson.json
+++ b/author/Cody_Boone_Ferguson.json
@@ -10,7 +10,7 @@
     "alt_url" : "https://ioccc.xexyl.net",
     "deprecated_twitter_handle" : null,
     "mastodon" : "@xexyl@fosstodon.org",
-    "mastodon_url" : null,
+    "mastodon_url" : "https://fosstodon.org/@xexyl",
     "github" : "@xexyl",
     "affiliation" : null,
     "winning_entry_set" : [

--- a/authors.html
+++ b/authors.html
@@ -1657,6 +1657,8 @@ URL: <a class="normal" href="https://xexyl.net">https://xexyl.net</a>
 <br>
 Alternate URL: <a class="normal" href="https://ioccc.xexyl.net">https://ioccc.xexyl.net</a>
 <br>
+Mastodon: <a class="normal" href="https://fosstodon.org/@xexyl"><span class="citation" data-cites="xexyl">@xexyl</span><span class="citation" data-cites="fosstodon.org">@fosstodon.org</span></a>
+<br>
 GitHub: <a class="normal" href="https://github.com/xexyl"><span class="citation" data-cites="xexyl">@xexyl</span></a>
 <br>
 author_handle: <a class="normal" href="https://github.com/ioccc-src/winner/blob/master/author/Cody_Boone_Ferguson.json">Cody_Boone_Ferguson</a>


### PR DESCRIPTION

'an successful' -> 'a successful'.

There is possibly another typo but I have to verify what the judges
meant.

Rebuilt index.html. I hope to make some reductions in text in the coming
days. I also have another fun update planned so people can see just how
wild the gotos are. I hope to do that sometime soon too.