### PR TITLE
Clean up YT heading in IOCCC28 index.html files

### DIFF
--- a/2024/burton/README.md
+++ b/2024/burton/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/burton - Prize in pentagrammatology](https://www.youtube.com/watch?v=PQGCfnVmmNA)
 

--- a/2024/burton/index.html
+++ b/2024/burton/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/burton/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=PQGCfnVmmNA">IOCCC28 - 2024/burton - Prize in pentagrammatology</a></p>
 </blockquote>

--- a/2024/cable1/README.md
+++ b/2024/cable1/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/cable1 - Prize in bot talk](https://www.youtube.com/watch?v=ZrGyUELYW2M)
 

--- a/2024/cable1/index.html
+++ b/2024/cable1/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/cable1/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=ZrGyUELYW2M">IOCCC28 - 2024/cable1 - Prize in bot talk</a></p>
 </blockquote>

--- a/2024/cable2/README.md
+++ b/2024/cable2/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/cable2 - Prize in murky waters](https://www.youtube.com/watch?v=RMI5oT9U4vc)
 

--- a/2024/cable2/index.html
+++ b/2024/cable2/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/cable2/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=RMI5oT9U4vc">IOCCC28 - 2024/cable2 - Prize in murky waters</a></p>
 </blockquote>

--- a/2024/carlini/README.md
+++ b/2024/carlini/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/carlini - Prize in perfect timing](https://www.youtube.com/watch?v=r6wUZUaaJBY)
 

--- a/2024/carlini/index.html
+++ b/2024/carlini/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/carlini/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=r6wUZUaaJBY">IOCCC28 - 2024/carlini - Prize in perfect timing</a></p>
 </blockquote>

--- a/2024/codemeow/README.md
+++ b/2024/codemeow/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/codemeow - Prize in tray planting](https://www.youtube.com/watch?v=OxRLL_RFZHs)
 

--- a/2024/codemeow/index.html
+++ b/2024/codemeow/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#KG">KG</a> - <em>Kyrgyz Republic</em> (<e
 
 <!-- BEFORE: 1st line of markdown file: 2024/codemeow/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=OxRLL_RFZHs">IOCCC28 - 2024/codemeow - Prize in tray planting</a></p>
 </blockquote>

--- a/2024/endoh1/README.md
+++ b/2024/endoh1/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/endoh1 - Prize in patient pointillism](https://www.youtube.com/watch?v=-BORKHexSPM)
 

--- a/2024/endoh1/index.html
+++ b/2024/endoh1/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 
 <!-- BEFORE: 1st line of markdown file: 2024/endoh1/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=-BORKHexSPM">IOCCC28 - 2024/endoh1 - Prize in patient pointillism</a></p>
 </blockquote>

--- a/2024/endoh2/README.md
+++ b/2024/endoh2/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/endoh2 - Prize in solid body physics](https://www.youtube.com/watch?v=KT9Fgg4t7gY)
 

--- a/2024/endoh2/index.html
+++ b/2024/endoh2/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 
 <!-- BEFORE: 1st line of markdown file: 2024/endoh2/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=KT9Fgg4t7gY">IOCCC28 - 2024/endoh2 - Prize in solid body physics</a></p>
 </blockquote>

--- a/2024/ferguson1/README.md
+++ b/2024/ferguson1/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/ferguson1 - Prize in diabolical logistics](https://www.youtube.com/watch?v=o7qSjWRoRlU)
 

--- a/2024/ferguson1/index.html
+++ b/2024/ferguson1/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/ferguson1/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=o7qSjWRoRlU">IOCCC28 - 2024/ferguson1 - Prize in diabolical logistics</a></p>
 </blockquote>

--- a/2024/ferguson2/README.md
+++ b/2024/ferguson2/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/ferguson2 - Prize in yil-tas](https://www.youtube.com/watch?v=KmSzapLxDnA)
 

--- a/2024/ferguson2/index.html
+++ b/2024/ferguson2/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/ferguson2/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=KmSzapLxDnA">IOCCC28 - 2024/ferguson2 - Prize in yil-tas</a></p>
 </blockquote>

--- a/2024/howe/README.md
+++ b/2024/howe/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/howe - Nice accent eh-ward](https://www.youtube.com/watch?v=oDY4rzIaKAo)
 

--- a/2024/howe/index.html
+++ b/2024/howe/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 
 <!-- BEFORE: 1st line of markdown file: 2024/howe/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=oDY4rzIaKAo">IOCCC28 - 2024/howe - Nice accent eh-ward</a></p>
 </blockquote>

--- a/2024/kramer/README.md
+++ b/2024/kramer/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/kramer - Prize in linguistic arithmetic](https://www.youtube.com/watch?v=Wkt6FbOYMxs)
 

--- a/2024/kramer/index.html
+++ b/2024/kramer/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/kramer/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=Wkt6FbOYMxs">IOCCC28 - 2024/kramer - Prize in linguistic arithmetic</a></p>
 </blockquote>

--- a/2024/kurdyukov1/README.md
+++ b/2024/kurdyukov1/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/kurdyukov1 - Prize in phased periodicity](https://www.youtube.com/watch?v=b2WfQdGJS8s)
 

--- a/2024/kurdyukov1/index.html
+++ b/2024/kurdyukov1/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#RU">RU</a> - <em>Russian Federation</em> 
 
 <!-- BEFORE: 1st line of markdown file: 2024/kurdyukov1/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=b2WfQdGJS8s">IOCCC28 - 2024/kurdyukov1 - Prize in phased periodicity</a></p>
 </blockquote>

--- a/2024/kurdyukov2/README.md
+++ b/2024/kurdyukov2/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/kurdyukov2 - Prize in art restoration](https://www.youtube.com/watch?v=dWxRYHTPQPE)
 

--- a/2024/kurdyukov2/index.html
+++ b/2024/kurdyukov2/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#RU">RU</a> - <em>Russian Federation</em> 
 
 <!-- BEFORE: 1st line of markdown file: 2024/kurdyukov2/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=dWxRYHTPQPE">IOCCC28 - 2024/kurdyukov2 - Prize in art restoration</a></p>
 </blockquote>

--- a/2024/kurdyukov3/README.md
+++ b/2024/kurdyukov3/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/kurdyukov3 - Prize in virtual quietus](https://www.youtube.com/watch?v=iaXMwqR93iE)
 

--- a/2024/kurdyukov3/index.html
+++ b/2024/kurdyukov3/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#RU">RU</a> - <em>Russian Federation</em> 
 
 <!-- BEFORE: 1st line of markdown file: 2024/kurdyukov3/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=iaXMwqR93iE">IOCCC28 - 2024/kurdyukov3 - Prize in virtual quietus</a></p>
 </blockquote>

--- a/2024/kurdyukov4/README.md
+++ b/2024/kurdyukov4/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/kurdyukov4 - Prize in embiggening](https://www.youtube.com/watch?v=YnU_jQs11Lk)
 

--- a/2024/kurdyukov4/index.html
+++ b/2024/kurdyukov4/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#RU">RU</a> - <em>Russian Federation</em> 
 
 <!-- BEFORE: 1st line of markdown file: 2024/kurdyukov4/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=YnU_jQs11Lk">IOCCC28 - 2024/kurdyukov4 - Prize in embiggening</a></p>
 </blockquote>

--- a/2024/macke/README.md
+++ b/2024/macke/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/macke - Prize in imitative rebooting](https://www.youtube.com/watch?v=jeQFI_8kGA4)
 

--- a/2024/macke/index.html
+++ b/2024/macke/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#DE">DE</a> - <em>Federal Republic of Germ
 
 <!-- BEFORE: 1st line of markdown file: 2024/macke/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=jeQFI_8kGA4">IOCCC28 - 2024/macke - Prize in imitative rebooting</a></p>
 </blockquote>

--- a/2024/maffiodo/README.md
+++ b/2024/maffiodo/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/maffiodo - Prize in creative interpretation](https://www.youtube.com/watch?v=JEWxbOD-1UY)
 

--- a/2024/maffiodo/index.html
+++ b/2024/maffiodo/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#IT">IT</a> - <em>Italian Republic</em> (<
 
 <!-- BEFORE: 1st line of markdown file: 2024/maffiodo/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=JEWxbOD-1UY">IOCCC28 - 2024/maffiodo - Prize in creative interpretation</a></p>
 </blockquote>

--- a/2024/mills/README.md
+++ b/2024/mills/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/mills - Prize in ℤ₃](https://www.youtube.com/watch?v=sXdTonHUN8s)
 

--- a/2024/mills/index.html
+++ b/2024/mills/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/mills/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=sXdTonHUN8s">IOCCC28 - 2024/mills - Prize in ℤ₃</a></p>
 </blockquote>

--- a/2024/stedolan/README.md
+++ b/2024/stedolan/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/stedolan - Best one liner](https://www.youtube.com/watch?v=NJ-e4SgXGpw)
 

--- a/2024/stedolan/index.html
+++ b/2024/stedolan/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#IE">IE</a> - <em>Republic of Ireland</em>
 
 <!-- BEFORE: 1st line of markdown file: 2024/stedolan/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=NJ-e4SgXGpw">IOCCC28 - 2024/stedolan - Best one liner</a></p>
 </blockquote>

--- a/2024/straadt/README.md
+++ b/2024/straadt/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/straadt - Prize in sound coding](https://www.youtube.com/watch?v=QYFXRvt0VJo)
 

--- a/2024/straadt/index.html
+++ b/2024/straadt/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#DK">DK</a> - <em>Denmark</em></li>
 
 <!-- BEFORE: 1st line of markdown file: 2024/straadt/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=QYFXRvt0VJo">IOCCC28 - 2024/straadt - Prize in sound coding</a></p>
 </blockquote>

--- a/2024/tmarrec/README.md
+++ b/2024/tmarrec/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/tmarrec - Prize in cyclonic coding](https://www.youtube.com/watch?v=dIDNZI55trg)
 

--- a/2024/tmarrec/index.html
+++ b/2024/tmarrec/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#CA">CA</a> - <em>Canada</em></li>
 
 <!-- BEFORE: 1st line of markdown file: 2024/tmarrec/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=dIDNZI55trg">IOCCC28 - 2024/tmarrec - Prize in cyclonic coding</a></p>
 </blockquote>

--- a/2024/tompng/README.md
+++ b/2024/tompng/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/tompng - Prize in quasi bijection](https://www.youtube.com/watch?v=9C4PpNCst8Y)
 

--- a/2024/tompng/index.html
+++ b/2024/tompng/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#JP">JP</a> - <em>Japan</em></li>
 
 <!-- BEFORE: 1st line of markdown file: 2024/tompng/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=9C4PpNCst8Y">IOCCC28 - 2024/tompng - Prize in quasi bijection</a></p>
 </blockquote>

--- a/2024/weaver/README.md
+++ b/2024/weaver/README.md
@@ -1,6 +1,7 @@
 ## Award presentation:
 
-Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
+Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
+YouTube show for this entry:
 
 > [IOCCC28 - 2024/weaver - Sur prize](https://www.youtube.com/watch?v=e1h5N6EDehg)
 

--- a/2024/weaver/index.html
+++ b/2024/weaver/index.html
@@ -473,7 +473,8 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
 <!-- BEFORE: 1st line of markdown file: 2024/weaver/README.md -->
 <h2 id="award-presentation">Award presentation:</h2>
-<p>Watch the following <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a> YouTube show:</p>
+<p>Watch the <a href="https://www.youtube.com/@OurFavoriteUniverse">Our Favorite Universe</a>
+YouTube show for this entry:</p>
 <blockquote>
 <p><a href="https://www.youtube.com/watch?v=e1h5N6EDehg">IOCCC28 - 2024/weaver - Sur prize</a></p>
 </blockquote>


### PR DESCRIPTION
In particular the following diff for each README.md (with all the index.html files rebuilt):

    -Watch the following [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse) YouTube show:
    +Watch the [Our Favorite Universe](https://www.youtube.com/@OurFavoriteUniverse)
    +YouTube show for this entry: