### PR TITLE
Fix html links in 2024/

### DIFF
--- a/2024/burton/.entry.json
+++ b/2024/burton/.entry.json
@@ -41,7 +41,7 @@
             "file_path" : "deobfuscated.html",
             "inventory_order" : 100,
             "OK_to_edit" : false,
-            "display_as" : "markdown",
+            "display_as" : "html",
             "display_via_github" : true,
             "entry_text" : "about deobfuscation"
         },
@@ -57,8 +57,8 @@
             "file_path" : "extra.html",
             "inventory_order" : 100,
             "OK_to_edit" : false,
-            "display_as" : "markdown",
-            "display_via_github" : true,
+            "display_as" : "html",
+            "display_via_github" : false,
             "entry_text" : "description of the extra files"
         },
         {

--- a/2024/burton/index.html
+++ b/2024/burton/index.html
@@ -881,7 +881,7 @@ due to the omissions noted above, but I am unaware of these.</p>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/prog.orig.c">prog.orig.c</a> - original source code</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/deobfuscated.html">deobfuscated.html</a> - about deobfuscation</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/dict">dict</a> - 5-letter wordle dictionary</li>
-<li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/extra.html">extra.html</a> - description of the extra files</li>
+<li><a href="extra.html">extra.html</a> - description of the extra files</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/reveal.c">reveal.c</a> - reveal wordle hints</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/try.sh">try.sh</a> - script to try entry</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/burton/deobfuscated.c">deobfuscated.c</a> - deobfuscated source code</li>

--- a/2024/ferguson1/.entry.json
+++ b/2024/ferguson1/.entry.json
@@ -97,8 +97,8 @@
             "file_path" : "deobfuscation.html",
             "inventory_order" : 100,
             "OK_to_edit" : false,
-            "display_as" : "markdown",
-            "display_via_github" : true,
+            "display_as" : "html",
+            "display_via_github" : false,
             "entry_text" : "hints on how to deobfuscate"
         },
         {
@@ -129,8 +129,8 @@
             "file_path" : "obfuscation.html",
             "inventory_order" : 100,
             "OK_to_edit" : false,
-            "display_as" : "markdown",
-            "display_via_github" : true,
+            "display_as" : "html",
+            "display_via_github" : false,
             "entry_text" : "obfuscation information"
         },
         {

--- a/2024/ferguson1/index.html
+++ b/2024/ferguson1/index.html
@@ -3710,11 +3710,11 @@ helps you appreciate the careful design even more.<a href="#fnref2" class="footn
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/bytecount.c">bytecount.c</a> - print each string with locations</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/byteread.c">byteread.c</a> - prints out the strings without locations</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/bytetest.c">bytetest.c</a> - prints every string extracted from data</li>
-<li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/deobfuscation.html">deobfuscation.html</a> - hints on how to deobfuscate</li>
+<li><a href="deobfuscation.html">deobfuscation.html</a> - hints on how to deobfuscate</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/gotos.txt">gotos.txt</a> - text file showing all the line changes in a run</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/lencount.c">lencount.c</a> - counts strings and reports longest one</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/mbcheck.c">mbcheck.c</a> - show location of multibyte characters</li>
-<li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/obfuscation.html">obfuscation.html</a> - obfuscation information</li>
+<li><a href="obfuscation.html">obfuscation.html</a> - obfuscation information</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/printer.c">printer.c</a> - prints strings like the game does</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/try.sh">try.sh</a> - script to try entry</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/devil.png">devil.png</a> - Devil driving wagon</li>

--- a/2024/howe/.entry.json
+++ b/2024/howe/.entry.json
@@ -41,8 +41,8 @@
             "file_path" : "prog.html",
             "inventory_order" : 100,
             "OK_to_edit" : false,
-            "display_as" : "markdown",
-            "display_via_github" : true,
+            "display_as" : "html",
+            "display_via_github" : false,
             "entry_text" : "eh man page"
         },
         {

--- a/2024/howe/index.html
+++ b/2024/howe/index.html
@@ -572,7 +572,7 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/howe/prog.c">prog.c</a> - entry source code</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/howe/Makefile">Makefile</a> - entry Makefile</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/howe/prog.orig.c">prog.orig.c</a> - original source code</li>
-<li><a href="https://github.com/ioccc-src/winner/blob/master/2024/howe/prog.html">prog.html</a> - eh man page</li>
+<li><a href="prog.html">prog.html</a> - eh man page</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2024/howe/try.sh">try.sh</a> - script to try entry</li>
 </ul>
 <h2 id="secondary-files">Secondary files</h2>


### PR DESCRIPTION
Due to a manifest mix-up (which had some html files marked as markdown and as display_via_github as true) the respective entries' index.html linked to html files on GitHub which do not render right (and is the wrong place in any case).

This means that the index.html files and the .entry.json files were updated. This in particular goes for:

    2024/burton
    2024/ferguson1
    2024/howe

Thanks to @SirWumpus for reporting this!