### PR TITLE
Fix CSILENCE= in next/Makefile.example

### DIFF
--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -39,9 +39,9 @@ TRUE= true
 
 # Common C compiler warnings to silence
 #
-# Example: CSILENCE= -Wno-poison-system-directories
+# Example: CSILENCE= -Wno-int-conversion
 #
-CSILENCE=
+CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage
 
 # Attempt to silence unknown warning options
 #


### PR DESCRIPTION
One of the warnings disabled (triggered in macOS) that was already added seemed to be missing.

I also disabled the silly warning triggered by clang with -Weverything (I think -Weverything) -Wunsafe-buffer-usage as that is against basic C (it will not even let you iterate through argv without whining about it being 'unsafe').

The example in the Makefile given is -Wno-int-conversion instead.