### PR TITLE
Minor fixes and updates go next/guidelines

### DIFF
--- a/bin/combine_author_handle.sh
+++ b/bin/combine_author_handle.sh
@@ -400,17 +400,17 @@ fi
 #
 export TMP_AUTHOR_HANDLE_LIST=".tmp.$NAME.AUTHOR_HANDLE_LIST.$$.tmp"
 if [[ $V_FLAG -ge 3 ]]; then
-    echo  "$0: debug[3]: list pf author_handle JSON files: $TMP_AUTHOR_HANDLE_LIST" 1>&2
+    echo  "$0: debug[3]: list of author_handle JSON files: $TMP_AUTHOR_HANDLE_LIST" 1>&2
 fi
 trap 'rm -f $TMP_AUTHOR_HANDLE_LIST; exit' 0 1 2 3 15
 rm -f "$TMP_AUTHOR_HANDLE_LIST"
 if [[ -e $TMP_AUTHOR_HANDLE_LIST ]]; then
-    echo "$0: ERROR: cannot remove list pf author_handle JSON files: $TMP_AUTHOR_HANDLE_LIST" 1>&2
+    echo "$0: ERROR: cannot remove list of author_handle JSON files: $TMP_AUTHOR_HANDLE_LIST" 1>&2
     exit 12
 fi
 find "$AUTHOR_DIR" -type f -name '*.json' -print | LC_ALL=C sort -t / -d > "$TMP_AUTHOR_HANDLE_LIST"
 if [[ ! -e $TMP_AUTHOR_HANDLE_LIST ]]; then
-    echo "$0: ERROR: cannot create list pf author_handle JSON files: $TMP_AUTHOR_HANDLE_LIST" 1>&2
+    echo "$0: ERROR: cannot create list of author_handle JSON files: $TMP_AUTHOR_HANDLE_LIST" 1>&2
     exit 13
 fi
 

--- a/bin/gen-year-index.sh
+++ b/bin/gen-year-index.sh
@@ -559,7 +559,7 @@ if [[ -z $NOOP ]]; then
     # case: YYYY index.html does not need to be updated
     #
     elif [[ $V_FLAG -ge 3 ]]; then
-	echo "$0: debug[3]: does not need to be updated: $YYYY/README.html" 1>&2
+	echo "$0: debug[3]: does not need to be updated: $YYYY/index.html" 1>&2
     fi
 
 # report disabled by -n

--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -41,7 +41,7 @@ TRUE= true
 #
 # Example: CSILENCE= -Wno-int-conversion
 #
-CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage
+CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage -Wno-overriding-deployment-version
 
 # Attempt to silence unknown warning options
 #

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -488,7 +488,7 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 </div>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.47 2025-03-15</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.48 2025-09-28</strong>.
 </p>
 <p class="leftbar">
 The markdown form of these guidelines <a href="guidelines.md"
@@ -554,22 +554,6 @@ of the above <strong>dates and times may change <em>AT ANY TIME</em></strong>!
 <p class="leftbar">
 The reason for the times of day are so that key IOCCC events are <strong>calculated</strong>
 to be a <strong>fun</strong>ctional UTC time. :-)
-</p>
-<p class="leftbar">
-<strong>NOTE</strong>: the updates to these guidelines on 2025-03-10 explained the new <code>-u uuidfile</code> and <code>-U uuidstr</code> options and are <strong>NOT</strong> important to read, in order
-to follow the guidelines. The options are in a release <strong>AFTER THIS</strong> IOCCC’s
-official release and not updating the toolkit is <strong>PERFECTLY</strong> okay.
-</p>
-<p class="leftbar">
-<strong>NOTE</strong>: the updates to these guidelines on 2025-03-12 also explain how the
-tools that require other tools now search under <code>$PATH</code>. It is perfectly fine to
-not use the newer versions so long as you use the minimum required version of
-the tools. See the
-FAQ on “<a href="../faq.html#minimum_versions">minimum required version of the tools</a>”
-for more details and the
-FAQ on “<a href="../faq.html#obtaining_mkiocccentry">obtaining the most recent release of the
-toolkit</a>”
-for more help.
 </p>
 <p class="leftbar">
 Until the contest status becomes <strong><a href="../faq.html#open">open</a></strong>,
@@ -860,12 +844,12 @@ FAQ on “<a href="../faq.html#obtaining_mkiocccentry">obtaining the mkiocccentr
 <p class="leftbar">
 <code>mkiocccentry</code> runs a number of checks, by the tool itself and by executing
 other tools, <em>before</em> packaging your xz compressed tarball, including running
-<code>chkentry(1)</code> on the submission directory.
+<code>chksubmit(1)</code> on the submission directory.
 </p>
 <p class="leftbar">
 If <code>mkiocccentry</code> encounters an <strong>error</strong>, the program will exit and the xz
 compressed tarball <strong>will not be formed</strong>. For instance, if
-<a href="#chkentry">chkentry</a> fails to validate the submission directory, either because
+<a href="#chksubmit">chksubmit</a> fails to validate the submission directory, either because
 of a validation error in the <code>.auth.json</code> or <code>.info.json</code>
 <a href="https://www.json.org/json-en.html">JSON</a> files or because of
 something else that <code>mkiocccentry(1)</code> creates or does, it is an
@@ -911,7 +895,7 @@ For example:
 (specifying the absolute or relative path to the tool) and you have not
 installed the tools (and we <strong>STRONGLY</strong> recommend you <strong>do</strong> install them),
 then you will have to specify the options (such as paths) for the tools that are required like
-<code>chkentry(1)</code>, <code>txzchk(1)</code> and <code>fnamchk(1)</code>.
+<code>chksubmit(1)</code>, <code>txzchk(1)</code> and <code>fnamchk(1)</code>.
 </p>
 <p class="leftbar">
 Make sure you have
@@ -2003,6 +1987,7 @@ tools</a>, <em>including, <strong>but not
 limited</strong></em> to
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry</a>,
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry</a>,
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c">chksubmit</a>,
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c">fnamchk</a>
 and
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/location_main.c">location</a>,

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -48,7 +48,7 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.47 2025-03-15**.
+These [IOCCC guidelines](guidelines.html) are version **28.48 2025-09-28**.
 </p>
 
 <p class="leftbar">
@@ -139,25 +139,6 @@ of the above **dates and times may change _AT ANY TIME_**!
 <p class="leftbar">
 The reason for the times of day are so that key IOCCC events are **calculated**
 to be a **fun**ctional UTC time.  :-)
-</p>
-
-<p class="leftbar">
-**NOTE**: the updates to these guidelines on 2025-03-10 explained the new `-u
-uuidfile` and `-U uuidstr` options and are **NOT** important to read, in order
-to follow the guidelines. The options are in a release **AFTER THIS** IOCCC's
-official release and not updating the toolkit is **PERFECTLY** okay.
-</p>
-
-<p class="leftbar">
-**NOTE**: the updates to these guidelines on 2025-03-12 also explain how the
-tools that require other tools now search under `$PATH`. It is perfectly fine to
-not use the newer versions so long as you use the minimum required version of
-the tools. See the
-FAQ on "[minimum required version of the tools](../faq.html#minimum_versions)"
-for more details and the
-FAQ on "[obtaining the most recent release of the
-toolkit](../faq.html#obtaining_mkiocccentry)"
-for more help.
 </p>
 
 <p class="leftbar">
@@ -508,13 +489,13 @@ FAQ on "[obtaining the mkiocccentry toolkit](../faq.html#obtaining_mkiocccentry)
 <p class="leftbar">
 `mkiocccentry` runs a number of checks, by the tool itself and by executing
 other tools, _before_ packaging your xz compressed tarball, including running
-`chkentry(1)` on the submission directory.
+`chksubmit(1)` on the submission directory.
 </p>
 
 <p class="leftbar">
 If `mkiocccentry` encounters an **error**, the program will exit and the xz
 compressed tarball **will not be formed**. For instance, if
-[chkentry](#chkentry) fails to validate the submission directory, either because
+[chksubmit](#chksubmit) fails to validate the submission directory, either because
 of a validation error in the `.auth.json` or `.info.json`
 [JSON](https://www.json.org/json-en.html) files or because of
 something else that `mkiocccentry(1)` creates or does, it is an
@@ -569,7 +550,7 @@ For example:
 (specifying the absolute or relative path to the tool) and you have not
 installed the tools (and we **STRONGLY** recommend you **do** install them),
 then you will have to specify the options (such as paths) for the tools that are required like
-`chkentry(1)`, `txzchk(1)` and `fnamchk(1)`.
+`chksubmit(1)`, `txzchk(1)` and `fnamchk(1)`.
 </p>
 
 <p class="leftbar">
@@ -1946,6 +1927,7 @@ tools](https://github.com/ioccc-src/mkiocccentry), _including, **but not
 limited**_ to
 [mkiocccentry](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c),
 [chkentry](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c),
+[chksubmit](https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c),
 [fnamchk](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c)
 and
 [location](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/location_main.c),


### PR DESCRIPTION

Some information is no longer useful - they were put in during the
IOCCC28 to let people know the version changes during the contest which
noted some useful information.
 
Also added references to chksubmit.

Rebuilt next/guidelines.html with these changes.