### PR TITLE
Add -Wno-overriding-deployment-version

### DIFF
--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -41,7 +41,7 @@ TRUE= true
 #
 # Example: CSILENCE= -Wno-int-conversion
 #
-CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage
+CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage -Wno-overriding-deployment-version
 
 # Attempt to silence unknown warning options
 #


### PR DESCRIPTION
A bug in macOS 26 (is anyone surprised any more?) ends up with warning:

    clang: warning: overriding deployment version from '16.0' to '26.0' [-Woverriding-deployment-version]

depending on invocation. Particularly with at least some versions of gcc, even though in this case it was actually gcc and not the system gcc that is really clang in disguise.

Because of this -Wno-overriding-deployment-version was added to next/Makefile.example.