### PR TITLE
Improve try scripts for 1989/ovdluhe

### DIFF
--- a/1989/ovdluhe/README.md
+++ b/1989/ovdluhe/README.md
@@ -63,6 +63,9 @@ value that's not a number.
 **NOTE**: if you specify too high a value for `P` the program might fail. If you
 specify a value < 0 it will fail to compile.
 
+The script will also run the program with `P=2` through `P=10` like the author
+suggested. Send intr (usually ctrl-c) to stop early.
+
 
 ## Judges' remarks:
 

--- a/1989/ovdluhe/index.html
+++ b/1989/ovdluhe/index.html
@@ -501,6 +501,8 @@ value that’s not a number.</p>
     P=5 ./try.alt.sh</code></pre>
 <p><strong>NOTE</strong>: if you specify too high a value for <code>P</code> the program might fail. If you
 specify a value &lt; 0 it will fail to compile.</p>
+<p>The script will also run the program with <code>P=2</code> through <code>P=10</code> like the author
+suggested. Send intr (usually ctrl-c) to stop early.</p>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>Run this program using your favorite text file as input. Files
 such as mailboxes, man pages and usenet articles are especially

--- a/1989/ovdluhe/try.alt.sh
+++ b/1989/ovdluhe/try.alt.sh
@@ -18,21 +18,63 @@ else
 fi
 
 # clear screen after compilation so that only the entry is shown
+clear
 
 i=0
-for ((i=0; i<4; ++i)); do
+for ((i=0; i<3; ++i)); do
     read -r -n 1 -p "Press any key to run: ./ovdluhe.alt < ovdluhe.alt.c: "
     echo 1>&2
+    echo 1>&2
     ./ovdluhe.alt < ovdluhe.alt.c
+    echo 1>&2
     echo 1>&2
 
     read -r -n 1 -p "Press any key to run: ./ovdluhe.alt < README.md: "
     echo 1>&2
+    echo 1>&2
     ./ovdluhe.alt < README.md
+    echo 1>&2
     echo 1>&2
 
     read -r -n 1 -p "Press any key to run: ./ovdluhe.alt < Makefile: "
     echo 1>&2
+    echo 1>&2
     ./ovdluhe.alt < Makefile
     echo 1>&2
+    echo 1>&2
 done
+
+echo "Now we will redefine P from 2 through 10, running the program on three files" 1>&2
+echo "three times. If you wish to stop at any point just send intr (usually ctrl-c)." 1>&2
+echo "To quit the script." 1>&2
+read -r -n 1 -p "Press any key to continue: "
+echo 1>&2
+echo 1>&2
+for ((P=2; P<=10; ++P)); do
+    echo "Recompiling with P=$P ..." 1>&2
+    make clobber CC="$CC" P="$P" alt >/dev/null 2>&1|| exit 1
+    for ((i=0; i<3; ++i)); do
+        read -r -n 1 -p "Press any key to run: ./ovdluhe.alt < ovdluhe.alt.c: "
+        echo 1>&2
+        echo 1>&2
+        ./ovdluhe.alt < ovdluhe.alt.c
+        echo 1>&2
+        echo 1>&2
+
+        read -r -n 1 -p "Press any key to run: ./ovdluhe.alt < README.md: "
+        echo 1>&2
+        echo 1>&2
+        ./ovdluhe.alt < README.md
+        echo 1>&2
+        echo 1>&2
+
+        read -r -n 1 -p "Press any key to run: ./ovdluhe.alt < Makefile: "
+        echo 1>&2
+        echo 1>&2
+        ./ovdluhe.alt < Makefile
+        echo 1>&2
+        echo 1>&2
+    done
+done
+
+

--- a/1989/ovdluhe/try.sh
+++ b/1989/ovdluhe/try.sh
@@ -19,15 +19,18 @@ i=0
 for ((i=0; i<4; ++i)); do
     read -r -n 1 -p "Press any key to run: ./ovdluhe < ovdluhe.c: "
     echo 1>&2
+    echo 1>&2
     ./ovdluhe < ovdluhe.c
     echo 1>&2
 
     read -r -n 1 -p "Press any key to run: ./ovdluhe < README.md: "
     echo 1>&2
+    echo 1>&2
     ./ovdluhe < README.md
     echo 1>&2
 
     read -r -n 1 -p "Press any key to run: ./ovdluhe < Makefile: "
+    echo 1>&2
     echo 1>&2
     ./ovdluhe < Makefile
     echo 1>&2


### PR DESCRIPTION
When I first wrote the try scripts, and in particular the ovdluhe.alt.c code to do what the author suggested one try, I just had the option in try.alt.sh to redefine P once. Now the user can do that but after the initial loop it loops from 2..10 (the range the author suggested) running the loop again (on the three files three times) so one can see what the author means.

The try.sh script has the updated idea by the judges of printing two lines, not one, after each prompt.

Rebuilt index.html from updated README.md.