### PR TITLE
Typo fixes in 2024/README.md

### DIFF
--- a/2024/README.md
+++ b/2024/README.md
@@ -8,7 +8,7 @@ See below for links to the [2024 winning IOCCC entries](#inventory).
 Check out the `index.html` web pages for each winning entry.  They have
 most of the information you need to compile and run the winning program.
 Take a look at the winning source code and try to figure out how it works.
-You might also want to check out the author’s remarks for even more details.
+You might also want to check out the author's remarks for even more details.
 
 You may [download all winning entries](2024.tar.bz2) in the form
 of a compressed tarball, for this year's contest.
@@ -62,9 +62,10 @@ Even so, the final rounds of judging required more rounds and tool longer than i
 At the end of the final round of the final rounds of judging, we had a record **23 winners of IOCCC28**,
 eclipsing the record of 15 winners!
 
-While we suspect that the 4 year gap between **IOCCC27** and **IOCCC28** allowed people extra
-time to improve their submissions, we also believe that people submitting to the IOCCC have
-adept in obfuscation and have become more skilled in the programming in the C language.
+While we suspect that the 4 year gap between **IOCCC27** and **IOCCC28** allowed
+people extra time to improve their submissions, we also believe that people
+submitting to the IOCCC have become more adept in adept in obfuscation and have
+become more skilled in the programming in the C language.
 
 
 ### Code size and Rule 2
@@ -124,8 +125,8 @@ to try and understand why the constant `2551443` is common to both entries.
 
 * [2024/cable1](cable1/index.html)
 
-This entry claims to be "_the world’s smallest LLM (large language
-model) inference engine_": running open-source model based on Meta’s
+This entry claims to be "_the world's smallest LLM (large language
+model) inference engine_": running open-source model based on Meta's
 LLaMA 2 with 7 billion parameters.  After downloading the model via the
 [2024/cable1/get_model.sh](%%REPO_URL%%/2024/cable1/get_model.sh) script,
 we invite you explore this **ChatIOCCC** tool.  While not super fast,
@@ -265,10 +266,10 @@ full-fledged C64 emulator is included!
 
 The "**Prize in yil-tas**" provides a hint as to what this marvelous
 winning entry is going, provided that you are someone familiar in at
-least 3 languages (**hint**: One of them is C, another id English).
+least 3 languages (**hint**: One of them is C, another is English).
 
-The IOCCC is honored to present this entry for your enjoyment and you ponder
-the [prog.c source code](%%REPO_URL%%/2024/ferguson2/prog.c).
+The IOCCC is honored to present this entry for your enjoyment and for you to
+ponder the [prog.c source code](%%REPO_URL%%/2024/ferguson2/prog.c).
 
 * [2024/carlini](carlini/index.html)
 
@@ -292,7 +293,7 @@ by computing the output of each gate in a loop, effectively running the CPU and 
 
 * Depending on the address of a variable, as not all platforms support
 [ASLR](https://en.wikipedia.org/wiki/Address_space_layout_randomization),
-as the single source of pseudo-randomness isn’t a good idea.  It’s
+as the single source of pseudo-randomness isn't a good idea.  It's
 much better to mix in other sources of variability (e.g. time, process
 ID, etc.) so that subsequent runs will behave differently.
 
@@ -300,8 +301,8 @@ ID, etc.) so that subsequent runs will behave differently.
 entry, and the submission's obfuscation is mainly in the C code source,
 then the submission likely to not make it into the final rounds of judging.
 
-* When working with modern C compilers, it’s crucial to explicitly
-declare variable and function types. Don’t assume they’ll
+* When working with modern C compilers, it's crucial to explicitly
+declare variable and function types. Don't assume they'll
 automatically default to an `int`.
 
 * Sadly, K&C-style C code does not compile well under modern C compilers.
@@ -319,7 +320,7 @@ C code that implements the mathematics is well obfuscated.
 
 * Just a friendly reminder that before you upload your submissions,
 uncompress the compressed tarball into a different directory. This way,
-you can be sure you didn’t miss uploading any important files!
+you can be sure you didn't miss uploading any important files!
 
 * Using a lot of goto statements to make your code harder to understand
 might not help it pass the final rounds of judging.
@@ -328,7 +329,7 @@ might not help it pass the final rounds of judging.
 ### Encouragement for those who did not win this year
 
 We know many of you that submitted to the IOCCC put in a ton of effort
-into your submissions for this year’s IOCCC.  We can’t just give out
+into your submissions for this year's IOCCC.  We can't just give out
 awards to everyone.  That would mean taking away from the submissions
 that we think are the best and deserve to win.
 
@@ -342,13 +343,13 @@ submitted with revisions, multiple times before rising to the level of
 a winning IOCCC entry.  You might also want to try with a different type
 of submission altogether for the next IOCCC.
 
-If you’re not planning to improve and resubmit your non-winning entry
-for the next IOCCC, you’re welcome to publish it.
+If you're not planning to improve and resubmit your non-winning entry
+for the next IOCCC, you're welcome to publish it.
 
 
 ## On Compiling and running winning entries
 
-Some C compilers aren’t as great as they could be. If yours isn’t
+Some C compilers aren't as great as they could be. If yours isn't
 working well, you might want to try compiling with an updated version
 of clang and/or gcc instead.
 
@@ -362,7 +363,7 @@ If you encounter problems in compiling and/or running the winning entries, see t
 For additional information on how to submit fixes, see the FAQ on:
 
 * [How to submit a fix](../faq.html#fix_an_entry) - how to submit a fix to an entry
-* [Update author information](../faq.html#fix_author) - how to correct or update an IOCCC author’s information
+* [Update author information](../faq.html#fix_author) - how to correct or update an IOCCC author's information
 
 
 ### For even more information

--- a/2024/ferguson1/.gitignore
+++ b/2024/ferguson1/.gitignore
@@ -9,6 +9,7 @@ addpadding
 bytecheck
 bytecount
 byteread
+bytes.txt
 bytetest
 data
 data.asc

--- a/2024/ferguson1/README.md
+++ b/2024/ferguson1/README.md
@@ -46,17 +46,33 @@ figure out how this program actually does what it does.
 Before you set off on your adventure to decode this program's logic, make
 sure you have enough food, ammo, clothes, oxen, and programming supplies.
 You’ll be driving for 2170 miles through a wild wilderness inspired
-by Oregon, so you’ll need to be prepared for anything! Regardless of
+by [Oregon Trail](https://en.wikipedia.org/wiki/The_Oregon_Trail_&lpar;series&rpar;), so you’ll need to be prepared for anything! Regardless of
 how well prepared you are, you will have a devil of a time jumping around
 inside this C code. :-)
 
 
 ## Author's remarks:
 
-
 <div id="devil">
 ### A Pact With the Devil On the Oregon Trail (...and his 134 regrets of goto)
 </div>
+
+<hr style="width:10%;text-align:left;margin-left:0">
+
+> Fun fact: after winning this, the author played the game in gdb from start to
+finish and not counting macros but counting all function calls (not libc
+functions, functions in prog.c), there were a total of **985** (!) line jumps.
+The prog.c, counting `#include`s, `#define`s, functions and some lines that have
+only braces, as well as 14 blank lines, has only 85 lines. A very tiny fraction
+of the time a line might be repeated in a row ONCE but that does not really matter.
+
+**NOTE**: I actually submitted two versions. This one is not encrypted. The
+encrypted one even encrypted emojis without having to decrypt them in order to
+print them (and everything else). I have kept references to encryption in this
+file even after publication. I do have a copy of it if anyone is interested.
+
+<hr style="width:10%;text-align:left;margin-left:0">
+
 
 The **Go To Hell In A Handcart Travel Company** PROUDLY welcomes all sinners to
 our GREATEST destination yet, with:
@@ -78,7 +94,7 @@ all the way back to the 1950s, all the while taking place in the 1800s),
 **PLEASE** either read the (probably totally unnecessary)
 [disclaimer](#disclaimer) or skip this perilous journey entirely. Obviously the
 judges will have no choice in the matter :-) but it's not really for them anyway
-but rather in case this wins.
+but rather in case this wins (which, of course, it did).
 
 Everyone might or might not want to look at the [commentary on the
 jokes](#jokes) as well as the [humour](#humour) section, [historical
@@ -2954,7 +2970,7 @@ comparison):
 
 and of course some of those spaces are not necessary but some are. I think you
 get the idea: my code is **FAR MORE** compact than the original game (and I do
-it with **MORE** gotos too) and I do more and even have lots of jokes even in
+it with **MORE** `goto`s too) and I do more and even have lots of jokes even in
 the code, and the code is also thematic! Now to be fair there are some things
 that my code does not do but the original does: it requires you to type some
 strings and it requires you to choose how to eat and tactics for the riders. But
@@ -3233,18 +3249,29 @@ traits I do not even know how to describe. Perhaps they would be utterly
 ineffable.
 
 Actually I wanted to see what it was like. It was VERY amusing - but only
-because I did not have to debug it. I ran out of files to include and I'm low on
+because I did not have to debug it. For the submission I included line changes
+for JUST the third prompt. It looked like:
 time (mere hours left) but to get to JUST the third prompt this is the lines it
-went in the following sequence:
 
 ```
     19 20 21 32 69 82 34 33 34 47 45 47 50 83 34 33 34 47 45 47 50 83 34 33 34
 ```
 
-The game loop is almost certainly much worse, especially those two for loops I
-mentioned, but there is much much more. If this is easier to follow then I'm a
-dragon. I'm not a dragon. I have a secret for you: dragons don't exist. Except
-on the Oregon Trail.
+I said the game loop is almost certainly much worse, especially those two for
+loops I mentioned, but there is much much more. If this is easier to follow then
+I'm a dragon. I'm not a dragon. I have a secret for you: dragons don't exist.
+Except on the Oregon Trail.
+
+I was right too: the entire game is worse, far far worse. After this won I did a
+full sequence. This is from start to finish and I include it for your amusement.
+Or horror. There are a few times where the line is the same but that only shows
+how very often the line changes. It is a total of 985 changes, counting
+function calls (i.e. each call to one of the few functions is a jump); calls to
+the macros are not counted.
+
+This is in a program that is JUST 85 lines! A program that has only 85 lines
+COUNTING the `#include`s, `#define`s, other functions and 14 blank lines that
+jumps 985 times is astonishing.
 
 > I have yet to see a single study that supported the supposition that GOTOs are
 harmful (I presume this is not because nobody has tried). Nonetheless, people
@@ -3263,6 +3290,7 @@ my program - or maintain it. Or write it.
 It would have been SO MUCH EASIER if I did not use 134 `goto`s. Actually, even a
 tiny portion of that would make it harder. Nobody, whether they're in their
 right mind or not, would WANT to maintain this, or something even close to it.
+Feel free to pass on judgement to me. I welcome it!
 
 Even flex/bison code, which as far as I am aware uses FAR fewer `goto`s, is
 notorious for `goto`s and is quite hard to follow. It would be a nightmare to

--- a/2024/ferguson1/index.html
+++ b/2024/ferguson1/index.html
@@ -491,13 +491,27 @@ figure out how this program actually does what it does.</p>
 <p>Before you set off on your adventure to decode this program’s logic, make
 sure you have enough food, ammo, clothes, oxen, and programming supplies.
 You’ll be driving for 2170 miles through a wild wilderness inspired
-by Oregon, so you’ll need to be prepared for anything! Regardless of
+by <a href="https://en.wikipedia.org/wiki/The_Oregon_Trail_(series)">Oregon Trail</a>, so you’ll need to be prepared for anything! Regardless of
 how well prepared you are, you will have a devil of a time jumping around
 inside this C code. :-)</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
 <div id="devil">
 <h3 id="a-pact-with-the-devil-on-the-oregon-trail-and-his-134-regrets-of-goto">A Pact With the Devil On the Oregon Trail (…and his 134 regrets of goto)</h3>
 </div>
+<hr style="width:10%;text-align:left;margin-left:0">
+<blockquote>
+<p>Fun fact: after winning this, the author played the game in gdb from start to
+finish and not counting macros but counting all function calls (not libc
+functions, functions in prog.c), there were a total of <strong>985</strong> (!) line jumps.
+The prog.c, counting <code>#include</code>s, <code>#define</code>s, functions and some lines that have
+only braces, as well as 14 blank lines, has only 85 lines. A very tiny fraction
+of the time a line might be repeated in a row ONCE but that does not really matter.</p>
+</blockquote>
+<p><strong>NOTE</strong>: I actually submitted two versions. This one is not encrypted. The
+encrypted one even encrypted emojis without having to decrypt them in order to
+print them (and everything else). I have kept references to encryption in this
+file even after publication. I do have a copy of it if anyone is interested.</p>
+<hr style="width:10%;text-align:left;margin-left:0">
 <p>The <strong>Go To Hell In A Handcart Travel Company</strong> PROUDLY welcomes all sinners to
 our GREATEST destination yet, with:</p>
 <p><img src="devil.png"
@@ -514,7 +528,7 @@ all the way back to the 1950s, all the while taking place in the 1800s),
 <strong>PLEASE</strong> either read the (probably totally unnecessary)
 <a href="#disclaimer">disclaimer</a> or skip this perilous journey entirely. Obviously the
 judges will have no choice in the matter :-) but it’s not really for them anyway
-but rather in case this wins.</p>
+but rather in case this wins (which, of course, it did).</p>
 <p>Everyone might or might not want to look at the <a href="#jokes">commentary on the
 jokes</a> as well as the <a href="#humour">humour</a> section, <a href="#history">historical
 references</a> and <a href="#cultural">cultural references</a> as well. The
@@ -2841,7 +2855,7 @@ comparison):</p>
     3826</code></pre>
 <p>and of course some of those spaces are not necessary but some are. I think you
 get the idea: my code is <strong>FAR MORE</strong> compact than the original game (and I do
-it with <strong>MORE</strong> gotos too) and I do more and even have lots of jokes even in
+it with <strong>MORE</strong> <code>goto</code>s too) and I do more and even have lots of jokes even in
 the code, and the code is also thematic! Now to be fair there are some things
 that my code does not do but the original does: it requires you to type some
 strings and it requires you to choose how to eat and tactics for the riders. But
@@ -3070,14 +3084,23 @@ proverbial hat to them. They would have to be extremely patient - and have
 traits I do not even know how to describe. Perhaps they would be utterly
 ineffable.</p>
 <p>Actually I wanted to see what it was like. It was VERY amusing - but only
-because I did not have to debug it. I ran out of files to include and I’m low on
-time (mere hours left) but to get to JUST the third prompt this is the lines it
-went in the following sequence:</p>
+because I did not have to debug it. For the submission I included line changes
+for JUST the third prompt. It looked like:
+time (mere hours left) but to get to JUST the third prompt this is the lines it</p>
 <pre><code>    19 20 21 32 69 82 34 33 34 47 45 47 50 83 34 33 34 47 45 47 50 83 34 33 34</code></pre>
-<p>The game loop is almost certainly much worse, especially those two for loops I
-mentioned, but there is much much more. If this is easier to follow then I’m a
-dragon. I’m not a dragon. I have a secret for you: dragons don’t exist. Except
-on the Oregon Trail.</p>
+<p>I said the game loop is almost certainly much worse, especially those two for
+loops I mentioned, but there is much much more. If this is easier to follow then
+I’m a dragon. I’m not a dragon. I have a secret for you: dragons don’t exist.
+Except on the Oregon Trail.</p>
+<p>I was right too: the entire game is worse, far far worse. After this won I did a
+full sequence. This is from start to finish and I include it for your amusement.
+Or horror. There are a few times where the line is the same but that only shows
+how very often the line changes. It is a total of 985 changes, counting
+function calls (i.e. each call to one of the few functions is a jump); calls to
+the macros are not counted.</p>
+<p>This is in a program that is JUST 85 lines! A program that has only 85 lines
+COUNTING the <code>#include</code>s, <code>#define</code>s, other functions and 14 blank lines that
+jumps 985 times is astonishing.</p>
 <blockquote>
 <p>I have yet to see a single study that supported the supposition that GOTOs are
 harmful (I presume this is not because nobody has tried). Nonetheless, people
@@ -3093,7 +3116,8 @@ sure is WRONG NOW. Anyone who thinks otherwise needs to try and debug
 my program - or maintain it. Or write it.</p>
 <p>It would have been SO MUCH EASIER if I did not use 134 <code>goto</code>s. Actually, even a
 tiny portion of that would make it harder. Nobody, whether they’re in their
-right mind or not, would WANT to maintain this, or something even close to it.</p>
+right mind or not, would WANT to maintain this, or something even close to it.
+Feel free to pass on judgement to me. I welcome it!</p>
 <p>Even flex/bison code, which as far as I am aware uses FAR fewer <code>goto</code>s, is
 notorious for <code>goto</code>s and is quite hard to follow. It would be a nightmare to
 try and maintain without the .l/.y source files.</p>

--- a/2024/ferguson1/obfuscation.html
+++ b/2024/ferguson1/obfuscation.html
@@ -509,6 +509,12 @@ that many and that is ridiculous.</p>
 YES I think it’s HILARIOUS. But if it was not for the IOCCC… Well, as I
 mention in my <a href="#devil">remarks above</a>, EVEN ONE IS TOO MANY
 in real code.</p>
+<p>I dare you to run the program in a debugger from start to finish to see how many
+line jumps there truly are. After I won I did it once: in a program with just 85
+lines (14 blank, some with just a brace, <code>#include</code>s, <code>#define</code>s included) there
+were a total of 985 line changes (a tiny tiny fraction had the same line number
+repeated once). I rarely went to the fort and I only hunted once (I might not
+have hunted at all). This is obscene.</p>
 <p>The best (or worst, depending on how you look at it :-) ) part is this works. As
 I note in those concluding remarks, a company actually introduced a security
 hole from ONE <code>goto</code>. Yet I have 116/134 and it actually works? That is surely

--- a/2024/ferguson1/obfuscation.md
+++ b/2024/ferguson1/obfuscation.md
@@ -67,6 +67,13 @@ YES I think it's HILARIOUS. But if it was not for the IOCCC... Well, as I
 mention in my [remarks above](#devil), EVEN ONE IS TOO MANY
 in real code.
 
+I dare you to run the program in a debugger from start to finish to see how many
+line jumps there truly are. After I won I did it once: in a program with just 85
+lines (14 blank, some with just a brace, `#include`s, `#define`s included) there
+were a total of 985 line changes (a tiny tiny fraction had the same line number
+repeated once). I rarely went to the fort and I only hunted once (I might not
+have hunted at all). This is obscene.
+
 The best (or worst, depending on how you look at it :-) ) part is this works. As
 I note in those concluding remarks, a company actually introduced a security
 hole from ONE `goto`. Yet I have 116/134 and it actually works? That is surely

--- a/2024/ferguson2/deobfus.c
+++ b/2024/ferguson2/deobfus.c
@@ -237,9 +237,9 @@ char *I(struct a *a)
              * Well remember that B is the letter <-> Navajo word for that
              * letter array. So B[J][0] would be the letter itself and B[J][1]
              * will be the word itself. But now we have the other horrible
-             * expressions! Remember that if X (it's always 1 in this file) is
-             * non-zero it's deciphering and if it's 0 it's enciphering. But
-             * what is:
+             * expressions! Remember that if X (it's always 0 in this file) is
+             * non-zero it's deciphering and if it's 0 (always 0 here) it's
+             * enciphering. But what is:
              *
              *      1/ *"1"+s/
              *           *"1"+1/ *"1"+s/ *"1"+1+(s-s)**"1"+(s*(s-s))**"1"

--- a/2024/guidelines.html
+++ b/2024/guidelines.html
@@ -60,6 +60,7 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
                 Winning entries
@@ -95,6 +96,7 @@
                 Updating author info
               </a>
             </div>
+
           </div>
         </div>
 
@@ -104,6 +106,7 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
                 News
@@ -117,8 +120,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../next/index.html" class="sub-item-link">
-                Rules and guidelines
+              <a href="../next/rules.html" class="sub-item-link">
+                IOCCC rules
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../next/guidelines.html" class="sub-item-link">
+                IOCCC guidelines
               </a>
             </div>
 
@@ -143,9 +152,10 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  Frequently Asked Questions
+                Frequently asked questions
               </a>
             </div>
 
@@ -182,9 +192,16 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
                 Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../social.html" class="sub-item-link">
+                IOCCC social media
               </a>
             </div>
 
@@ -196,7 +213,7 @@
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The Judges
+                The judges
               </a>
             </div>
 
@@ -276,6 +293,7 @@
             <a class="mobile-submenu-item" href="../thanks-for-help.html">
               Thanks for the help
             </a>
+
           </div>
         </div>
 
@@ -294,8 +312,12 @@
               Contest status
             </a>
 
-            <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and guidelines
+            <a class="mobile-submenu-item" href="../next/rules.html">
+              IOCCC rules
+            </a>
+
+            <a class="mobile-submenu-item" href="../next/guidelines.html">
+              IOCCC guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
@@ -305,6 +327,7 @@
             <a class="mobile-submenu-item" href="../SECURITY.html">
               Security policy
             </a>
+
           </div>
         </div>
 
@@ -315,7 +338,7 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../faq.html">
-              Frequently Asked Questions
+              Frequently asked questions
             </a>
 
             <a class="mobile-submenu-item" href="../quick-start.html#enter">
@@ -347,17 +370,22 @@
               Home page
             </a>
 
+            <a class="mobile-submenu-item" href="../social.html">
+              IOCCC social media
+            </a>
+
             <a class="mobile-submenu-item" href="../about.html">
               About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The Judges
+              The judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
               Contact us
             </a>
+
           </div>
         </div>
       </div>
@@ -2514,7 +2542,7 @@ as well as
 
 <!--
 
-    Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.
+    Copyright © 1984-2025 by Landon Curt Noll. All Rights Reserved.
 
     You are free to share and adapt this file under the terms of this license:
 
@@ -2528,7 +2556,7 @@ as well as
 
 <div class="footer">
 
-    <div id="copyright"><h3>Copyright &copy; 1984-2024 by Landon Curt Noll:
+    <div id="copyright"><h3>Copyright &copy; 1984-2025 by Landon Curt Noll:
 	<a href="https://creativecommons.org/faq/#what-does-some-rights-reserved-mean"
 	   target="_blank"
 	   rel="license noopener noreferrer">Some Rights Reserved</a></h3>

--- a/2024/index.html
+++ b/2024/index.html
@@ -500,9 +500,10 @@ of judging was that we were very likely to have more winning entries than in pre
 Even so, the final rounds of judging required more rounds and tool longer than in any previous IOCCC.</p>
 <p>At the end of the final round of the final rounds of judging, we had a record <strong>23 winners of IOCCC28</strong>,
 eclipsing the record of 15 winners!</p>
-<p>While we suspect that the 4 year gap between <strong>IOCCC27</strong> and <strong>IOCCC28</strong> allowed people extra
-time to improve their submissions, we also believe that people submitting to the IOCCC have
-adept in obfuscation and have become more skilled in the programming in the C language.</p>
+<p>While we suspect that the 4 year gap between <strong>IOCCC27</strong> and <strong>IOCCC28</strong> allowed
+people extra time to improve their submissions, we also believe that people
+submitting to the IOCCC have become more adept in adept in obfuscation and have
+become more skilled in the programming in the C language.</p>
 <h3 id="code-size-and-rule-2">Code size and Rule 2</h3>
 <p>We were pleased to observe that while the <a href="../faq.html#size_rule_history">IOCCC size limit</a>
 increased by about 21%, we received many submissions that were well under the new
@@ -666,9 +667,9 @@ full-fledged C64 emulator is included!</p>
 </ul>
 <p>The “<strong>Prize in yil-tas</strong>” provides a hint as to what this marvelous
 winning entry is going, provided that you are someone familiar in at
-least 3 languages (<strong>hint</strong>: One of them is C, another id English).</p>
-<p>The IOCCC is honored to present this entry for your enjoyment and you ponder
-the <a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson2/prog.c">prog.c source code</a>.</p>
+least 3 languages (<strong>hint</strong>: One of them is C, another is English).</p>
+<p>The IOCCC is honored to present this entry for your enjoyment and for you to
+ponder the <a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson2/prog.c">prog.c source code</a>.</p>
 <ul>
 <li><a href="carlini/index.html">2024/carlini</a></li>
 </ul>

--- a/2024/rules.html
+++ b/2024/rules.html
@@ -60,6 +60,7 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../years.html" class="sub-item-link">
                 Winning entries
@@ -95,6 +96,7 @@
                 Updating author info
               </a>
             </div>
+
           </div>
         </div>
 
@@ -104,6 +106,7 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../news.html" class="sub-item-link">
                 News
@@ -117,8 +120,14 @@
             </div>
 
             <div class="outfit-font">
-              <a href="../next/index.html" class="sub-item-link">
-                Rules and guidelines
+              <a href="../next/rules.html" class="sub-item-link">
+                IOCCC rules
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../next/guidelines.html" class="sub-item-link">
+                IOCCC guidelines
               </a>
             </div>
 
@@ -143,9 +152,10 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../faq.html" class="sub-item-link">
-                  Frequently Asked Questions
+                Frequently asked questions
               </a>
             </div>
 
@@ -182,9 +192,16 @@
           </span>
 
           <div class="sub-item">
+
             <div class="outfit-font">
               <a href="../index.html" class="sub-item-link">
                 Home page
+              </a>
+            </div>
+
+            <div class="outfit-font">
+              <a href="../social.html" class="sub-item-link">
+                IOCCC social media
               </a>
             </div>
 
@@ -196,7 +213,7 @@
 
             <div class="outfit-font">
               <a href="../judges.html" class="sub-item-link">
-                The Judges
+                The judges
               </a>
             </div>
 
@@ -276,6 +293,7 @@
             <a class="mobile-submenu-item" href="../thanks-for-help.html">
               Thanks for the help
             </a>
+
           </div>
         </div>
 
@@ -294,8 +312,12 @@
               Contest status
             </a>
 
-            <a class="mobile-submenu-item" href="../next/index.html">
-              Rules and guidelines
+            <a class="mobile-submenu-item" href="../next/rules.html">
+              IOCCC rules
+            </a>
+
+            <a class="mobile-submenu-item" href="../next/guidelines.html">
+              IOCCC guidelines
             </a>
 
             <a class="mobile-submenu-item" href="../markdown.html">
@@ -305,6 +327,7 @@
             <a class="mobile-submenu-item" href="../SECURITY.html">
               Security policy
             </a>
+
           </div>
         </div>
 
@@ -315,7 +338,7 @@
           <div class="mobile-submenu-wrapper">
 
             <a class="mobile-submenu-item" href="../faq.html">
-              Frequently Asked Questions
+              Frequently asked questions
             </a>
 
             <a class="mobile-submenu-item" href="../quick-start.html#enter">
@@ -347,17 +370,22 @@
               Home page
             </a>
 
+            <a class="mobile-submenu-item" href="../social.html">
+              IOCCC social media
+            </a>
+
             <a class="mobile-submenu-item" href="../about.html">
               About the IOCCC
             </a>
 
             <a class="mobile-submenu-item" href="../judges.html">
-              The Judges
+              The judges
             </a>
 
             <a class="mobile-submenu-item" href="../contact.html">
               Contact us
             </a>
+
           </div>
         </div>
       </div>
@@ -1287,7 +1315,7 @@ as well as
 
 <!--
 
-    Copyright © 1984-2024 by Landon Curt Noll. All Rights Reserved.
+    Copyright © 1984-2025 by Landon Curt Noll. All Rights Reserved.
 
     You are free to share and adapt this file under the terms of this license:
 
@@ -1301,7 +1329,7 @@ as well as
 
 <div class="footer">
 
-    <div id="copyright"><h3>Copyright &copy; 1984-2024 by Landon Curt Noll:
+    <div id="copyright"><h3>Copyright &copy; 1984-2025 by Landon Curt Noll:
 	<a href="https://creativecommons.org/faq/#what-does-some-rights-reserved-mean"
 	   target="_blank"
 	   rel="license noopener noreferrer">Some Rights Reserved</a></h3>

--- a/thanks-for-help.html
+++ b/thanks-for-help.html
@@ -5165,11 +5165,11 @@ be made consistent but adding markdown where necessary in the remarks is).</p>
 <div id="try">
 <h2 id="try-script-system">Try script system</h2>
 </div>
-<p><a href="#cody">Cody</a> devised the <code>try</code> script system and added the many <code>try.sh</code>,
-<code>try.alt.sh</code> and various other forms, as well as a number of wrapper scripts to
-more easily run programs. It is not always useful but these scripts do a variety
-of things to really show off the entries, so this really helps with the
-presentation of the winning entries.</p>
+<p><a href="#cody">Cody</a> devised the <code>try</code> script system (which we now use as part of
+judging) and added the many <code>try.sh</code>, <code>try.alt.sh</code> and various other forms, as
+well as a number of wrapper scripts to more easily run programs. It is not
+always useful but these scripts do a variety of things to really show off the
+entries, so this really helps with the presentation of the winning entries.</p>
 <p>Cody also added the example scripts for future submitters,
 <a href="https://github.com/ioccc-src/winner/blob/master/next/try.sh">try.sh</a> and
 <a href="https://github.com/ioccc-src/winner/blob/master/next/try.alt.sh">try.alt.sh</a>.</p>
@@ -5228,16 +5228,14 @@ definitions of ‘<code>HARD</code>’ :-) ), such as
 <a href="thanks-for-help.html#2001_anonymous">2001/anonymous</a> and
 <a href="thanks-for-help.html#2004_burley">2004/burley</a>; fixing entries like
 <a href="thanks-for-help.html#1985_sicherman">1985/sicherman</a> to
-not require <code>-traditional-cpp</code>; fixing
-entries like <a href="thanks-for-help.html#1991_dds">1991/dds</a> (or, as in the case of
+not need <code>-traditional-cpp</code>; fixing
+entries like <a href="thanks-for-help.html#1991_dds">1991/dds</a> to work with
+<a href="faq.html#clang">clang</a> (or, as in the case of
 <a href="thanks-for-help.html#1989_westley">1989/westley</a>, a true masterpiece in
-obfuscation, as much as possible) to work with <a href="faq.html#clang">clang</a>; porting entries like
+obfuscation, as much as possible); porting entries like
 <a href="thanks-for-help.html#1998_schweikh1">1998/schweikh1</a> to
-<a href="faq.html#macos_compile">macOS</a>; porting entries like
-<a href="thanks-for-help.html#2001_herrmann2">2001/herrmann2</a> to work in <a href="faq.html#32bit">both 32-bit and
-64-bit</a>; providing <a href="faq.html#alt_code">alternate code</a> where useful/necessary;
-improving all <a href="#makefiles">Makefiles</a>; writing <a href="#try">scripts</a> to greatly simplify running many
-of the entries; and other important fixes.</p>
+<a href="faq.html#macos_compile">macOS</a>; fixing entries like
+<a href="thanks-for-help.html#2001_herrmann2">2001/herrmann2</a> to work with <a href="faq.html#32bit">32 and 64-bit</a>; providing <a href="faq.html#alt_code">alt code</a> where useful/needed; improving all <a href="#makefiles">Makefiles</a>; devising the <a href="#try">try scripts</a> which we now use as part of judging; and other important fixes.</p>
 <p>Cody Boone Ferguson also used one of his own tools to detect many dead links.
 While the tool was not perfect it went a long way to uncover a good number of
 bad, broken or otherwise invalid links. It was a very laborious task to copy and
@@ -5253,9 +5251,9 @@ run <code>sed(1)</code> on specified files under git that we sometimes use to ed
 website, greatly improved the manifests and checked that the generated html
 files look good and are presentable, suggested CSS rules for
 image responsiveness (and made other CSS improvements) and he greatly improved the FAQ.</p>
-<p>Cody also wrote some of the <a href="bin/index.html">website scripts</a>, improved and
-bug fixed others, co-developed the <a href="https://github.com/xexyl/jparse">JSON parser and tools</a> with
-us, as we now make extensive use of JSON, and helped test and fix the submit
+<p>Cody also wrote some <a href="bin/index.html">website scripts</a>, improved and
+fixed others, co-developed the <a href="https://github.com/xexyl/jparse">JSON parser and tools</a> with
+us, as we now make extensive use of JSON, and helped test/fix the submit
 server and mailing list for IOCCC28 and beyond.</p>
 <p><strong>THANK YOU VERY MUCH</strong> for your extensive efforts in helping improve the IOCCC
 presentation of past IOCCC entries, fixing many entries that no

--- a/thanks-for-help.md
+++ b/thanks-for-help.md
@@ -7050,11 +7050,11 @@ Jump to: [top](#)
 ## Try script system
 </div>
 
-[Cody](#cody) devised the `try` script system and added the many `try.sh`,
-`try.alt.sh` and various other forms, as well as a number of wrapper scripts to
-more easily run programs. It is not always useful but these scripts do a variety
-of things to really show off the entries, so this really helps with the
-presentation of the winning entries.
+[Cody](#cody) devised the `try` script system (which we now use as part of
+judging) and added the many `try.sh`, `try.alt.sh` and various other forms, as
+well as a number of wrapper scripts to more easily run programs. It is not
+always useful but these scripts do a variety of things to really show off the
+entries, so this really helps with the presentation of the winning entries.
 
 Cody also added the example scripts for future submitters,
 [try.sh](%%REPO_URL%%/next/try.sh) and
@@ -7140,16 +7140,14 @@ definitions of '`HARD`' :-) ), such as
 [2001/anonymous](thanks-for-help.html#2001_anonymous) and
 [2004/burley](thanks-for-help.html#2004_burley); fixing entries like
 [1985/sicherman](thanks-for-help.html#1985_sicherman) to
-not require `-traditional-cpp`; fixing
-entries like [1991/dds](thanks-for-help.html#1991_dds) (or, as in the case of
+not need `-traditional-cpp`; fixing
+entries like [1991/dds](thanks-for-help.html#1991_dds) to work with
+[clang](faq.html#clang) (or, as in the case of
 [1989/westley](thanks-for-help.html#1989_westley), a true masterpiece in
-obfuscation, as much as possible) to work with [clang](faq.html#clang); porting entries like
+obfuscation, as much as possible); porting entries like
 [1998/schweikh1](thanks-for-help.html#1998_schweikh1) to
-[macOS](faq.html#macos_compile); porting entries like
-[2001/herrmann2](thanks-for-help.html#2001_herrmann2) to work in [both 32-bit and
-64-bit](faq.html#32bit); providing [alternate code](faq.html#alt_code) where useful/necessary;
-improving all [Makefiles](#makefiles); writing [scripts](#try) to greatly simplify running many
-of the entries; and other important fixes.
+[macOS](faq.html#macos_compile); fixing entries like
+[2001/herrmann2](thanks-for-help.html#2001_herrmann2) to work with [32 and 64-bit](faq.html#32bit); providing [alt code](faq.html#alt_code) where useful/needed; improving all [Makefiles](#makefiles); devising the [try scripts](#try) which we now use as part of judging; and other important fixes.
 
 Cody Boone Ferguson also used one of his own tools to detect many dead links.
 While the tool was not perfect it went a long way to uncover a good number of
@@ -7168,9 +7166,9 @@ website, greatly improved the manifests and checked that the generated html
 files look good and are presentable, suggested CSS rules for
 image responsiveness (and made other CSS improvements) and he greatly improved the FAQ.
 
-Cody also wrote some of the [website scripts](bin/index.html), improved and
-bug fixed others, co-developed the [JSON parser and tools](https://github.com/xexyl/jparse) with
-us, as we now make extensive use of JSON, and helped test and fix the submit
+Cody also wrote some [website scripts](bin/index.html), improved and
+fixed others, co-developed the [JSON parser and tools](https://github.com/xexyl/jparse) with
+us, as we now make extensive use of JSON, and helped test/fix the submit
 server and mailing list for IOCCC28 and beyond.
 
 **THANK YOU VERY MUCH** for your extensive efforts in helping improve the IOCCC


### PR DESCRIPTION

Also rebuilt 2024/guidelines.html, 2024/rules.html (obviously
2024/index.html was also rebuilt).

The other ones were rebuilt because the markdown had 2025 (from 2024) 
and it was not rebuilt. I noticed a lot of files have this problem (in
copyright). May I suggest sgit(1) to save you time? :-) (I would do it
but I don't want to cause a problem with any pull requests that might
be opened.
