### PR TITLE
Various typos in 2024/

### DIFF
--- a/2024/burton/README.md
+++ b/2024/burton/README.md
@@ -64,7 +64,7 @@ This assistant prompts "? ", and the input expected is the guessed word
 followed by the first letters of the color revealed for that guess:
 
 ``` <!---sh-->
-    $ prog dict
+    $ ./prog dict
     ? terns ybbbb
     loath
     ? loath gbbyy
@@ -109,7 +109,7 @@ The example session (Wordle 228) below demonstrates this:
 
 ```
     # do NOT do this
-    $ prog dict
+    $ ./prog dict
     ? terns bbbby
     shoal
     ? shoal gggbb
@@ -118,7 +118,7 @@ The example session (Wordle 228) below demonstrates this:
     xyzzy          <<-- no candidate words match
 
     # do THIS instead
-    $ prog dict
+    $ ./prog dict
     ? terns bbbby
     shoal
     ? shoal gggbb
@@ -129,8 +129,8 @@ The example session (Wordle 228) below demonstrates this:
     shock
 ```
 
-In the guess word `shook`, there are 2 o's, but only one shown valid in
-the puzzle.  If you mark the leftmost o as black (as according to the
+In the guess word `shook`, there are 2 'o's, but only one shown valid in
+the puzzle.  If you mark the leftmost 'o' as black (as according to the
 Wordle game), this program cannot find the winning word (`shock`),
 producing the error word `xyzzy`.
 

--- a/2024/burton/index.html
+++ b/2024/burton/index.html
@@ -510,7 +510,7 @@ or <code>crate</code> (see the <a href="extra.html">extra.html</a> that accompan
 The letters will turn yellow, black, black, black, black.
 This assistant prompts “?”, and the input expected is the guessed word
 followed by the first letters of the color revealed for that guess:</p>
-<pre><code>    $ prog dict
+<pre><code>    $ ./prog dict
     ? terns ybbbb
     loath
     ? loath gbbyy
@@ -542,7 +542,7 @@ and one of them is marked black and the other non-black,
 this program MUST have the black letter marked <em>yellow</em>.
 The example session (Wordle 228) below demonstrates this:</p>
 <pre><code>    # do NOT do this
-    $ prog dict
+    $ ./prog dict
     ? terns bbbby
     shoal
     ? shoal gggbb
@@ -551,7 +551,7 @@ The example session (Wordle 228) below demonstrates this:</p>
     xyzzy          &lt;&lt;-- no candidate words match
 
     # do THIS instead
-    $ prog dict
+    $ ./prog dict
     ? terns bbbby
     shoal
     ? shoal gggbb
@@ -560,8 +560,8 @@ The example session (Wordle 228) below demonstrates this:</p>
     shock
     ? shock ggggg
     shock</code></pre>
-<p>In the guess word <code>shook</code>, there are 2 o’s, but only one shown valid in
-the puzzle. If you mark the leftmost o as black (as according to the
+<p>In the guess word <code>shook</code>, there are 2 ‘o’s, but only one shown valid in
+the puzzle. If you mark the leftmost ’o’ as black (as according to the
 Wordle game), this program cannot find the winning word (<code>shock</code>),
 producing the error word <code>xyzzy</code>.</p>
 <p>The included simulator <code>gen</code> produces the required transformation of b -&gt; y.</p>

--- a/2024/endoh1/README.md
+++ b/2024/endoh1/README.md
@@ -28,10 +28,10 @@ When you `make all` you see what looks like a C program, `rt.c`.
 However if you try to compile `rt.c`, you will fail: even if you try to
 define the symbols `X`, `Y`, `W`, and `H`.
 
-Well, the propose of the C program, `rt.c` is to generate the red, green, and blue colors of
+Well, the purpose of the C program, `rt.c` is to generate the red, green, and blue colors of
 a single pixel, in the C Preprocessor!!!
 
-For the patient, a image may be rendered a slow pixel at a time.
+For the patient, an image may be rendered a slow pixel at a time.
 Think of this as digital [Pointillism](https://en.wikipedia.org/wiki/Pointillism).  :-)
 
 For the truly impatient who wishes to get right to the point without trying to dot around
@@ -78,7 +78,7 @@ example for `SIZE` values of 8, 32, 128, and then 512.
 
 The optimal `RESERVE` will depend on your hardware, operating system,
 a C compiler.  Making `RESERVE` too small (i.e., too negative) may slow
-down the result.  We recommend that experiment various values pf `RESERVE`
+down the result.  We recommend that experiment various values of `RESERVE`
 with moderate `SIZE` of **32** in order to try to find an optimal `JOBS`
 value before attempting to try a larger size such as **512** and beyond.
 

--- a/2024/endoh1/index.html
+++ b/2024/endoh1/index.html
@@ -487,9 +487,9 @@ YouTube show for this entry:</p>
 <p>When you <code>make all</code> you see what looks like a C program, <code>rt.c</code>.
 However if you try to compile <code>rt.c</code>, you will fail: even if you try to
 define the symbols <code>X</code>, <code>Y</code>, <code>W</code>, and <code>H</code>.</p>
-<p>Well, the propose of the C program, <code>rt.c</code> is to generate the red, green, and blue colors of
+<p>Well, the purpose of the C program, <code>rt.c</code> is to generate the red, green, and blue colors of
 a single pixel, in the C Preprocessor!!!</p>
-<p>For the patient, a image may be rendered a slow pixel at a time.
+<p>For the patient, an image may be rendered a slow pixel at a time.
 Think of this as digital <a href="https://en.wikipedia.org/wiki/Pointillism">Pointillism</a>. :-)</p>
 <p>For the truly impatient who wishes to get right to the point without trying to dot around
 waiting for the <a href="https://github.com/ioccc-src/winner/blob/master/2024/endoh1/try.sh">try.sh</a> to finish, you may view these images:</p>
@@ -525,7 +525,7 @@ such as the operating system, daemons, terminal window, etc. You can even
 example for <code>SIZE</code> values of 8, 32, 128, and then 512.</p>
 <p>The optimal <code>RESERVE</code> will depend on your hardware, operating system,
 a C compiler. Making <code>RESERVE</code> too small (i.e., too negative) may slow
-down the result. We recommend that experiment various values pf <code>RESERVE</code>
+down the result. We recommend that experiment various values of <code>RESERVE</code>
 with moderate <code>SIZE</code> of <strong>32</strong> in order to try to find an optimal <code>JOBS</code>
 value before attempting to try a larger size such as <strong>512</strong> and beyond.</p>
 <div id="larger">

--- a/2024/endoh1/try.sh
+++ b/2024/endoh1/try.sh
@@ -27,7 +27,7 @@ ${MAKE} -j 2 prog.c >/dev/null 2>&1 < /dev/null
 status="$?"
 if [[ $status -ne 0 ]]; then
     JOBS="1"
-    echo "NOTE: make dues not support -j 2, so make out.ppm will only use a single CPU job." 1>&2
+    echo "NOTE: make does not support -j 2, so make out.ppm will only use a single CPU job." 1>&2
 
 else
     # determine how parallel we want to make


### PR DESCRIPTION
The following files (not all of these files were checked yet) were modified (when mentioning README.md I also rebuilt the index.html file):

    2024/burton/README.md
    2024/endoh1/README.md
    2024/endoh1/try.sh