### PR TITLE
Update FAQ, rules/guidelines etc. for #208

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -453,7 +453,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>28.2.22 2025-08-24</strong>.</p>
+<p>This is FAQ version <strong>28.2.23 2025-11-17</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -464,7 +464,6 @@
 <li><strong>Q 0.1.3</strong>: <a class="normal" href="#compiling_mkiocccentry">How do I compile the mkiocccentry toolkit?</a></li>
 <li><strong>Q 0.1.4</strong>: <a class="normal" href="#install">How do I install mkiocccentry(1) and related tools?</a></li>
 <li><strong>Q 0.1.5</strong>: <a class="normal" href="#using_mkiocccentry">How do I use mkiocccentry?</a></li>
-<li><strong>Q 0.1.6</strong>: <a class="normal" href="#minimum_versions">What are the minimum versions required for this contest?</a></li>
 </ul></li>
 <li><strong>Q 0.2</strong>: <a class="normal" href="#platform">What platform should I assume for my submission?</a></li>
 <li><strong>Q 0.3</strong>: <a class="normal" href="#makefile">What should I put in my submission Makefile?</a></li>
@@ -478,15 +477,14 @@
 <li><strong>Q 1.1</strong>: <a class="normal" href="#prog_c">May I use a different source or compiled filename than prog.c or prog?</a></li>
 <li><strong>Q 1.2</strong>: <a class="normal" href="#markdown">What is markdown and how does the IOCCC use it?</a></li>
 <li><strong>Q 1.3</strong>: <a class="normal" href="#mkiocccentry_bugs">How do I report bugs in an <code>mkiocccentry</code> tool?</a></li>
-<li><strong>Q 1.4</strong>: <a class="normal" href="#subdirectories">How may I use subdirectories in my submission if Rule 17 disallows them?</a></li>
-<li><strong>Q 1.5</strong>: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a></li>
-<li><strong>Q 1.6</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
-<li><strong>Q 1.7</strong>: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a></li>
-<li><strong>Q 1.8</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
-<li><strong>Q 1.9</strong>: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
-<li><strong>Q 1.10</strong>: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a></li>
-<li><strong>Q 1.11</strong>: <a class="normal" href="#download_submission">Can I download my submission tarball from the submit server?</a></li>
-<li><strong>Q 1.12</strong>: <a class="normal" href="#del_submission">Can I delete a submission from the submit server?</a></li>
+<li><strong>Q 1.4</strong>: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a></li>
+<li><strong>Q 1.5</strong>: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a></li>
+<li><strong>Q 1.6</strong>: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a></li>
+<li><strong>Q 1.7</strong>: <a class="normal" href="#rule17">What are the details behind Rule 17?</a></li>
+<li><strong>Q 1.8</strong>: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a></li>
+<li><strong>Q 1.9</strong>: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a></li>
+<li><strong>Q 1.10</strong>: <a class="normal" href="#download_submission">Can I download my submission tarball from the submit server?</a></li>
+<li><strong>Q 1.11</strong>: <a class="normal" href="#del_submission">Can I delete a submission from the submit server?</a></li>
 </ul>
 <h2 id="ioccc-judging-process">2. <a href="#judging_process">IOCCC Judging process</a></h2>
 <ul>
@@ -504,18 +502,17 @@
 </ul>
 <h2 id="the-mkiocccentry-toolkit-finer-details">3. <a href="#mkiocccentry_details">The mkiocccentry toolkit: finer details</a></h2>
 <ul>
-<li><strong>Q 3.0</strong>: <a class="normal" href="#mkiocccentry_process">What is the <code>mkiocccentry(1)</code> process and what sort of checks does it perform?</a></li>
-<li><strong>Q 3.1</strong>: <a class="normal" href="#txzchk">How can I validate my submission tarball?</a></li>
-<li><strong>Q 3.2</strong>: <a class="normal" href="#fnamchk">What is the <code>fnamchk</code> tool?</a></li>
-<li><strong>Q 3.3</strong>: <a class="normal" href="#chkentry">How can I validate my submission directory?</a></li>
-<li><strong>Q 3.4</strong>: <a class="normal" href="#auth_json">What is a <code>.auth.json</code> file?</a></li>
-<li><strong>Q 3.5</strong>: <a class="normal" href="#info_json">What is a <code>.info.json</code> file?</a></li>
-<li><strong>Q 3.6</strong>: <a class="normal" href="#author_handle_faq">What is an <code>author handle</code>?</a></li>
-<li><strong>Q 3.7</strong>: <a class="normal" href="#author_handle_json">What is an <code>author_handle.json</code> file and how are they used?</a></li>
-<li><strong>Q 3.8</strong>: <a class="normal" href="#find_author_handle">How can I find my author handle?</a></li>
-<li><strong>Q 3.9</strong>: <a class="normal" href="#entry_id_faq">What is an <code>entry_id</code>?</a></li>
-<li><strong>Q 3.10</strong>: <a class="normal" href="#entry_json">What is a <code>.entry.json</code> file and how is it used?</a></li>
-<li><strong>Q 3.11</strong>: <a class="normal" href="#jparse">How can I validate any JSON document?</a></li>
+<li><strong>Q 3.0</strong>: <a class="normal" href="#txzchk">How can I validate my submission tarball?</a></li>
+<li><strong>Q 3.1</strong>: <a class="normal" href="#fnamchk">What is the <code>fnamchk</code> tool?</a></li>
+<li><strong>Q 3.2</strong>: <a class="normal" href="#chksubmit">How can I validate my submission directory?</a></li>
+<li><strong>Q 3.3</strong>: <a class="normal" href="#auth_json">What is a <code>.auth.json</code> file?</a></li>
+<li><strong>Q 3.4</strong>: <a class="normal" href="#info_json">What is a <code>.info.json</code> file?</a></li>
+<li><strong>Q 3.5</strong>: <a class="normal" href="#author_handle_faq">What is an <code>author handle</code>?</a></li>
+<li><strong>Q 3.6</strong>: <a class="normal" href="#author_handle_json">What is an <code>author_handle.json</code> file and how are they used?</a></li>
+<li><strong>Q 3.7</strong>: <a class="normal" href="#find_author_handle">How can I find my author handle?</a></li>
+<li><strong>Q 3.8</strong>: <a class="normal" href="#entry_id_faq">What is an <code>entry_id</code>?</a></li>
+<li><strong>Q 3.9</strong>: <a class="normal" href="#entry_json">What is a <code>.entry.json</code> file and how is it used?</a></li>
+<li><strong>Q 3.10</strong>: <a class="normal" href="#jparse">How can I validate any JSON document?</a></li>
 </ul>
 <h2 id="compiling-ioccc-entries">4. <a href="#compiling">Compiling IOCCC entries</a></h2>
 <ul>
@@ -683,7 +680,7 @@ submission directory, run <code>make clobber</code> and then scan the directory 
 looking for mismatches. If no errors are detected it will list everything to you
 again, asking you to confirm it is good.</p>
 <p>If everything is OK, it will write the required <code>.auth.json</code> and <code>.info.json</code>
-and then run <code>chkentry(1)</code> on the directory. If all is OK it will create the
+and then run <code>chksubmit(1)</code> on the directory. If all is OK it will create the
 tarball. After the tarball is formed, it will run <code>txzchk(1)</code> on it, which runs
 <code>fnamchk(1)</code>. If all is OK, your submission tarball should be good to go.</p>
 <p>Please see
@@ -691,7 +688,7 @@ FAQ on “<a href="#txzchk">txzchk</a>”,
 the
 FAQ on “<a href="#fnamchk">fnamchk</a>”
 and the
-FAQ on “<a href="#chkentry">chkentry</a>”
+FAQ on “<a href="#chksubmit">chksubmit</a>”
 for more information on these important tools, if you want more information.</p>
 <p>See the
 FAQ on “<a href="#submit">how to upload you submission</a>”
@@ -742,11 +739,12 @@ above) run as either <code>sudo(8)</code> or root <code>make install</code>:</p>
     # as root:
     make install</code></pre>
 <p>If everything goes well you should be able to run <code>mkiocccentry(1)</code>,
-<code>txzchk(1)</code>, <code>chkentry(1)</code> and all the other installed tools from any directory,
+<code>txzchk(1)</code>, <code>chksubmit(1)</code> and all the other installed tools from any directory,
 and the tools that rely on other tools will be able to find those required tools
 from any directory too.</p>
 <p>Some tools like <code>bug_report.sh</code> and <code>hostchk.sh</code> are not meant to be installed
-and will not work from any directory, however.</p>
+and will not work from any directory, however, nor should they be installed
+(some previously were but this was fixed post IOCCC28 and prior to IOCCC29).</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="using_mkiocccentry">
 <h4 id="q-0.1.5-how-do-i-use-mkiocccentry">Q 0.1.5: How do I use mkiocccentry?</h4>
@@ -793,25 +791,9 @@ information about your submission <em>as well as author details</em> (that will 
 looked at if the submission wins), run some tests and run a number of other
 tools, as mentioned above, and as described in the “<a href="#mkiocccentry_details">finer
 details</a>” section.</p>
-<p>See also the
-FAQ on “<a href="#minimum_versions">what the minimum required versions are for this
-contest</a>”
-for more details on how to verify you have the correct versions for this
-contest.</p>
-<p>Jump to: <a href="#">top</a></p>
-<div id="minimum_versions">
-<h4 id="q-0.1.6-what-are-the-minimum-versions-required-for-this-contest">Q 0.1.6: What are the minimum versions required for this contest?</h4>
-</div>
-<p>At minimum, the tools <strong>MUST</strong> be version:</p>
-<ul>
-<li><code>iocccsize(1)</code>: <code>"28.15 2024-06-27"</code>.</li>
-<li><code>mkiocccentry(1)</code>: <code>"2.0.1 2025-03-02"</code>.</li>
-<li><code>fnamchk(1)</code>: <code>"2.0.0 2025-02-28"</code>.</li>
-<li><code>txzchk(1)</code>: <code>"2.0.1 2025-03-02"</code>.</li>
-<li><code>chkentry(1)</code>: <code>"2.0.1 2025-03-02"</code>.</li>
-</ul>
-<p>See also the
-FAQ on “<a href="#obtaining_mkiocccentry">obtaining the latest release of the toolkit</a>”.</p>
+<p><strong>PLEASE NOTE</strong>: if your submission directory (or topdir) has certain errors the
+mkiocccentry tool will exit with a fatal error, asking you to fix the problem
+first.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="SUS">
 <div id="platform">
@@ -984,7 +966,7 @@ FAQ on “<a href="#makefile">submission Makefiles</a>”.</p>
 </div>
 <p>Files in your submission tarball <strong>MUST</strong> be
 specific permissions. In particular: directories <strong>MUST</strong> be <code>drwxr-xr-x</code> (i.e.
-<code>0755</code>), the optional files, <code>try.sh</code> or <code>try.alt.sh</code>, if provided, <strong>MUST</strong> be
+<code>0755</code>), the optional files, files ending with <code>.sh</code>, if provided, <strong>MUST</strong> be
 <code>-r-xr-xr-x</code> (i.e. <code>0555</code>) and all other files <strong>MUST</strong> be <code>-r--r--r--</code> (i.e.
 <code>0444</code>).</p>
 <p>If you need a file to be executable, say a script, then make sure you do so in
@@ -1093,22 +1075,8 @@ FAQ on “<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/FAQ.md#
 in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 for more thorough details on bug reporting.</p>
 <p>Jump to: <a href="#">top</a></p>
-<div id="subdirectories">
-<h4 id="q-1.4-how-may-i-use-subdirectories-in-my-submission-if-rule-17-disallows-them">Q 1.4: How may I use subdirectories in my submission if Rule 17 disallows them?</h4>
-</div>
-<p>In order to submit a subdirectory, you may simply include a tarball. As long as
-the maximum depth of all files does not exceed the maximum, defined as
-<code>MAX_PATH_DEPTH</code>, the maximum filename length (a single component not counting
-the <code>/</code>) of all files does not exceed <code>MAX_FILENAME_LEN</code> and
-the maximum path length (all components) of all files does not exceed
-<code>MAX_PATH_LEN</code>. These macros are defined in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>.</p>
-<p>See also the
-FAQ on “<a href="#rule17">Rule 17</a>”,
-the <a href="next/guidelines.html">guidelines</a> and <a href="next/rules.html#rule17">Rule 17</a>
-itself.</p>
 <div id="mkiocccentry_test">
-<h4 id="q-1.5-how-can-i-check-if-my-submission-passes-tests-without-having-to-answer-questions">Q 1.5: How can I check if my submission passes tests without having to answer questions?</h4>
+<h4 id="q-1.4-how-can-i-check-if-my-submission-passes-tests-without-having-to-answer-questions">Q 1.4: How can I check if my submission passes tests without having to answer questions?</h4>
 </div>
 <p>In case you do not have a UUID or you simply want to test if <code>mkiocccentry(1)</code>
 does not detect any issues with your submission, without having to answer all
@@ -1121,7 +1089,7 @@ use the <code>-x</code> option though).</p>
 <p>An example use of this option is:</p>
 <pre><code>    mkiocccentry -d workdir topdir</code></pre>
 <p>This will run the tests that <code>mkiocccentry(1)</code>, write the JSON files, use
-<code>chkentry(1)</code>, package the tarball and run <code>txzchk(1)</code> on it.</p>
+<code>chksubmit(1)</code>, package the tarball and run <code>txzchk(1)</code> on it.</p>
 <p>If you don’t want to deal with the having to move or delete the submission
 directory, you could instead do:</p>
 <pre><code>    mkiocccentry -x -d workdir topdir</code></pre>
@@ -1134,35 +1102,30 @@ FAQ on “<a href="#info_json">.info.json</a>”,
 the
 FAQ on “<a href="#auth_json">.auth.json</a>”,
 the
-FAQ on “<a href="#chkentry">chkentry</a>,
+FAQ on “<a href="#chksubmit">chksubmit</a>,
 the
 FAQ on”<a href="#txzchk">txzchk</a>”
 and the
 FAQ on “<a href="#fnamchk">fnamchk</a>”
 for more details.</p>
 <div id="extra-files">
-<h1 id="what-are-extra-files-and-how-may-i-include-additional-files-beyond-the-max-allowed">What are extra files and how may I include additional files beyond the max allowed?</h1>
+<h1 id="what-are-extra-files-and-how-may-i-include-additional-files-beyond-the-max-allowed">1.5: What are extra files and how may I include additional files beyond the max allowed?</h1>
 </div>
-<p class="leftbar">
-Extra files are defined as files that are not the required files (<code>prog.c</code>,
-<code>Makefile</code>, <code>remarks.md</code> and the two generated by <code>mkiocccentry(1)</code> <code>.info.json</code>
-and <code>.auth.json</code>) and files that are also not the optional files (<code>try.sh</code>,
-<code>prog.alt.c</code> and <code>try.alt.sh</code>).
-</p>
-<p class="leftbar">
-<strong>NOTE</strong>: optional filenames are only optional if they are in the submission top
-level directory.
-</p>
-<p class="leftbar">
-If you need to include more files than this, you may include a tarball that
+<p>Extra files are defined as files that are not the free files (the required files
+<code>prog.c</code>, <code>Makefile</code>, <code>remarks.md</code> and the optional <code>try.sh</code>, <code>try.alt.sh</code>,
+<code>prog.alt.c</code> and the two generated by <code>mkiocccentry(1)</code> <code>.info.json</code> and
+<code>.auth.json</code>).</p>
+<p><strong>NOTE</strong>: optional filenames are only optional if they are in the submission top
+level directory.</p>
+<p>You may provide up to 31 extra files.</p>
+<p>If you need to include more files than this, you may include a tarball that
 itself is an extra file, meaning it counts <strong>AS</strong> an extra file.
 This file does <strong>NOT</strong> need to pass the <code>txzchk(1)</code> tests; only your submission
-tarball needs to pass these tests.
-</p>
+tarball needs to pass these tests. However see below if you do do this.</p>
 <p>Please pay careful attention to <a href="next/rules.html#rule17">Rule 17</a> and in
-particular the part about the <a href="#max-files">maximum number of files per
-submission</a>, which not only discusses the maximum
-number of files (including extra files) but also specific rules you must follow
+particular the part about the maximum number of files per
+submission, which not only discusses the maximum
+number of files but also specific rules you must follow
 if you do include a tarball. Not following these points puts you at great risk
 of violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <p>Also, remember what the <a href="next/guidelines.html">guidelines</a> say:</p>
@@ -1175,7 +1138,7 @@ The <code>mkiocccentry(1)</code> tool creates a v7 format tarball to prevent thi
 <p>Jump to: <a href="#">top</a></p>
 <div id="ai">
 <div id="llm">
-<h3 id="q-1.7-may-i-use-ai-llm-virtual-coding-assistants-or-similar-tools-to-write-my-submission">Q 1.7: May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</h3>
+<h3 id="q-1.6-may-i-use-ai-llm-virtual-coding-assistants-or-similar-tools-to-write-my-submission">Q 1.6: May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</h3>
 </div>
 </div>
 <p>You are free to use whatever tools you wish to write your code.
@@ -1188,380 +1151,267 @@ ultimate author of the code you submit.</p>
 you used as well as how you used them to help write your submission.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule17">
-<h3 id="q-1.8-what-are-details-behind-rule-17">Q 1.8: What are details behind Rule 17?</h3>
+<h3 id="q-1.7-what-are-details-behind-rule-17">Q 1.7: What are details behind Rule 17?</h3>
 </div>
 <h3 id="tldr-rule-17---use-mkiocccentry1">TL;DR Rule 17 - Use <code>mkiocccentry(1)</code></h3>
-<p class="leftbar">
-This is a <strong>COMPLEX</strong> rule. <strong>Violating this rule will cause your submission to
-be REJECTED!</strong> To help you avoid such a rejection, you are <strong>HIGHLY ENCOURAGED</strong>
+<p>This is a <strong>COMPLEX</strong> rule. <strong>Violating this rule WILL CAUSE YOUR SUBMISSION TO
+BE REJECTED!</strong> To help you avoid such a rejection, you are <strong>HIGHLY ENCOURAGED</strong>
 to use the <code>mkiocccentry(1)</code> tool, based on the latest release of the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>, to form your
-submission’s xz compressed tarball.
-</p>
-<p class="leftbar">
-The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
-contains <strong>IMPORTANT</strong> tools and libraries such as:
-</p>
+submission’s xz compressed tarball.</p>
+<p>The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
+contains <strong>IMPORTANT</strong> tools and libraries such as:</p>
 <ul>
-<li><p class="leftbar">
-<code>mkiocccentry(1)</code>
-</p></li>
-<li><p class="leftbar">
-<code>iocccsize(1)</code>
-</p></li>
-<li><p class="leftbar">
-<code>txzchk(1)</code>
-</p></li>
-<li><p class="leftbar">
-<code>fnamchk(1)</code>
-</p></li>
-<li><p class="leftbar">
-<code>jparse(3)</code>
-</p></li>
-<li><p class="leftbar">
-<code>chkentry(1)</code> (which uses <code>jparse(3)</code>)
-</p></li>
+<li><code>mkiocccentry(1)</code></li>
+<li><code>iocccsize(1)</code></li>
+<li><code>txzchk(1)</code></li>
+<li><code>fnamchk(1)</code></li>
+<li><code>jparse(3)</code></li>
+<li><code>chksubmit(1)</code> (which uses <code>jparse(3)</code> and is a wrapper to <code>chkentry(1)</code>)</li>
 </ul>
-<p class="leftbar">
-The above mentioned tools will help you verify that your submission
+<p>The above mentioned tools will help you verify that your submission
 conforms to <a href="next/rules.html#rule17">Rule 17</a>. Each of these tool has a <code>-h</code>
 option that provides command line help. For additional details of each tool, see
-its man page, and in some cases, the <a href="next/guidelines.html">IOCCC guidelines</a>.
-</p>
-<p class="leftbar">
-The maximum number of <strong>extra files</strong> is 31. See the <a href="#max-files">maximum number of extra
-files section</a> below for finer details and the
-FAQ on “<a href="#extra-files">what extra files are and how to include additional files</a>”,
-should you need to include more files than this maximum.
-</p>
+its man page, and in some cases, the <a href="next/guidelines.html">IOCCC guidelines</a>.</p>
+<p>The maximum number of <strong>extra files</strong> is 31. See the
+FAQ on “<a href="#extra-files">extra files</a>”
+for more details.</p>
+<p>Below we will list more details and link to relevant FAQs as well.</p>
 <p>Jump to: <a href="#">top</a></p>
 <h3 id="rule-17---the-complex-details">Rule 17 - The COMPLEX details</h3>
-<p class="leftbar">
 <p>Each submission <strong>MUST</strong> be in the form of an xz compressed tarball.
 The xz compressed tarball filename <strong>MUST</strong> be of the form:
 <code>^submit.username-slot_num.[1-9][0-9]{9,}.txz$</code>.</p>
-<p class="leftbar">
-… where <em><code>username</code></em> is your IOCCC registration username <strong>in the form of a
+<p>… where <em><code>username</code></em> is your IOCCC registration username <strong>in the form of a
 <a href="https://en.wikipedia.org/wiki/Universally_unique_identifier">UUID</a></strong> (see
 <a href="https://datatracker.ietf.org/doc/html/rfc9562">RFC 9562</a> for
 details), and where <em><code>slot_num</code></em> is a single decimal digit integer
-(i.e., &gt;= <code>0</code> and &lt;= <code>9</code>).
-</p>
-<p class="leftbar">
-In particular, <code>username</code> is in the form of:
+(i.e., &gt;= <code>0</code> and &lt;= <code>9</code>).</p>
+<p>In particular, <code>username</code> is in the form of:
 <code>xxxxxxxx-xxxx-4xxx-Nxxx-xxxxxxxxxxxx</code> where <code>'x'</code> is a hex digit in the range
-of <code>[0-9a-f]</code>, 4 is the UUID version, and <code>N</code> is one of <code>8</code>, <code>9</code>, <code>a</code>, or <code>b</code>.
-</p>
-<p class="leftbar">
-Your xz compressed tarball <strong>MUST</strong> contain, <strong>at a minimum</strong>, the following
-files, in the <strong>TOP LEVEL</strong> directory:
-</p>
+of <code>[0-9a-f]</code>, 4 is the UUID version, and <code>N</code> is one of <code>8</code>, <code>9</code>, <code>a</code>, or <code>b</code>.</p>
+<p>Your xz compressed tarball <strong>MUST</strong> contain, <strong>at a minimum</strong>, the following
+files, in the <strong>TOP LEVEL</strong> directory (see below for more details on each file
+in this list):</p>
 <ul>
-<li><p class="leftbar">
-<code>prog.c</code>
-</p></li>
-<li><p class="leftbar">
-<code>Makefile</code>
-</p></li>
-<li><p class="leftbar">
-<code>remarks.md</code>
-</p></li>
-<li><p class="leftbar">
-<code>.auth.json</code>
-</p></li>
-<li><p class="leftbar">
-<code>.info.json</code>
-</p></li>
+<li><code>prog.c</code>: your submission code.</li>
+<li><code>Makefile</code>: your Makefile that is based on
+<a href="next/Makefile.example">next/Makefile.example</a>.</li>
+<li><code>remarks.md</code>: your remarks about the submission in markdown format.</li>
+<li><code>.auth.json</code>: a JSON file about the author details (which will only be looked at by
+the judges IF it wins), generated by the <code>mkiocccentry(1)</code> tool.</li>
+<li><code>.info.json</code>: a JSON file about the submission itself which will be looked at
+by the judges during judging.</li>
 </ul>
-<p class="leftbar">
-<code>prog.c</code> is of course your submission program.
-</p>
-<p class="leftbar">
-The <code>Makefile</code> <strong>MUST</strong> be a <strong>non</strong>-empty file in <strong><a href="https://www.gnu.org/software/make/manual/make.html">GNU
+<p>Note that these do not count against extra files. Neither do the <code>try.sh</code>,
+<code>prog.alt.c</code> or <code>try.alt.sh</code>, should you provide them, and they are in the top
+level directory. See the
+FAQ on “<a href="#extra-files">extra files</a>”
+for more details on what this means, should you need to include additional files.</p>
+<p>The <code>prog.c</code> is probably pretty obvious if you’re here. :-)</p>
+<p>The <code>Makefile</code> <strong>MUST</strong> be a <strong>non</strong>-empty file in <strong><a href="https://www.gnu.org/software/make/manual/make.html">GNU
 Makefile</a></strong> format. See the
 <a href="next/guidelines.html#makefile">Makefile section in the guidelines</a>,
 the
 FAQ on “<a href="#submission_makefile">submission Makefiles</a>”
 and the
 FAQ on “<a href="#make_compatibility">IOCCC make(1) compatibility</a>”
-for help.
-</p>
-<p class="leftbar">
-The <code>remarks.md</code> <strong>MUST</strong> be a <strong>non</strong>-empty file in markdown format
+for help.</p>
+<p>The <code>remarks.md</code> <strong>MUST</strong> be a <strong>non</strong>-empty file in markdown format
 (<code>mkiocccentry(1)</code> only checks the file size but if you do not have any text in
 it you still risk violating this rule). See also
 <a href="next/rules.html#rule18">Rule 18</a> and our
 FAQ on “<a href="#remarks_md">remarks.md</a>”,
 our
 FAQ on “<a href="#markdown">markdown</a>”
-and our <a href="markdown.html">markdown guidelines</a>.
-</p>
-<p class="leftbar">
-See also the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide
-and the <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.
-</p>
-<p class="leftbar">
-The <code>.auth.json</code> file is created by <code>mkiocccentry(1)</code> and it holds information
+and our <a href="markdown.html">markdown guidelines</a>.</p>
+<p>See also the <a href="https://www.markdownguide.org/basic-syntax">markdown syntax</a> guide
+and the <a href="https://spec.commonmark.org/current/">CommonMark Spec</a>.</p>
+<p>The <code>.auth.json</code> file is created by <code>mkiocccentry(1)</code> and it holds information
 about the author(s) of the submission. It will <strong>ONLY</strong> be looked at if your
 submission wins but it <strong>MUST</strong> still be valid according to <code>jparse(3)</code> <strong>AND</strong>
-<code>chkentry(1)</code>.
-</p>
-<p class="leftbar">
-The <code>.info.json</code> file is created by <code>mkiocccentry(1)</code> and it holds information
+<code>chksubmit(1)</code> even if it does not win; if <code>chksubmit(1)</code> does not validate this
+file your submission <strong>WILL</strong> be rejected for violating Rule 17! See the
+FAQ on “<a href="#auth.json">.auth.json</a>”
+for more details on this file.</p>
+<p>The <code>.info.json</code> file is created by <code>mkiocccentry(1)</code> and it holds information
 about the submission itself. It also <strong>MUST</strong> be valid according to <strong>BOTH</strong>
-<code>jparse(3)</code> <strong>AND</strong> <code>chkentry(1)</code>.
-</p>
-<p class="leftbar">
-For the complete <code>mkiocccentry(1)</code> process, see the
-FAQ on the “<a href="#mkiocccentry_process">mkiocccentry process</a>”.
-</p>
-<p class="leftbar">
-The tool performs a lot of checks, both directly and indirectly, and if it or
+<code>jparse(3)</code> <strong>AND</strong> <code>chksubmit(1)</code>. See the
+FAQ on “<a href="#info.json">.info.json</a>”
+for more details on this file.</p>
+<p>See the
+FAQ on “<a href="#chksubmit">chksubmit(1)</a>”
+for more details on this important tool.</p>
+<p>For the complete <code>mkiocccentry(1)</code> process, see the
+FAQ on the “<a href="#mkiocccentry_process">mkiocccentry process</a>”.</p>
+<p>The tool performs a lot of checks, both directly and indirectly, and if it or
 any other tool detects <strong>ANY</strong> problem, you are <strong>HIGHLY</strong> encouraged to fix it
-and try again.
-</p>
-<p class="leftbar">
-On the other hand, some issues are errors and you <strong>MUST</strong> fix those.
-</p>
-<p class="leftbar">
-If you do use <code>mkiocccentry(1)</code> and you run into a problem, you might see the
-FAQ on “<a href="#questions">how to ask a question about the IOCCC rules, guidelines and
-tools</a>”.
-If you believe you have encountered a bug, feel free to open a bug report at the
-<a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">mkiocccentry repo issues
-page</a>.
-</p>
-<p class="leftbar">
-The xz compressed tarball file <strong>MUST</strong> be &lt;= <strong>3999971</strong> octets in size.
-</p>
-<p class="leftbar">
-When your submission’s xz compressed tarball is uncompressed, the total size of
+and try again.</p>
+<p>On the other hand, some issues are errors and you <strong>MUST</strong> fix those.</p>
+<p>If you do use <code>mkiocccentry(1)</code> (which we STRONGLY recommend you do) and you run
+into a problem, you might see the FAQ on “<a href="#questions">how to ask a question about the IOCCC
+rules, guidelines and tools</a>”. If you believe you have encountered
+a bug, feel free to open a bug report at the <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">mkiocccentry repo issues
+page</a>.</p>
+<p>The xz compressed tarball file <strong>MUST</strong> be &lt;= <strong>3999971</strong> octets in size.</p>
+<p>When your submission’s xz compressed tarball is uncompressed, the total size of
 your submission (the sum of the size of the program source code,
 remarks/comments, Makefile and all other files) <strong>MUST</strong> be &lt;= <strong>28314624</strong>
-octets (<strong>27651K</strong>) in size.
-</p>
-<p class="leftbar">
-One of the many checks <code>txzchk(1)</code> performs is summing up the total size. Of
+octets (<strong>27651K</strong>) in size.</p>
+<p>One of the many checks <code>txzchk(1)</code> performs is summing up the total size. Of
 course if you manipulate the tarball to get past this you risk violating this
-rule.
-</p>
-<p class="leftbar">
-Your submission’s xz compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> tests. See
-the <a href="next/guidelines.html#txzchk">guidelines on txzchk(1)</a> for more details on this tool.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT</strong>: Make <strong>SURE</strong> you have the most recent version of the
+rule.</p>
+<p>Your submission’s xz compressed tarball <strong>MUST</strong> pass the <code>txzchk(1)</code> tests. See
+the <a href="next/guidelines.html#txzchk">guidelines on txzchk(1)</a> for more details on this tool.</p>
+<p><strong>IMPORTANT</strong>: make <strong>SURE</strong> you have the most recent version of the
 <code>mkiocccentry</code> toolkit! Not doing so will put you at a great risk of violating
 this rule! See the
 FAQs on “<a href="#mkiocccentry">obtaining, compiling, installing and using the mkiocccentry toolkit</a>”
-for more details.
-</p>
-<p class="leftbar">
-You are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code> tool to form your
+for more details.</p>
+<p>You are <strong>HIGHLY ENCOURAGED</strong> to use the <code>mkiocccentry(1)</code> tool to form your
 submission’s xz compressed tarball. See the <a href="next/guidelines.html#mkiocccentry">guidelines on
 mkiocccentry(1)</a> for
 more details on this tool and see the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
-repo</a> for the toolkit itself.
-</p>
-<p class="leftbar">
-Your entry <strong>MAY</strong> have subdirectories, depending on the depth and total length of
-the filenames. Certain directories like <code>.git</code>, <code>RCCS</code>, <code>CVS</code> and <code>.svn</code>
-(amongst others) are skipped. For more information, see the
-FAQ on “<a href="#subdirectories">subdirectories</a>”.
-</p>
-<p class="leftbar">
-With the exception of those generated by the <code>mkiocccentry(1)</code> tool or the tools
-it or any other tool invokes, files in your submission <strong>MUST</strong>:
-</p>
+repo</a> for the toolkit itself.</p>
+<p>Your entry <strong>MAY</strong> have subdirectories, depending on the depth (a max depth,
+noted below) and total length of the filenames. Certain directories like <code>.git</code>,
+<code>RCCS</code>, <code>CVS</code> and <code>.svn</code> (amongst others) are skipped. For more information, see
+the
+FAQ on “<a href="#subdirectories">subdirectories</a>”.</p>
+<p>With the exception of those generated by the <code>mkiocccentry(1)</code> tool or the tools
+it or any other tool invokes, files in your submission <strong>MUST</strong>:</p>
 <ul>
-<li><p class="leftbar">
-Be &lt;= <strong>38</strong> characters in length.
-</p></li>
-<li><p class="leftbar">
-<strong>NOT</strong> have a leading <strong><code>/</code></strong>.
-</p></li>
-<li><p class="leftbar">
-<strong>NOT</strong> contain a path component of: <strong><code>.</code></strong> (that is, with
+<li>Be &lt;= <strong>38</strong> characters in length.</li>
+<li><strong>NOT</strong> have a leading <strong><code>/</code></strong>.</li>
+<li><strong>NOT</strong> contain a path component of: <strong><code>.</code></strong> (that is, with
 the exception of files generated by <code>mkiocccentry(1)</code> itself, it must have
-<strong>NO</strong> dot file including <code>.</code> itself).
-</p></li>
-<li><p class="leftbar">
-<strong>NOT</strong> contain a path component of: <strong><code>..</code></strong> (that is,
-<strong>NO</strong> path component that matches the regular expression <strong><code>^..$</code></strong>).
-</p></li>
-<li><p class="leftbar">
-Match the regular expression
+<strong>NO</strong> dot file including <code>.</code> itself).</li>
+<li><strong>NOT</strong> contain a path component of: <strong><code>..</code></strong> (that is,
+<strong>NO</strong> path component that matches the regular expression <strong><code>^..$</code></strong>).</li>
+<li>Match the regular expression
 <code>^[0-9A-Za-z]+[0-9A-Za-z_+.-]*$</code> (again, excluding files generated by
-<code>mkiocccentry(1)</code>).
-</p></li>
-<li><p class="leftbar">
-<strong>NOT</strong> have a directory/file depth &gt; 4.
-</p></li>
-<li><p class="leftbar">
-<strong>NOT</strong> have a total <strong>path</strong> length &gt; 99 characters.
-</p></li>
+<code>mkiocccentry(1)</code>).</li>
+<li><strong>NOT</strong> have a directory/file depth &gt; 4.</li>
+<li><strong>NOT</strong> have a total <strong>path</strong> length &gt; 99 characters.</li>
 </ul>
-<p class="leftbar">
-The submission tarball created by <code>mkiocccentry(1)</code> <strong>MUST</strong> have
-the additional files that are generated by the <code>mkiocccentry(1)</code> tool:
-</p>
+<p>Again, the submission tarball <strong>MUST</strong> have the mkiocccentry(1) created JSON
+files:</p>
 <ul>
-<li><p class="leftbar">
-<code>.auth.json</code> which contains information about the author or
+<li><code>.auth.json</code> which contains information about the author or
 authors (that will only be looked at if the submission wins).
 </p></li>
-<li><p class="leftbar">
-<code>.info.json</code> which contains information about the
+<li><code>.info.json</code> which contains information about the
 submission.
 </p></li>
 </ul>
-<p class="leftbar">
-The <code>chkentry(1)</code> tool will validate these two JSON files, and do other checks
+<p>The <code>chksubmit(1)</code> tool will validate these two JSON files, and do other checks
 on your submission directory as well, <em>prior to</em> <code>mkiocccentry(1)</code> forming the
-tarball.
-</p>
-<p class="leftbar">
-Files and directories in your submission tarball <strong>MUST</strong> be specific
+tarball. See the
+FAQ on “<a href="#chksubmit">chksubmit(1)</a>”
+for more details on this tool.</p>
+<p>Files and directories in your submission tarball <strong>MUST</strong> be specific
 permissions and <code>mkiocccentry(1)</code> does this for you. In particular: directories
-<strong>MUST</strong> be <code>drwxr-xr-x</code> (i.e. <code>0755</code>); the optional files, not counting
-<code>prog.alt.c</code> (i.e. <code>try.sh</code> and <code>try.alt.sh</code>), if provided, <strong>MUST</strong> be
+<strong>MUST</strong> be <code>drwxr-xr-x</code> (i.e. <code>0755</code>); any file ending with <code>.sh</code> <strong>MUST</strong> be
 <code>-r-xr-xr-x</code> (i.e. <code>0555</code>); and all other files <strong>MUST</strong> be <code>-r--r--r--</code> (i.e.
-<code>0444</code>). If any file or directory does not have the correct permissions, your submission <strong>WILL</strong>
-be rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!
-</p>
-<p class="leftbar">
-After <code>mkiocccentry(1)</code> creates the directories and copies the files with these
+<code>0444</code>). If any file or directory does not have the correct permissions, your
+submission <strong>WILL</strong> be rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
+<p>After <code>mkiocccentry(1)</code> creates the directories and copies the files with these
 modes, it also verifies them after the fact and if they are not correct it is an
-<strong>error</strong>.
-</p>
-<p class="leftbar">
-If you do need different permissions, then see the
+<strong>error</strong>.</p>
+<p>If you do need different permissions, then see the
 FAQ on “<a href="#file_perms">file permissions</a>”. Also keep in mind
-<a href="next/rules.html#rule4">Rule 4</a>, <a href="next/rules.html#rule5">Rule 5</a> and <a href="next/rules.html#rule21">Rule 21</a>.
-</p>
-<p class="leftbar">
-The <code>txzchk(1)</code> tool will also verify file/directory permissions (and many other
-things) for you, and so will <code>chkentry(1)</code> (along with other checks on files and
+<a href="next/rules.html#rule4">Rule 4</a>, <a href="next/rules.html#rule5">Rule 5</a> and <a href="next/rules.html#rule21">Rule 21</a>.</p>
+<p>The <code>txzchk(1)</code> tool will also verify file/directory permissions (and many other
+things) for you, and so will <code>chksubmit(1)</code> (along with other checks on files and
 directories in your submission directory, including the two required JSON files,
 <code>.auth.json</code> and <code>.info.json</code>). If these checks fail it is an <strong>error</strong>
 and <code>mkiocccentry(1)</code> will abort. In this case (it fails and you used
 <code>mkiocccentry(1)</code>) it is very <strong>possibly</strong> a bug; please <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it as a bug at
 the mkiocccentry issues
-page</a>.
-</p>
-<p class="leftbar">
-The tarball filename <strong>MUST</strong> pass <code>fnamchk(1)</code>; the tool <code>txzchk(1)</code>
+page</a>.</p>
+<p>The tarball filename <strong>MUST</strong> pass <code>fnamchk(1)</code>; the tool <code>txzchk(1)</code>
 will run <code>fnamchk(1)</code> as part of its algorithm. If you use <code>mkiocccentry(1)</code>
 there should be no problem but if you were to package things manually it is
 possible there could be a problem and this poses a big risk of violating <a href="next/rules.html#rule17">Rule
-17</a>.
-</p>
-<p class="leftbar">
-The <code>fnamchk(1)</code>, which <code>txzchk(1)</code> executes, will verify that the
+17</a>.</p>
+<p>The <code>fnamchk(1)</code>, which <code>txzchk(1)</code> executes, will verify that the
 filename is correct. But if you do package your tarball manually, and you have a
 mismatch in what is in the tarball and the name, <code>txzchk(1)</code> will flag the
-discrepancy as an error and exit with non-zero.
-</p>
-<p class="leftbar">
-These checks <strong>MUST PASS</strong>. If they do not you stand a significant chance of
-having your submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!
-</p>
+discrepancy as an error and exit with non-zero.</p>
+<p>These checks <strong>MUST PASS</strong>. If they do not you stand a significant chance of
+having your submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!</p>
 <div id="max-files">
 <h4 id="maximum-number-of-files-per-submission">Maximum number of files per submission</h4>
 </div>
-<p class="leftbar">
-The maximum number of files your submission tarball may contain, not counting
-the optional files (<code>prog.alt.c</code>, <code>try.sh</code>, <code>try.alt.sh</code>) and the mandatory
-files (<code>prog.c</code>, <code>Makefile</code>, <code>remarks.md</code> plus the <code>mkiocccentry(1)</code> generated
-files <code>.auth.json</code> and <code>.info.json</code>), is 31. This is defined in the macro
+<p>The maximum number of files your submission tarball may contain, not counting
+the free files (<code>prog.c</code>, <code>remarks.md</code>, <code>Makefile</code>, <code>prog.alt.c</code>, <code>try.sh</code>,
+<code>try.alt.sh</code>,, <code>.info.json</code> and <code>.auth.json</code>) is 31. This is defined in the macro
 <code>MAX_EXTRA_FILE_COUNT</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">soup/limit_ioccc.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>. See the
 FAQ on “<a href="#extra-files">what extra files are and how to include more</a>”
-if you need to include more files.
-</p>
-<p class="leftbar">
-If you do include a tarball that takes your extra files count over the maximum,
+if you need to include more files.</p>
+<p>If you do include a tarball that takes your extra files count over the maximum,
 you <strong>MUST</strong> explain this in your <code>remarks.md</code> file! <strong>PLEASE</strong> do not include a
 tarball with extra files for a test-suite; instead mention in your remarks that
 you have extra files for a test-suite that can be included should your
 submission win. Of course if you don’t need that many files for a test-suite you
-are more than welcome to include those files in your submission.
-</p>
-<p class="leftbar">
-If you need to extract a tarball by some Makefile, or perhaps the program
+are more than welcome to include those files in your submission.</p>
+<p>If you need to extract a tarball by some Makefile, or perhaps the program
 itself, then <code>make clobber</code> <strong>MUST</strong> remove everything that the extraction
-created!
-</p>
-<p class="leftbar">
-Tarballs <strong>MUST</strong> only create files and directories <em>under</em> the submission
+created!</p>
+<p>Tarballs <strong>MUST</strong> only create files and directories <em>under</em> the submission
 directory. They may <strong>NOT</strong> contain absolute paths (paths that start with <code>/</code>)!
 <code>txzchk</code> does <strong>NOT</strong> check other tarballs so <strong>YOU MUST</strong> verify these details
-yourself.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT REMINDER</strong>: <strong>MAKE SURE</strong> your tarball does not reveal who you are!
-The <code>mkiocccentry(1)</code> tool uses the v7 format. For instance you might try:
-</p>
+yourself.</p>
+<p><strong>IMPORTANT REMINDER</strong>: <strong>MAKE SURE</strong> your tarball does not reveal who you are!
+The <code>mkiocccentry(1)</code> tool uses the v7 format. For instance you might try:</p>
 <pre><code>    tar --format=v7 -cJf foo.txz directory</code></pre>
 <hr style="width:50%;text-align:left;margin-left:0">
-<p class="leftbar">
-<strong>IMPORTANT</strong>: where <a href="next/rules.html#rule17">Rule 17</a> and the tools from the latest
+<p><strong>IMPORTANT</strong>: where <a href="next/rules.html#rule17">Rule 17</a> and the tools from the latest
 release of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
 conflict, the <a href="judges.html">IOCCC judges</a> will use their best judgment which
-is likely to favor <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> code.
-</p>
-<p class="leftbar">
-This means you should <strong>MAKE SURE</strong> that you use <code>mkiocccentry(1)</code> to
+is likely to favor <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> code.</p>
+<p>This means you should <strong>MAKE SURE</strong> that you use <code>mkiocccentry(1)</code> to
 package your submission; <code>mkiocccentry(1)</code> will run the above mentioned tools
 (that do not act on the tarball) <strong>before</strong> creating the tarball and after the
 tarball is created it will then verify that the tarball is okay by running
 <code>txzchk(1)</code> on it. If any step fails it is an error and submitting the
-submission will result in violating this rule.
-</p>
-<p class="leftbar">
-<strong>MAKE SURE</strong> you use the correct release of the repository; you should do this
+submission will result in violating this rule.</p>
+<p><strong>MAKE SURE</strong> you use the correct release of the repository; you should do this
 <strong>AFTER</strong> the contest opens (pull any changes or if you prefer download the
 repository via the download option at GitHub). See the
 FAQ on “<a href="#obtaining_mkiocccentry">obtaining the latest release of mkiocccentry</a>”
-for more help on ensuring you do have the most up to date release.
-</p>
-<p class="leftbar">
-We recommend that you run <code>make</code> and then install the tools (and man pages) via
+for more help on ensuring you do have the most up to date release.</p>
+<p>We recommend that you run <code>make</code> and then install the tools (and man pages) via
 <code>make install</code> (as root or using <code>sudo(8)</code>) to help you run these tools from
 your submission’s directory (or any other directory). The <code>make install</code> will
 install in <code>/usr/local</code>. However, <strong>you do not have</strong> to install them, but in
 that case you’ll have to run it from the toolkit’s directory or use the correct
 options to specify the path to the necessary tools, and also specify the path to
-your files, which can be problematic.
-</p>
-<p class="leftbar">
-These tools will link in the <code>jparse(3)</code> library, the <code>dbg</code> library and the
-<code>dyn_array</code> library; <code>chkentry(1)</code> uses the JSON parser (<code>jparse(3)</code>) to
-validate and parse the <a href="https://www.json.org/json-en.html">JSON</a> files but the
-other tools use parts of the <code>jparse</code> utility functions as well.
-</p>
-<p class="leftbar">
-If you run into a problem with one or more of these tools, <strong>PLEASE</strong> <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it
+your files, which can be problematic.</p>
+<p>These tools will link in the <code>jparse(3)</code> library, the <code>dbg</code> library and the
+<code>dyn_array</code> library as well as the <code>pr(3)</code> and <code>soup(3)</code> libraries;
+<code>chksubmit(1)</code> uses the JSON parser (<code>jparse(3)</code>) to validate and parse the
+<a href="https://www.json.org/json-en.html">JSON</a> files but the other tools use parts of
+the <code>jparse</code> utility functions as well.</p>
+<p>If you run into a problem with one or more of these tools, <strong>PLEASE</strong> <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it
 as a bug at the mkiocccentry issues
 page</a>,
 <strong>making sure to run <code>bug_report.sh</code></strong>. See the <a href="next/guidelines.html">guidelines</a>
 for help here and also read our
-FAQ on “<a href="#mkiocccentry_bugs">mkiocccentry repo bugs</a>”.
-</p>
-<p class="leftbar">
-At the risk of stating the obvious: submissions that violate <a href="next/rules.html#rule17">Rule
+FAQ on “<a href="#mkiocccentry_bugs">mkiocccentry repo bugs</a>”.</p>
+<p>At the risk of stating the obvious: submissions that violate <a href="next/rules.html#rule17">Rule
 17</a> <strong>WILL BE REJECTED</strong>, so <strong>BE SURE</strong> to use the latest release of the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>, to form and test
 your submission’s xz compressed tarball. Do <strong>NOT</strong> assume you have the most
 recent release without pulling or downloading via GitHub and do <strong>MAKE SURE</strong> you
 do this <strong>AFTER</strong> the <a href="status.html">contest status</a> has changed to
-<a href="#open">open</a>.
-</p>
+<a href="#open">open</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="uuid">
 <div id="uuid_file">
-<h3 id="q-1.9-how-can-i-avoid-re-entering-my-uuid-to-mkiocccentry">Q 1.9: How can I avoid re-entering my UUID to mkiocccentry?</h3>
+<h3 id="q-1.8-how-can-i-avoid-re-entering-my-uuid-to-mkiocccentry">Q 1.8: How can I avoid re-entering my UUID to mkiocccentry?</h3>
 </div>
 </div>
 <p>Because some people might want to submit more than one submission, an option to
@@ -1583,7 +1433,7 @@ if your UUID was <code>test</code> (for test mode) you could do:</p>
 FAQ on “<a href="#answers_file">the answers file</a>”.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="submission_dir">
-<h3 id="q-1.10-how-can-i-avoid-having-to-move-or-delete-my-submission-directory-for-the-same-workdir">Q 1.10: How can I avoid having to move or delete my submission directory for the same workdir?</h3>
+<h3 id="q-1.9-how-can-i-avoid-having-to-move-or-delete-my-submission-directory-for-the-same-workdir">Q 1.9: How can I avoid having to move or delete my submission directory for the same workdir?</h3>
 </div>
 <p>If you wish to not have to worry about removing or moving the submission
 directory under the workdir, you may use the <code>-x</code> option to <code>mkiocccentry</code>. For
@@ -1595,7 +1445,7 @@ first so you do not have to do so.</p>
 specify the path by the <code>-r rm</code> option.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="download_submission">
-<h3 id="q-1.11-can-i-download-my-submission-tarball-from-the-submit-server">Q 1.11: Can I download my submission tarball from the submit server?</h3>
+<h3 id="q-1.10-can-i-download-my-submission-tarball-from-the-submit-server">Q 1.10: Can I download my submission tarball from the submit server?</h3>
 </div>
 <p>We do not support this. If you need to verify your submission, then
 you can re-upload (while the contest is in open state) and verify the SHA256
@@ -1955,309 +1805,10 @@ entries that do not win on their web page for everyone to see.</p>
 <h2 id="section-3-the-mkiocccentry-toolkit-finer-details">Section 3: The mkiocccentry toolkit: finer details</h2>
 </div>
 <p>Jump to: <a href="#">top</a></p>
-<div id="mkiocccentry_process">
-<h3 id="q-3.0-what-is-the-mkiocccentry1-process-and-what-sort-of-checks-does-it-perform">Q 3.0: What is the <code>mkiocccentry(1)</code> process and what sort of checks does it perform?</h3>
-</div>
-<p><strong>TL;DR</strong>: the program will make a submission directory (name based on the
-username and slot number you provide) under the workdir and then switch to the
-topdir. It will then create lists of files and directories to present to you, to
-verify everything is in order. If something is not allowed (bad filename for
-example) or an error occurs (missing required file for example) you will be
-notified of this. After you verify everything is okay the files/directories
-found will be copied/made and it will then switch to the submission directory.
-In the submission directory it first runs <code>make clobber</code> and then scans the
-directory hierarchy again, verifying things are still okay. When done it will
-ask you to verify things still look OK to you too. If all is good it’ll ask you
-for more information about the author(s). Next the two required JSON files
-<code>.auth.json</code> and <code>.info.json</code> will be created. After that <code>chkentry(1)</code> will be
-run on the directory. If all is good it’ll give you another chance to say the
-files/directories look good and if you answer yes it’ll create the tarball and
-run <code>txzchk</code> on it.</p>
-<p>In most cases the program will prompt you to verify your input is correct. In
-the case of author information (which will only be looked at if you win) you
-will be asked to verify country code prior to being asked the other questions.
-If you fail to enter other author information correctly you will be prompted
-right away to fix it. Afterwards, when the author information is collected, it
-will ask you to confirm. This procedure happens for each author.</p>
-<p>In the case of <code>-i answers</code> option being used, you will not have to put in most
-information but you will have to confirm the lists of files and directories are
-correct, unless you use <code>-Y</code> (which we do not recommend).</p>
-<p>If <code>topdir</code> is not a readable (<code>+r</code>), searchable (<code>+x</code>) directory it is an error.</p>
-<p>If <code>workdir</code> is not a writable (<code>+w</code>), searchable (<code>+x</code>) directory it is an error.</p>
-<p>If <code>workdir</code> is in <code>topdir</code> the program will not descend into it (the workdir).</p>
-<p>If <code>topdir</code> is the same (by device and inode) as <code>workdir</code> it is an error.
-If somehow <code>topdir</code> or <code>workdir</code> is found under the submission directory (by
-device and inode) it is an error (and you should report it as a bug.</p>
-<p>In more detail the <code>mkiocccentry(1)</code> tool performs the below steps.</p>
-<ol start="0" type="1">
-<li>Ask the user for a submission ID (see the <a href="next/register.html">how to register</a>
-for more details on how to obtain this and <a href="next/rules.html#rule17">Rule 17</a> for
-the importance of this).
-<ul>
-<li>If this is an invalid UUID (malformed), you will be asked to correct it
-until it is.</li>
-<li>If the <code>-u uuidfile</code> option is used and the UUID in the file <code>uuidfile</code> is not malformed,
-the user will not be prompted for a UUID.</li>
-<li>If the <code>-U uuidstr</code> option is used and the UUID is not malformed, the user
-will not be prompted for a UUID.</li>
-<li>The <code>-u</code> and <code>-U</code> options may not be used with any option that reads from
-an answers file (<code>-i answers</code>, <code>-d</code>, <code>-s seed</code>).</li>
-</ul></li>
-<li>Ask the user for the submission slot (the submission number; see <a href="next/register.html">how to
-register</a> and <a href="next/rules.html#rule17">Rule 17</a> for more details).
-<ul>
-<li>If this is out of range (see <code>MAX_SUBMIT_SLOT</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>)
-you will be asked to correct it until it is.</li>
-</ul></li>
-<li>Make the submission directory under <code>topdir</code> in the form of
-<code>workdir/submit.USERNAME-SLOT</code>.
-<ul>
-<li>If this directory already exists it is an error, unless the <code>-x</code> option is
-used, in which case it’ll be deleted.</li>
-<li>If for some reason the default <code>rm</code> paths do not work, you may use <code>-r rm</code>
-to specify the path to a working <code>rm</code> command.</li>
-</ul></li>
-<li>Change to the <code>topdir</code>.</li>
-<li>Traverse the directory, creating lists of ignored/forbidden
-files/directories/symlinks as well as a list directories to make and a list of
-files to copy to the submission directory (and if (sub)directories are found
-with files, copy those files to their respective directory). Note the following:
-<ul>
-<li>If the depth is too deep it is an error (see <code>MAX_PATH_DEPTH</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>If there are too many extra directories (total count not including the
-submission directory itself, unrelated to <code>MAX_PATH_DEPTH</code> above) it is an
-error (see <code>MAX_EXTRA_DIR_COUNT</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>If the max path length is &lt;= 0 it is an error (and a bug!).</li>
-<li>If the max depth is &lt;= 0 it is an error (and a bug!).</li>
-<li>If the max filename length is &lt;= 0 it is an error (and a bug!).</li>
-<li>If a path is NULL it is an error.</li>
-<li>If a path is an empty string it is an error.</li>
-<li>If the path length (i.e. <code>strlen(path)</code> where path starts after the
-initial <code>./</code> of the path in the <code>topdir</code>) is too long it is an error (see <code>MAX_PATH_LEN</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>If a filename (last component of the path) is too long it is an error (see <code>MAX_FILENAME_LEN</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>If a filename or directory name is not a sane relative path, not allowed
-or will not be added for some other reason, it will be added to a relevant list to show to
-the user later, to let them know it will not be added to the submission. By <code>relative</code> we mean it
-must not start with <code>/</code> (which shouldn’t happen even if you give an absolute
-path) and by <code>sane</code> we mean that each component must match the regexp: <code>^[0-9A-Za-z]+[0-9A-Za-z_+.-]*$</code>.</li>
-<li>If a directory is unreadable it is an error.</li>
-<li>If a directory causes a cycle in the tree it is an error.</li>
-<li>If <code>stat(2)</code> on the path fails it is an error.</li>
-<li>If <code>prog.c</code>, <code>Makefile</code> or <code>remarks.md</code> is/are not found it is an error.</li>
-<li>If too many files that are not <code>prog.c</code>, <code>Makefile</code>, <code>remarks.md</code>,
-<code>try.sh</code>, <code>prog.alt.c</code> or <code>try.alt.sh</code> are found, it is an error (see
-<code>MAX_EXTRA_FILE_COUNT</code> in
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>Symlinks are not allowed but it is not an error (they will be added to a
-list and ignored).</li>
-<li>If any file type other than a regular file, a directory or a symlink is
-encountered it is an error.</li>
-<li>If there is an unknown error it is an error :-)</li>
-</ul></li>
-<li>Show each list to the user, asking if this is okay. The lists include:
-<ul>
-<li>Ignored directories (those like <code>.git</code>, <code>CVS</code>, <code>RCCS</code>, <code>.svn</code> and various
-others).</li>
-<li>Unsafe directory names that will not be added (i.e. those that are not
-POSIX plus + safe chars only; see above step (4)). This includes directories
-starting with a <code>.</code>.</li>
-<li>Forbidden files such as <code>index.html</code>, <code>README.md</code>, <code>prog</code>, <code>prog.alt</code>.</li>
-<li>Unsafe filenames that will not be added (i.e. those that are not POSIX
-plus + safe chars only; see above step (4)). This includes files starting
-with <code>.</code>.</li>
-<li>Symlinks found (these are not allowed).</li>
-<li>Directories to be made.</li>
-<li>Required files (<code>prog.c</code>, <code>Makefile</code> and <code>remarks.md</code>) to be copied.</li>
-<li>Non-required files to be copied.</li>
-<li>The user is asked to verify each list, including the lists of directories
-and files to be made/copied, and if the user says it is not OK the program will abort.</li>
-</ul></li>
-<li>Make any directories if necessary (under
-<code>workdir/submit.USERNAME-SLOT</code> i.e. the submission directory).
-<ul>
-<li>Directories <strong>MUST</strong> be and are made with mode <code>0755</code>.</li>
-<li>If any directory is not this mode <code>txzchk(1)</code> will flag it (and so will
-<code>mkiocccentry(1)</code>).</li>
-</ul></li>
-<li>The non-ignored files are copied to their respective directories under the
-submission directory.
-<ul>
-<li><code>try.sh</code> and <code>try.alt.sh</code> <strong>MUST</strong> be and are copied as mode <code>0555</code>.</li>
-<li>All other files <strong>MUST</strong> be and are copied as mode <code>0444</code>.</li>
-<li>Anything else will be flagged by <code>txzchk(1)</code> (and it’ll be flagged by
-<code>mkiocccentry(1)</code> too).</li>
-</ul></li>
-<li><code>cd submit.USERNAME-SLOT</code> (i.e. switch to submission directory).</li>
-<li><code>make -f Makefile clobber</code>.
-<ul>
-<li>If this fails it is not an error but you are warned about it (it is an error only if the <code>Makefile</code>
-does not a regular readable file but; even so, see <a href="next/rules.html#rule20">Rule 20</a>.</li>
-</ul></li>
-<li>Traverse the new tree from <code>.</code> (the submission directory) with additional steps from (4).
-<ul>
-<li>If any file has an ignored directory name in it, it is an error.</li>
-<li>If a symlink is found it is an error.</li>
-<li>If any file type other than a directory or regular file exists it is an
-error.</li>
-<li>If a forbidden filename exists it is an error.</li>
-<li>If any file or directory starts with <code>/</code> or is not POSIX plus + safe chars
-only (see (4) above) it is an error (though this should not actually happen
-unless you’re doing something funny).</li>
-<li>If the directory depth becomes too deep it is an error.</li>
-<li>If <code>prog.c</code>, <code>Makefile</code> or <code>remarks.md</code> are missing (or not readable
-regular files) it is an error.</li>
-<li>If an optional file is a directory it is an error.</li>
-<li>If a file or directory is in the submission directory that was not found
-in the topdir it is an error.</li>
-<li>If a file or directory found in the topdir is not in the submission
-directory it is an error.</li>
-<li>If a file or directory in the submission directory is a different type
-from the topdir (e.g. if <code>foo</code> was a directory in topdir but in the submission
-directory it is a file) it is an error.</li>
-<li>If a file (based on the name) or directory has the wrong permission it is
-an error (see (7) above).</li>
-<li>If <code>fts_read(3)</code> reports something as a directory but it’s not a directory
-it is an error (and likewise if it reports something as a file and it’s not
-a file it is an error) - though this should never happen.</li>
-<li>If a directory name (full path from the submission directory) is the name
-of a mandatory file it is an error.</li>
-<li>If a directory name (full path from the submission directory) is the name
-of of an optional file it is an error.</li>
-<li><code>iocccsize(1)</code> (via the <code>mkiocccentry(1)</code> function <code>check_prog_c()</code>) will
-be run on your <code>prog.c</code>, allowing you to override any warnings; if you do not
-override an issue flagged it is an error but if warnings from <code>check_prog_c()</code>
-are ignored you risk violating the <a href="next/rules.html">Rules</a>, including <a href="next/rules.html#rule2">Rule
-2</a>.</li>
-<li><code>check_Makefile()</code> will be run on <code>Makefile</code>; if it is a non-readable or
-empty file it is an error but otherwise you may override any warnings
-(risking violating the <a href="next/rules.html">Rules</a>, especially <a href="next/rules.html#rule17">Rule
-17</a> and <a href="next/rules.html#rule20">Rule 20</a>).</li>
-<li><code>check_remarks_md()</code> will be run on your <code>remarks.m</code>; if it is not a
-regular readable file or it is empty it is an error. Otherwise it will
-proceed. Note it does not check that there is any text in the file, just
-that the file size is not 0, and having a <code>remarks.md</code> that is not size 0
-but has no content is violating <a href="next/rules.html#rule17">Rule 17</a> and <a href="next/rules.html#rule19">Rule
-19</a>.</li>
-<li>If any other error condition from step (4) occurs it is also an error.</li>
-</ul></li>
-<li>Present the list of non-dot files that remain and ask the user to confirm.</li>
-<li>Ask the user for a submission title.</li>
-<li>Ask the user for a one line abstract of the submission.</li>
-<li>Ask the user for the number of authors and for each author ask a variety of
-questions (see below for more information on what kind of questions).</li>
-<li>Create <code>.info.json</code>.</li>
-<li>Create <code>.auth.json</code>.</li>
-<li>Run <code>chkentry(1)</code> on your submission directory to verify things look good,
-including that the <code>.info.json</code> and <code>.auth.json</code> files are okay.
-<ul>
-<li>It also checks that the manifest in <code>.info.json</code> matches what is in the
-submission directory and it verifies file permissions too; if you wish to
-know what else it does we suggest you read the source code.</li>
-</ul></li>
-<li>Show the output of <code>ls -lakR .</code>, asking the user to confirm that the listing
-is okay.</li>
-<li>Create the tarball with the name in the form of
-<code>submit.USERNAME-SLOT.TIMESTAMP</code>.</li>
-<li>Run <code>txzchk(1)</code> on the tarball.</li>
-</ol>
-<p>If any of the steps fail or if the user says something is not okay, it aborts.
-Some of the other checks that are made:</p>
-<ul>
-<li>If <code>prog.c</code> violates <a href="next/rules.html#rule2">Rule 2</a> (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">iocccsize.c</a>).</li>
-<li>If <code>prog.c</code> is empty (see <a href="next/rules.html#rule1">Rule 1</a> and the
-<a href="next/guidelines.html">Guidelines</a>).</li>
-<li>If <code>prog.c</code> has any NUL (<code>\0</code>) char (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c">rule_count.c</a>).</li>
-<li>If <code>prog.c</code> has any unknown or invalid trigraph (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c">rule_count.c</a>).</li>
-<li>If <code>prog.c</code> triggers a word buffer overflow (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c">rule_count.c</a>).</li>
-<li>If <code>prog.c</code> triggers an <code>ungetc(3)</code> error (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c">rule_count.c</a>).</li>
-<li>If the first rule in the <code>Makefile</code> is not <code>all</code>.</li>
-<li>If the <code>Makefile</code> does not have a <code>clean</code> rule.</li>
-<li>If the <code>Makefile</code> does not have a <code>clobber</code> rule.</li>
-<li>If the <code>Makefile</code> does not have a <code>try</code> rule.</li>
-</ul>
-<p>Conditions that one <strong>MUST</strong> correct, and which <code>mkiocccentry(1)</code> will prompt until
-they are correct, are:</p>
-<ul>
-<li>Your <em>contest ID</em> is invalidly formed.</li>
-<li>Your <em>submit slot</em> is &lt; 0 or &gt; <code>MAX_SUBMIT_SLOT</code> (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>Your <em>title</em> is not in the range of 1 through <code>MAX_TITLE_LEN</code> chars (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>Your <em>title</em> does not match the regexp <code>^[0-9a-z][0-9a-z._+-]*$</code>.</li>
-<li>Your <em>abstract</em> is not between 1 and <code>MAX_ABSTRACT_LEN</code> chars
-(see <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>The author count is not 1 through <code>MAX_AUTHORS</code> (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>An author <em>name</em> is not 1 through <code>MAX_NAME_LEN</code> chars (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>Duplicate author <em>name</em>.</li>
-<li><em>Country code</em> is invalid (i.e. it is not a ISO 3166-1 2 character code).</li>
-<li>An <em>email</em>, if provided, is not in the format of <code>x@y</code> or
-if <code>x</code> or <code>y</code> contain a <code>@</code>, are empty or if the total length is longer than
-<code>MAX_EMAIL_LEN</code> (see <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>A <em>URL</em> or <em>alt URL</em>, if provided, does not start with <code>http://</code>
-or <code>https://</code> or is longer than <code>MAX_URL_LEN</code> chars (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>)
-or does not have anything after the <code>http://</code> or <code>https://</code>.</li>
-<li>A <em>mastodon handle</em>, if provided, is not in the form of
-<code>@user@site</code> (i.e. starts with an <code>@</code>, has text following it and then another
-<code>@</code> followed by more text and has no other <code>@</code>), or if it is longer than <code>MAX_MASTODON_LEN</code> (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>A <em>GitHub account</em>, if provided, does not start with an <code>@</code>,
-has more than one <code>@</code>, does not have any text after the <code>@</code> or is longer than <code>MAX_GITHUB_LEN</code> (see
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>An <em>affiliation</em>, if provided, is longer than
-<code>MAX_AFFILIATION_LEN</code> (see <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h">limit_ioccc.h</a>).</li>
-<li>An <em>author handle</em>, if the default is not accepted, does
-not match the regexp <code>^[0-9A-Za-z][0-9A-Za-z._+-]*$</code>.</li>
-<li>An <em>author handle</em> is repeated.</li>
-</ul>
-<p>The program does confirm that the information for each author is correct,
-allowing you to correct the information without having to start the program
-over.</p>
-<p>Although the <code>mkiocccentry(1)</code> tool will verify everything for you, you may wish
-to validate different parts individually with the different tools. As the
-<a href="next/rules.html">rules</a> state, each of these tools has a <code>-h</code> option.</p>
-<p>See the
-FAQ on “<a href="#jparse">jparse</a>”,
-the
-FAQ on “<a href="#auth_json">.auth.json</a>”,
-the
-FAQ on “<a href="#info_json">.info.json</a>”,
-the
-FAQ on “<a href="#chkentry">chkentry</a>”,
-the
-FAQ on “<a href="#txzchk">txzchk</a>”
-and the
-FAQ on “<a href="#fnamchk">fnamchk</a>”
-for more details on the tools that <code>mkiocccentry</code> either executes directly or
-indirectly as part of the packaging process, especially if you wish to run one
-or more of these tools manually.</p>
-<p>See also the
-FAQ on “<a href="#mkiocccentry_test">how to test everything at once without having to answer
-questions</a>”.</p>
-<p>See also the <a href="next/guidelines.html">Guidelines</a> and the <a href="next/rules.html">Rules</a>
-(especially <a href="next/rules.html#rule1">Rule 1</a>, <a href="next/rules.html#rule2">Rule 2</a>, <a href="next/rules.html#rule17">Rule
-17</a>, <a href="next/rules.html#rule19">Rule 19</a> and <a href="next/rules.html#rule20">Rule
-20</a>).</p>
-<p>Finally, if you wish to not have to enter the same answers just to update a
-submission, see the
-FAQ on the “<a href="#answers_file">answers file feature</a>”.</p>
-<p>Jump to: <a href="#">top</a></p>
 <div id="txzchk">
 <div id="tarball">
 <div id="xz">
-<h3 id="q-3.1-how-can-i-validate-my-submission-tarball">Q 3.1: How can I validate my submission tarball?</h3>
+<h3 id="q-3.0-how-can-i-validate-my-submission-tarball">Q 3.0: How can I validate my submission tarball?</h3>
 </div>
 </div>
 </div>
@@ -2282,7 +1833,7 @@ code</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="fnamchk">
 <div id="tarball_filename">
-<h3 id="q-3.2-what-is-the-fnamchk-tool">Q 3.2: What is the <code>fnamchk</code> tool?</h3>
+<h3 id="q-3.1-what-is-the-fnamchk-tool">Q 3.1: What is the <code>fnamchk</code> tool?</h3>
 </div>
 </div>
 <p>This tool, which is in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
@@ -2300,20 +1851,20 @@ you can do so. For instance:</p>
 FAQ on “<a href="#txzchk">validating your submission tarball</a>”
 for more information.</p>
 <p>Jump to: <a href="#">top</a></p>
-<div id="chkentry">
-<h3 id="q-3.3-how-can-i-validate-my-submission-directory">Q 3.3: How can I validate my submission directory?</h3>
+<div id="chksubmit">
+<h3 id="q-3.2-how-can-i-validate-my-submission-directory">Q 3.2: How can I validate my submission directory?</h3>
 </div>
 <p>If you want to validate your submission directory manually, including but not
-limited to the <code>.auth.json</code> and <code>.info.json</code> files, you should use <code>chkentry(1)</code>
+limited to the <code>.auth.json</code> and <code>.info.json</code> files, you should use <code>chksubmit(1)</code>
 from the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
-<p>The <code>chkentry(1)</code> tool runs a variety of checks on your submission directory,
+<p>The <code>chksubmit(1)</code> tool runs a variety of checks on your submission directory,
 including, but not limited to, using the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3">jparse
 API</a>
 to validate the two IOCCC specific JSON files (as valid JSON) and additional
 checks on those files as well. An important thing that it does is verify that
 your files are the right permissions and that the manifest in the <code>.info.json</code>
 files match what is in the directory. What all the checks are is out of scope of this
-document; if you wish to know we recommend you read the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">source
+document; if you wish to know we recommend you read the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c">source
 code</a>.</p>
 <p><strong>NOTE</strong>: the IOCCC <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3">jparse
 API</a>
@@ -2324,7 +1875,7 @@ FAQ on “<a href="#auth_json">.auth.json</a>”
 and
 FAQ on “<a href="#info_json">.info.json</a>”
 for more details on the two required and very important JSON files.</p>
-<p>The <code>chkentry(1)</code> tool accepts a single arg, a directory that <strong>MUST</strong> have the
+<p>The <code>chksubmit(1)</code> tool accepts a single arg, a directory that <strong>MUST</strong> have the
 two JSON files, <code>.auth.json</code> and <code>.info.json</code> as well as the <code>prog.c</code>,
 <code>Makefile</code> and <code>remarks.md</code> files along with all the other files listed in the
 <code>.info.json</code> manifest. (Okay there is an option to skip files but this is for
@@ -2333,15 +1884,15 @@ a great risk of violating <a href="next/rules.html#rule17">Rule 17</a>!).</p>
 <p>As an example, if your submission directory is
 <code>00000000-0000-4000-0000-000000000000-3/</code> then you should run the following
 command:</p>
-<pre><code>    chkentry 00000000-0000-4000-0000-000000000000-3</code></pre>
+<pre><code>    chksubmit 00000000-0000-4000-0000-000000000000-3</code></pre>
 <p>If there is a <a href="https://www.json.org/json-en.html">JSON</a> issue detected by the
-<code>jparse(3)</code> API (i.e. it is not valid JSON) it is an error and <code>chkentry(1)</code>
+<code>jparse(3)</code> API (i.e. it is not valid JSON) it is an error and <code>chksubmit(1)</code>
 will report this, exiting with a non-zero exit code. If the parsing is OK (i.e.
 valid JSON) but there is an issue in one or both of the
 <a href="https://www.json.org/json-en.html">JSON</a> files in <strong>the context of the IOCCC</strong>,
 it will report this as an <strong>error</strong>. It also does, as briefly noted above, other
 checks.</p>
-<p>If <code>chkentry(1)</code> fails to validate your submission directory your submission
+<p>If <code>chksubmit(1)</code> fails to validate your submission directory your submission
 <strong>WILL</strong> be <strong>REJECTED</strong>! This is why you <strong>MUST</strong> make sure you use the
 <code>mkiocccentry(1)</code> tool to form your submission directory.</p>
 <p>See the
@@ -2349,9 +1900,14 @@ FAQ on “<a href="#auth_json">.auth.json</a>”
 and the
 FAQ on “<a href="#info_json">.info.json</a>”
 as well as <a href="next/rules.html#rule17">Rule 17</a> for more information.</p>
+<p><strong>NOTE</strong>: the <code>chksubmit(1)</code> tool invokes <code>chkentry(1)</code> but as a contestant you
+do not need to worry about those details. One should use <code>chksubmit(1)</code> instead
+of <code>chkentry(1)</code> when validating a directory; <code>chkentry(1)</code> is for the judges
+and is what was used in IOCCC28. For IOCCC29 and beyond, <code>mkiocccentry(1)</code> uses
+<code>chksubmit(1)</code> and so should you.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="auth_json">
-<h3 id="q-3.4-what-is-a-.auth.json-file">Q 3.4: What is a <code>.auth.json</code> file?</h3>
+<h3 id="q-3.3-what-is-a-.auth.json-file">Q 3.3: What is a <code>.auth.json</code> file?</h3>
 </div>
 <p>This file is constructed by the <code>mkiocccentry(1)</code> <strong>prior to</strong> forming the xz
 compressed tarball of your submission. The <code>.auth.json</code> file contains
@@ -2411,12 +1967,12 @@ defined as <code>MKIOCCCENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
-<li><p><code>chkentry_version</code> (double quoted string)</p>
+<li><p><code>chksubmit_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry</code> that was used to validate the submission
+<li>The version of <code>chksubmit</code> that was used to validate the submission
 directory, including the <code>.auth.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chksubmit</code> version, defined
 as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
@@ -2583,7 +2139,7 @@ formed - see <code>gettimeofday(2)</code>) second.</li>
 <code>test_formed_timestamp_usec()</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c">soup/entry_util.c</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case <code>chkentry(1)</code> will report an <strong>error</strong> and your
+this is not the case <code>chksubmit(1)</code> will report an <strong>error</strong> and your
 submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>timestamp_epoch</code> (double quoted string)</p>
 <ul>
@@ -2603,35 +2159,35 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 </ul>
-<p>This file will be validated with the <code>chkentry(1)</code> tool and if there are any
+<p>This file will be validated with the <code>chksubmit(1)</code> tool and if there are any
 problems with it or the submission directory, <strong>it is an error</strong>. If there is an
 error the tarball will <strong>NOT</strong> be formed by <code>mkiocccentry</code>; otherwise the
 <code>txzchk(1)</code> tool will be executed on the tarball.</p>
 <p>This file will <strong>NOT</strong> be looked at unless the submission wins! Nonetheless, the
 file <strong>MUST</strong> be present in the submission directory and it <strong>MUST</strong> be valid
 JSON and it <strong>MUST</strong> pass all IOCCC semantics checks and all other checks
-<code>chkentry(1)</code> perform. <code>chkentry(1)</code> is used by <code>mkiocccentry(1)</code> and the judges
+<code>chksubmit(1)</code> perform. <code>chksubmit(1)</code> is used by <code>mkiocccentry(1)</code> and the judges
 will use it on the submission directory as part of the judging process.</p>
 <p>At the risk of stating the obvious, if your <code>.auth.json</code> file is invalid JSON or
-is reported invalid by <code>chkentry(1)</code>, or if your submission directory is
-reported invalid by <code>chkentry(1)</code>, your submission will almost certainly be
+is reported invalid by <code>chksubmit(1)</code>, or if your submission directory is
+reported invalid by <code>chksubmit(1)</code>, your submission will almost certainly be
 rejected for violating the <a href="next/rules.html">Rules</a> and in particular <a href="next/rules.html#rule17">Rule
 17</a>.</p>
-<p>An obvious example where <code>chkentry(1)</code> would fail to validate <code>.auth.json</code> is if
+<p>An obvious example where <code>chksubmit(1)</code> would fail to validate <code>.auth.json</code> is if
 there is a mismatch of type in the JSON file with what is expected, for
 instance, if in <code>.auth.json</code> the <code>no_comment</code> that we chose to not comment on is
 not a string or is the wrong string. Another obvious example is when things are
 out of range (see above for list). Two more examples would be if a field is
 missing or if an unknown filed is in the file. In these cases (and any others
-that must be established as valid by <code>chkentry(1)</code>) your submission would be
+that must be established as valid by <code>chksubmit(1)</code>) your submission would be
 rejected for violating <a href="next/rules.html#rule17">Rule 17</a> and in particular
-because <code>chkentry(1)</code> would not validate the <code>.auth.json</code> file (and maybe other
+because <code>chksubmit(1)</code> would not validate the <code>.auth.json</code> file (and maybe other
 things too).</p>
 <p>If you wish to <strong>verify</strong> that your <code>.auth.json</code> file is valid <strong>JSON</strong> then see the
 FAQ on “<a href="#validating_json">validating JSON documents</a>”.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="info_json">
-<h3 id="q-3.5-what-is-a-.info.json-file">Q 3.5: What is a <code>.info.json</code> file?</h3>
+<h3 id="q-3.4-what-is-a-.info.json-file">Q 3.4: What is a <code>.info.json</code> file?</h3>
 </div>
 <p>This file is constructed by the <code>mkiocccentry(1)</code> <strong>prior to</strong> forming the xz
 compressed tarball of your submission. The <code>.info.json</code> file contains
@@ -2709,12 +2265,12 @@ defined as <code>IOCCCSIZE_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
-<li><p><code>chkentry_version</code> (double quoted string)</p>
+<li><p><code>chksubmit_version</code> (double quoted string)</p>
 <ul>
-<li>The version of <code>chkentry</code> that was used to validate the submission
+<li>The version of <code>chksubmit</code> that was used to validate the submission
 directory, including the <code>.info.json</code> file.</li>
 </ul>
-<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chkentry</code> version, defined
+<p><strong>IMPORTANT:</strong> this <strong>MUST</strong> be &gt;= <strong>THIS</strong> IOCCC’s <code>chksubmit</code> version, defined
 as <code>CHKENTRY_VERSION</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h">soup/version.h</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
@@ -2987,7 +2543,7 @@ submission rejected for violating <a href="next/rules.html#rule17">Rule 17</a>!<
 <li>Any additional file that you need or want to include with your submission.</li>
 </ul>
 <p><strong>IMPORTANT:</strong> this MUST <strong>NOT</strong> match a mandatory filename (see above list)
-and <code>chkentry</code> will verify this for you; it is <strong>ALSO</strong> an <strong>error</strong> if the
+and <code>chksubmit</code> will verify this for you; it is <strong>ALSO</strong> an <strong>error</strong> if the
 filenames are not unique, not POSIX plus + safe chars only, if they are the
 wrong permission and various other things. In these cases you stand a great
 risk of having your submission rejected for violating <a href="next/rules.html#rule17">Rule
@@ -3018,7 +2574,7 @@ formed - see <code>gettimeofday(2)</code>) second.</li>
 <code>test_formed_timestamp_usec()</code> in
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c">soup/entry_util.c</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
-this is not the case <code>chkentry(1)</code> will report an <strong>error</strong> and your
+this is not the case <code>chksubmit(1)</code> will report an <strong>error</strong> and your
 submission <strong>WILL BE</strong> rejected!</p></li>
 <li><p><code>timestamp_epoch</code> (double quoted string)</p>
 <ul>
@@ -3038,28 +2594,28 @@ this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/">mkiocccentry repo</a>. If
 this is not the case your submission <strong>WILL BE</strong> rejected!</p></li>
 </ul>
-<p>This file will be validated with the <code>chkentry(1)</code> tool and if there are any
+<p>This file will be validated with the <code>chksubmit(1)</code> tool and if there are any
 problems with it or the submission directory, <strong>it is an error</strong>. If there is an
 error the tarball will <strong>NOT</strong> be formed by <code>mkiocccentry</code>; otherwise the
 <code>txzchk(1)</code> tool will be executed on the tarball.</p>
-<p>When the <a href="judges.html">Judges</a> use <code>chkentry(1)</code> on your submission directory,
+<p>When the <a href="judges.html">Judges</a> use <code>chksubmit(1)</code> on your submission directory,
 if this JSON file is invalid JSON or does not match the requirements outlined
 above, or if any other is found, your submission <strong>WILL BE</strong> rejected.</p>
-<p>An obvious example where <code>chkentry</code> would fail to validate <code>.info.json</code> is if
+<p>An obvious example where <code>chksubmit</code> would fail to validate <code>.info.json</code> is if
 there is a mismatch of type in the JSON file with what is expected, for
 instance, if in <code>.info.json</code> the <code>no_comment</code> that we chose to not comment on is
 not a string or is the wrong string. Another obvious example is when things are
 out of range (see above for list). Two more examples would be if a field is
 missing or if an unknown filed is in the file. In these cases (and any others
-that must be established as valid by <code>chkentry</code>) your submission would be
+that must be established as valid by <code>chksubmit</code>) your submission would be
 rejected for violating <a href="next/rules.html#rule17">Rule 17</a> and in particular
-because <code>chkentry</code> would not validate the <code>.info.json</code> file.</p>
+because <code>chksubmit</code> would not validate the <code>.info.json</code> file.</p>
 <p>If you wish to <strong>verify</strong> that your <code>.info.json</code> file is valid <strong>JSON</strong> then see the
 FAQ on “<a href="#validating_json">validating JSON documents</a>”.</p>
 <p>Jump to: <a href="#">top</a></p>
 <!-- we cannot use id="author_handle" because of a header in FAQ 6.6 -->
 <div id="author_handle_faq">
-<h3 id="q-3.6-what-is-an-author_handle">Q 3.6: What is an <code>author_handle</code>?</h3>
+<h3 id="q-3.5-what-is-an-author_handle">Q 3.5: What is an <code>author_handle</code>?</h3>
 </div>
 <p>An <code>author_handle</code> is string that refers to a given author and is unique to the
 IOCCC. Each author has exactly one <code>author_handle</code>.</p>
@@ -3106,7 +2662,7 @@ in the case of <a href="https://github.com/ioccc-src/winner/blob/master/2005/ano
 <p>Jump to: <a href="#">top</a></p>
 <div id="author_json">
 <div id="author_handle_json">
-<h3 id="q-3.7-what-is-an-author_handle.json-file-and-how-are-they-used">Q 3.7: What is an <code>author_handle.json</code> file and how are they used?</h3>
+<h3 id="q-3.6-what-is-an-author_handle.json-file-and-how-are-they-used">Q 3.6: What is an <code>author_handle.json</code> file and how are they used?</h3>
 </div>
 </div>
 <p><strong>TL:DR</strong>: The contents of these JSON files contain the best known
@@ -3456,7 +3012,7 @@ for information about how to update
 and/or correct IOCCC author information.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="find_author_handle">
-<h3 id="q-3.8-how-can-i-find-my-author-handle">Q 3.8: How can I find my author handle?</h3>
+<h3 id="q-3.7-how-can-i-find-my-author-handle">Q 3.7: How can I find my author handle?</h3>
 </div>
 <p>If you are an <em>author</em> of a winning <em>entry</em>, you may find your own <em>author_handle</em>
 by going to your entry in the <a href="authors.html">authors.html</a> web page and viewing the string
@@ -3490,7 +3046,7 @@ for more information on terms such as <em>author</em>, <em>entry</em>, and <em>s
 <p>Jump to: <a href="#">top</a></p>
 <!-- we cannot use id="entry_id" because of a header in FAQ 6.6 -->
 <div id="entry_id_faq">
-<h3 id="q-3.9-what-is-an-entry_id">Q 3.9: What is an <code>entry_id</code>?</h3>
+<h3 id="q-3.8-what-is-an-entry_id">Q 3.8: What is an <code>entry_id</code>?</h3>
 </div>
 <p>An <code>entry_id</code> is a string that identifies a winning entry of the IOCCC.</p>
 <p>An <code>entry_id</code> is a 4-digit year, followed by an underscore, followed by a directory name.</p>
@@ -3500,7 +3056,7 @@ of 2020 is found under the directory
 <p>The <code>entry_id</code> for that winning entry is <code>2020_ferguson2</code>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="entry_json">
-<h3 id="q-3.10-what-is-a-.entry.json-file-and-how-is-it-used">Q 3.10: What is a <code>.entry.json</code> file and how is it used?</h3>
+<h3 id="q-3.9-what-is-a-.entry.json-file-and-how-is-it-used">Q 3.9: What is a <code>.entry.json</code> file and how is it used?</h3>
 </div>
 <p><strong>TL:DR</strong>: The contents of this JSON file contain information about each winning
 entry in JSON format.</p>
@@ -3917,7 +3473,7 @@ something along those lines.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="validating_json">
 <div id="jparse">
-<h3 id="q-3.11-how-can-i-validate-any-json-document">Q 3.11: How can I validate any JSON document?</h3>
+<h3 id="q-3.10-how-can-i-validate-any-json-document">Q 3.10: How can I validate any JSON document?</h3>
 </div>
 </div>
 <p>If you want or need to verify that a JSON document (as a string or file) is
@@ -3948,7 +3504,7 @@ the tool.</p>
 repo</a> but we recommend you compile and
 install via the <code>mkiocccentry</code> repo because it has the dependencies built in,
 and because the <code>mkiocccentry</code> copy is that which is used by the current IOCCC,
-as the two can be different at times.</p>
+as the two can sometimes be different.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **28.2.22 2025-08-24**.
+This is FAQ version **28.2.23 2025-11-17**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -11,7 +11,6 @@ This is FAQ version **28.2.22 2025-08-24**.
     - **Q 0.1.3**: <a class="normal" href="#compiling_mkiocccentry">How do I compile the mkiocccentry toolkit?</a>
     - **Q 0.1.4**: <a class="normal" href="#install">How do I install mkiocccentry(1) and related tools?</a>
     - **Q 0.1.5**: <a class="normal" href="#using_mkiocccentry">How do I use mkiocccentry?</a>
-    - **Q 0.1.6**: <a class="normal" href="#minimum_versions">What are the minimum versions required for this contest?</a>
 - **Q 0.2**: <a class="normal" href="#platform">What platform should I assume for my submission?</a>
 - **Q 0.3**: <a class="normal" href="#makefile">What should I put in my submission Makefile?</a>
 - **Q 0.4**: <a class="normal" href="#remarks">What should I put in the remarks.md file of my submission?</a>
@@ -24,15 +23,14 @@ This is FAQ version **28.2.22 2025-08-24**.
 - **Q 1.1**: <a class="normal" href="#prog_c">May I use a different source or compiled filename than prog.c or prog?</a>
 - **Q 1.2**: <a class="normal" href="#markdown">What is markdown and how does the IOCCC use it?</a>
 - **Q 1.3**: <a class="normal" href="#mkiocccentry_bugs">How do I report bugs in an `mkiocccentry` tool?</a>
-- **Q 1.4**: <a class="normal" href="#subdirectories">How may I use subdirectories in my submission if Rule 17 disallows them?</a>
-- **Q 1.5**: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a>
-- **Q 1.6**: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a>
-- **Q 1.7**: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a>
-- **Q 1.8**: <a class="normal" href="#rule17">What are the details behind Rule 17?</a>
-- **Q 1.9**: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a>
-- **Q 1.10**: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a>
-- **Q 1.11**: <a class="normal" href="#download_submission">Can I download my submission tarball from the submit server?</a>
-- **Q 1.12**: <a class="normal" href="#del_submission">Can I delete a submission from the submit server?</a>
+- **Q 1.4**: <a class="normal" href="#mkiocccentry_test">How can I check if my submission passes tests without having to answer questions?</a>
+- **Q 1.5**: <a class="normal" href="#extra-files">What are extra files and how may I include additional files beyond the max allowed?</a>
+- **Q 1.6**: <a class="normal" href="#ai">May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?</a>
+- **Q 1.7**: <a class="normal" href="#rule17">What are the details behind Rule 17?</a>
+- **Q 1.8**: <a class="normal" href="#uuid">How can I avoid re-entering my UUID to mkiocccentry?</a>
+- **Q 1.9**: <a class="normal" href="#submission_dir">How can I avoid having to move or delete my submission directory for the same workdir?</a>
+- **Q 1.10**: <a class="normal" href="#download_submission">Can I download my submission tarball from the submit server?</a>
+- **Q 1.11**: <a class="normal" href="#del_submission">Can I delete a submission from the submit server?</a>
 
 
 ## 2. [IOCCC Judging process](#judging_process)
@@ -50,18 +48,17 @@ This is FAQ version **28.2.22 2025-08-24**.
 
 
 ## 3. [The mkiocccentry toolkit: finer details](#mkiocccentry_details)
-- **Q 3.0**: <a class="normal" href="#mkiocccentry_process">What is the `mkiocccentry(1)` process and what sort of checks does it perform?</a>
-- **Q 3.1**: <a class="normal" href="#txzchk">How can I validate my submission tarball?</a>
-- **Q 3.2**: <a class="normal" href="#fnamchk">What is the `fnamchk` tool?</a>
-- **Q 3.3**: <a class="normal" href="#chkentry">How can I validate my submission directory?</a>
-- **Q 3.4**: <a class="normal" href="#auth_json">What is a `.auth.json` file?</a>
-- **Q 3.5**: <a class="normal" href="#info_json">What is a `.info.json` file?</a>
-- **Q 3.6**: <a class="normal" href="#author_handle_faq">What is an `author handle`?</a>
-- **Q 3.7**: <a class="normal" href="#author_handle_json">What is an `author_handle.json` file and how are they used?</a>
-- **Q 3.8**: <a class="normal" href="#find_author_handle">How can I find my author handle?</a>
-- **Q 3.9**: <a class="normal" href="#entry_id_faq">What is an `entry_id`?</a>
-- **Q 3.10**: <a class="normal" href="#entry_json">What is a `.entry.json` file and how is it used?</a>
-- **Q 3.11**: <a class="normal" href="#jparse">How can I validate any JSON document?</a>
+- **Q 3.0**: <a class="normal" href="#txzchk">How can I validate my submission tarball?</a>
+- **Q 3.1**: <a class="normal" href="#fnamchk">What is the `fnamchk` tool?</a>
+- **Q 3.2**: <a class="normal" href="#chksubmit">How can I validate my submission directory?</a>
+- **Q 3.3**: <a class="normal" href="#auth_json">What is a `.auth.json` file?</a>
+- **Q 3.4**: <a class="normal" href="#info_json">What is a `.info.json` file?</a>
+- **Q 3.5**: <a class="normal" href="#author_handle_faq">What is an `author handle`?</a>
+- **Q 3.6**: <a class="normal" href="#author_handle_json">What is an `author_handle.json` file and how are they used?</a>
+- **Q 3.7**: <a class="normal" href="#find_author_handle">How can I find my author handle?</a>
+- **Q 3.8**: <a class="normal" href="#entry_id_faq">What is an `entry_id`?</a>
+- **Q 3.9**: <a class="normal" href="#entry_json">What is a `.entry.json` file and how is it used?</a>
+- **Q 3.10**: <a class="normal" href="#jparse">How can I validate any JSON document?</a>
 
 
 ## 4. [Compiling IOCCC entries](#compiling)
@@ -247,7 +244,7 @@ looking for mismatches. If no errors are detected it will list everything to you
 again, asking you to confirm it is good.
 
 If everything is OK, it will write the required `.auth.json` and `.info.json`
-and then run `chkentry(1)` on the directory. If all is OK it will create the
+and then run `chksubmit(1)` on the directory. If all is OK it will create the
 tarball. After the tarball is formed, it will run `txzchk(1)` on it, which runs
 `fnamchk(1)`. If all is OK, your submission tarball should be good to go.
 
@@ -256,7 +253,7 @@ FAQ on "[txzchk](#txzchk)",
 the
 FAQ on "[fnamchk](#fnamchk)"
 and the
-FAQ on "[chkentry](#chkentry)"
+FAQ on "[chksubmit](#chksubmit)"
 for more information on these important tools, if you want more information.
 
 See the
@@ -342,12 +339,13 @@ above) run as either `sudo(8)` or root `make install`:
 ```
 
 If everything goes well you should be able to run `mkiocccentry(1)`,
-`txzchk(1)`, `chkentry(1)` and all the other installed tools from any directory,
+`txzchk(1)`, `chksubmit(1)` and all the other installed tools from any directory,
 and the tools that rely on other tools will be able to find those required tools
 from any directory too.
 
 Some tools like `bug_report.sh` and `hostchk.sh` are not meant to be installed
-and will not work from any directory, however.
+and will not work from any directory, however, nor should they be installed
+(some previously were but this was fixed post IOCCC28 and prior to IOCCC29).
 
 
 Jump to: [top](#)
@@ -410,34 +408,12 @@ looked at if the submission wins), run some tests and run a number of other
 tools, as mentioned above, and as described in the "[finer
 details](#mkiocccentry_details)" section.
 
-See also the
-FAQ on "[what the minimum required versions are for this
-contest](#minimum_versions)"
-for more details on how to verify you have the correct versions for this
-contest.
+**PLEASE NOTE**: if your submission directory (or topdir) has certain errors the
+mkiocccentry tool will exit with a fatal error, asking you to fix the problem
+first.
 
 
 Jump to: [top](#)
-
-
-<div id="minimum_versions">
-#### Q 0.1.6: What are the minimum versions required for this contest?
-</div>
-
-At minimum, the tools **MUST** be version:
-
-- `iocccsize(1)`: `"28.15 2024-06-27"`.
-- `mkiocccentry(1)`: `"2.0.1 2025-03-02"`.
-- `fnamchk(1)`: `"2.0.0 2025-02-28"`.
-- `txzchk(1)`: `"2.0.1 2025-03-02"`.
-- `chkentry(1)`: `"2.0.1 2025-03-02"`.
-
-See also the
-FAQ on "[obtaining the latest release of the toolkit](#obtaining_mkiocccentry)".
-
-
-Jump to: [top](#)
-
 
 <div id="SUS">
 <div id="platform">
@@ -645,7 +621,7 @@ Jump to: [top](#)
 
 Files in your submission tarball **MUST** be
 specific permissions. In particular: directories **MUST** be `drwxr-xr-x` (i.e.
-`0755`), the optional files, `try.sh` or `try.alt.sh`, if provided, **MUST** be
+`0755`), the optional files, files ending with `.sh`, if provided, **MUST** be
 `-r-xr-xr-x` (i.e. `0555`) and all other files **MUST** be `-r--r--r--` (i.e.
 `0444`).
 
@@ -806,28 +782,8 @@ for more thorough details on bug reporting.
 
 Jump to: [top](#)
 
-
-<div id="subdirectories">
-#### Q 1.4: How may I use subdirectories in my submission if Rule 17 disallows them?
-</div>
-
-In order to submit a subdirectory, you may simply include a tarball. As long as
-the maximum depth of all files does not exceed the maximum, defined as
-`MAX_PATH_DEPTH`, the maximum filename length (a single component not counting
-the `/`) of all files does not exceed `MAX_FILENAME_LEN` and
-the maximum path length (all components) of all files does not exceed
-`MAX_PATH_LEN`. These macros are defined in
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h).
-
-
-See also the
-FAQ on "[Rule 17](#rule17)",
-the [guidelines](next/guidelines.html) and [Rule 17](next/rules.html#rule17)
-itself.
-
-
 <div id="mkiocccentry_test">
-#### Q 1.5: How can I check if my submission passes tests without having to answer questions?
+#### Q 1.4: How can I check if my submission passes tests without having to answer questions?
 </div>
 
 In case you do not have a UUID or you simply want to test if `mkiocccentry(1)`
@@ -847,7 +803,7 @@ An example use of this option is:
 ```
 
 This will run the tests that `mkiocccentry(1)`, write the JSON files, use
-`chkentry(1)`, package the tarball and run `txzchk(1)` on it.
+`chksubmit(1)`, package the tarball and run `txzchk(1)` on it.
 
 If you don't want to deal with the having to move or delete the submission
 directory, you could instead do:
@@ -865,7 +821,7 @@ FAQ on "[.info.json](#info_json)",
 the
 FAQ on "[.auth.json](#auth_json)",
 the
-FAQ on "[chkentry](#chkentry),
+FAQ on "[chksubmit](#chksubmit),
 the
 FAQ on "[txzchk](#txzchk)"
 and the
@@ -874,32 +830,28 @@ for more details.
 
 
 <div id="extra-files">
-# What are extra files and how may I include additional files beyond the max allowed?
+# 1.5: What are extra files and how may I include additional files beyond the max allowed?
 </div>
 
-<p class="leftbar">
-Extra files are defined as files that are not the required files (`prog.c`,
-`Makefile`, `remarks.md` and the two generated by `mkiocccentry(1)` `.info.json`
-and `.auth.json`) and files that are also not the optional files (`try.sh`,
-`prog.alt.c` and `try.alt.sh`).
-</p>
+Extra files are defined as files that are not the free files (the required files
+`prog.c`, `Makefile`, `remarks.md` and the optional `try.sh`, `try.alt.sh`,
+`prog.alt.c` and the two generated by `mkiocccentry(1)` `.info.json` and
+`.auth.json`).
 
-<p class="leftbar">
 **NOTE**: optional filenames are only optional if they are in the submission top
 level directory.
-</p>
 
-<p class="leftbar">
+You may provide up to 31 extra files.
+
 If you need to include more files than this, you may include a tarball that
 itself is an extra file, meaning it counts **AS** an extra file.
 This file does **NOT** need to pass the `txzchk(1)` tests; only your submission
-tarball needs to pass these tests.
-</p>
+tarball needs to pass these tests. However see below if you do do this.
 
 Please pay careful attention to [Rule 17](next/rules.html#rule17) and in
-particular the part about the [maximum number of files per
-submission](#max-files), which not only discusses the maximum
-number of files (including extra files) but also specific rules you must follow
+particular the part about the maximum number of files per
+submission, which not only discusses the maximum
+number of files but also specific rules you must follow
 if you do include a tarball. Not following these points puts you at great risk
 of violating [Rule 17](next/rules.html#rule17)!
 
@@ -921,7 +873,7 @@ Jump to: [top](#)
 
 <div id="ai">
 <div id="llm">
-### Q 1.7: May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?
+### Q 1.6: May I use AI, LLM, Virtual coding assistants, or similar tools to write my submission?
 </div>
 </div>
 
@@ -940,87 +892,79 @@ Jump to: [top](#)
 
 
 <div id="rule17">
-### Q 1.8: What are details behind Rule 17?
+### Q 1.7: What are details behind Rule 17?
 </div>
 
 
 ### TL;DR Rule 17 - Use `mkiocccentry(1)`
 
-<p class="leftbar">
-This is a **COMPLEX** rule.  **Violating this rule will cause your submission to
-be REJECTED!** To help you avoid such a rejection, you are **HIGHLY ENCOURAGED**
+This is a **COMPLEX** rule.  **Violating this rule WILL CAUSE YOUR SUBMISSION TO
+BE REJECTED!** To help you avoid such a rejection, you are **HIGHLY ENCOURAGED**
 to use the `mkiocccentry(1)` tool, based on the latest release of the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry), to form your
 submission's xz compressed tarball.
-</p>
 
-<p class="leftbar">
 The [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 contains **IMPORTANT** tools and libraries such as:
-</p>
 
-* <p class="leftbar">`mkiocccentry(1)`</p>
-* <p class="leftbar">`iocccsize(1)`</p>
-* <p class="leftbar">`txzchk(1)`</p>
-* <p class="leftbar">`fnamchk(1)`</p>
-* <p class="leftbar">`jparse(3)`</p>
-* <p class="leftbar">`chkentry(1)` (which uses `jparse(3)`)</p>
+- `mkiocccentry(1)`
+- `iocccsize(1)`
+- `txzchk(1)`
+- `fnamchk(1)`
+- `jparse(3)`
+- `chksubmit(1)` (which uses `jparse(3)` and is a wrapper to `chkentry(1)`)
 
-<p class="leftbar">
 The above mentioned tools will help you verify that your submission
 conforms to [Rule 17](next/rules.html#rule17).  Each of these tool has a `-h`
 option that provides command line help. For additional details of each tool, see
 its man page, and in some cases, the [IOCCC guidelines](next/guidelines.html).
-</p>
 
-<p class="leftbar">
-The maximum number of **extra files** is 31. See the [maximum number of extra
-files section](#max-files) below for finer details and the
-FAQ on "[what extra files are and how to include additional files](#extra-files)",
-should you need to include more files than this maximum.
-</p>
+The maximum number of **extra files** is 31. See the
+FAQ on "[extra files](#extra-files)"
+for more details.
 
+Below we will list more details and link to relevant FAQs as well.
 
 Jump to: [top](#)
 
 
 ### Rule 17 - The COMPLEX details
 
-<p class="leftbar">
 Each submission **MUST** be in the form of an xz compressed tarball.
 The xz compressed tarball filename **MUST** be of the form:
 `^submit.username-slot_num.[1-9][0-9]{9,}.txz$`.
 
-<p class="leftbar">
 ... where _`username`_ is your IOCCC registration username **in the form of a
 [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)** (see
 [RFC 9562](https://datatracker.ietf.org/doc/html/rfc9562) for
 details), and where _`slot_num`_ is a single decimal digit integer
 (i.e., >= `0` and <= `9`).
-</p>
 
-<p class="leftbar">
 In particular, `username` is in the form of:
 `xxxxxxxx-xxxx-4xxx-Nxxx-xxxxxxxxxxxx` where `'x'` is a hex digit in the range
 of `[0-9a-f]`, 4 is the UUID version, and `N` is one of `8`, `9`, `a`, or `b`.
-</p>
 
-<p class="leftbar">
 Your xz compressed tarball **MUST** contain, **at a minimum**, the following
-files, in the **TOP LEVEL** directory:
-</p>
+files, in the **TOP LEVEL** directory (see below for more details on each file
+in this list):
 
-* <p class="leftbar">`prog.c`</p>
-* <p class="leftbar">`Makefile`</p>
-* <p class="leftbar">`remarks.md`</p>
-* <p class="leftbar">`.auth.json`</p>
-* <p class="leftbar">`.info.json`</p>
+- `prog.c`: your submission code.
+- `Makefile`: your Makefile that is based on
+[next/Makefile.example](next/Makefile.example).
+- `remarks.md`: your remarks about the submission in markdown format.
+- `.auth.json`: a JSON file about the author details (which will only be looked at by
+the judges IF it wins), generated by the `mkiocccentry(1)` tool.
+- `.info.json`: a JSON file about the submission itself which will be looked at
+by the judges during judging.
 
-<p class="leftbar">
-`prog.c` is of course your submission program.
-</p>
+Note that these do not count against extra files. Neither do the `try.sh`,
+`prog.alt.c` or `try.alt.sh`, should you provide them, and they are in the top
+level directory. See the
+FAQ on "[extra files](#extra-files)"
+for more details on what this means, should you need to include additional files.
 
-<p class="leftbar">
+The `prog.c` is probably pretty obvious if you're here. :-)
+
 The `Makefile` **MUST** be a **non**-empty file in **[GNU
 Makefile](https://www.gnu.org/software/make/manual/make.html)** format. See the
 [Makefile section in the guidelines](next/guidelines.html#makefile),
@@ -1029,9 +973,7 @@ FAQ on "[submission Makefiles](#submission_makefile)"
 and the
 FAQ on "[IOCCC make&lpar;1&rpar; compatibility](#make_compatibility)"
 for help.
-</p>
 
-<p class="leftbar">
 The `remarks.md` **MUST** be a **non**-empty file in markdown format
 (`mkiocccentry(1)` only checks the file size but if you do not have any text in
 it you still risk violating this rule).  See also
@@ -1040,225 +982,174 @@ FAQ on "[remarks.md](#remarks_md)",
 our
 FAQ on "[markdown](#markdown)"
 and our [markdown guidelines](markdown.html).
-</p>
 
-<p class="leftbar">
 See also the [markdown syntax](https://www.markdownguide.org/basic-syntax) guide
 and the [CommonMark Spec](https://spec.commonmark.org/current/).
-</p>
 
-<p class="leftbar">
 The `.auth.json` file is created by `mkiocccentry(1)` and it holds information
 about the author(s) of the submission. It will **ONLY** be looked at if your
 submission wins but it **MUST** still be valid according to `jparse(3)` **AND**
-`chkentry(1)`.
-</p>
+`chksubmit(1)` even if it does not win; if `chksubmit(1)` does not validate this
+file your submission **WILL** be rejected for violating Rule 17! See the
+FAQ on "[.auth.json](#auth.json)"
+for more details on this file.
 
-<p class="leftbar">
 The `.info.json` file is created by `mkiocccentry(1)` and it holds information
 about the submission itself. It also **MUST** be valid according to **BOTH**
-`jparse(3)` **AND** `chkentry(1)`.
-</p>
+`jparse(3)` **AND** `chksubmit(1)`. See the
+FAQ on "[.info.json](#info.json)"
+for more details on this file.
 
-<p class="leftbar">
+See the
+FAQ on "[chksubmit&lpar;1&rpar;](#chksubmit)"
+for more details on this important tool.
+
 For the complete `mkiocccentry(1)` process, see the
 FAQ on the "[mkiocccentry process](#mkiocccentry_process)".
-</p>
 
-<p class="leftbar">
 The tool performs a lot of checks, both directly and indirectly, and if it or
 any other tool detects **ANY** problem, you are **HIGHLY** encouraged to fix it
 and try again.
-</p>
 
-<p class="leftbar">
 On the other hand, some issues are errors and you **MUST** fix those.
-</p>
 
-<p class="leftbar">
-If you do use `mkiocccentry(1)` and you run into a problem, you might see the
-FAQ on "[how to ask a question about the IOCCC rules, guidelines and
-tools](#questions)".
-If you believe you have encountered a bug, feel free to open a bug report at the
-[mkiocccentry repo issues
+If you do use `mkiocccentry(1)` (which we STRONGLY recommend you do) and you run
+into a problem, you might see the FAQ on "[how to ask a question about the IOCCC
+rules, guidelines and tools](#questions)".  If you believe you have encountered
+a bug, feel free to open a bug report at the [mkiocccentry repo issues
 page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
-</p>
 
-<p class="leftbar">
 The xz compressed tarball file **MUST** be <= **3999971** octets in size.
-</p>
 
-<p class="leftbar">
 When your submission's xz compressed tarball is uncompressed, the total size of
 your submission (the sum of the size of the program source code,
 remarks/comments, Makefile and all other files) **MUST** be <= **28314624**
 octets (**27651K**) in size.
-</p>
 
-<p class="leftbar">
 One of the many checks `txzchk(1)` performs is summing up the total size. Of
 course if you manipulate the tarball to get past this you risk violating this
 rule.
-</p>
 
-<p class="leftbar">
 Your submission's xz compressed tarball **MUST** pass the `txzchk(1)` tests. See
 the [guidelines on txzchk&lpar;1&rpar;](next/guidelines.html#txzchk) for more details on this tool.
-</p>
 
-<p class="leftbar">
-**IMPORTANT**: Make **SURE** you have the most recent version of the
+**IMPORTANT**: make **SURE** you have the most recent version of the
 `mkiocccentry` toolkit! Not doing so will put you at a great risk of violating
 this rule! See the
 FAQs on "[obtaining, compiling, installing and using the mkiocccentry toolkit](#mkiocccentry)"
 for more details.
-</p>
 
-<p class="leftbar">
 You are **HIGHLY ENCOURAGED** to use the `mkiocccentry(1)` tool to form your
 submission's xz compressed tarball. See the [guidelines on
 mkiocccentry&lpar;1&rpar;](next/guidelines.html#mkiocccentry) for
 more details on this tool and see the [mkiocccentry
 repo](https://github.com/ioccc-src/mkiocccentry) for the toolkit itself.
-</p>
 
-<p class="leftbar">
-Your entry **MAY** have subdirectories, depending on the depth and total length of
-the filenames. Certain directories like `.git`, `RCCS`, `CVS` and `.svn`
-(amongst others) are skipped. For more information, see the
+Your entry **MAY** have subdirectories, depending on the depth (a max depth,
+noted below) and total length of the filenames. Certain directories like `.git`,
+`RCCS`, `CVS` and `.svn` (amongst others) are skipped. For more information, see
+the
 FAQ on "[subdirectories](#subdirectories)".
-</p>
 
-<p class="leftbar">
 With the exception of those generated by the `mkiocccentry(1)` tool or the tools
 it or any other tool invokes, files in your submission **MUST**:
-</p>
 
-* <p class="leftbar">Be <= **38** characters in length.</p>
-* <p class="leftbar">**NOT** have a leading **`/`**.</p>
-* <p class="leftbar">**NOT** contain a path component of: **`.`** (that is, with
+- Be <= **38** characters in length.
+- **NOT** have a leading **`/`**.
+- **NOT** contain a path component of: **`.`** (that is, with
 the exception of files generated by `mkiocccentry(1)` itself, it must have
-**NO** dot file including `.` itself).</p>
-* <p class="leftbar">**NOT** contain a path component of: **`..`** (that is,
-**NO** path component that matches the regular expression **`^..$`**).</p>
-* <p class="leftbar">Match the regular expression
+**NO** dot file including `.` itself).
+- **NOT** contain a path component of: **`..`** (that is,
+**NO** path component that matches the regular expression **`^..$`**).
+- Match the regular expression
 `^[0-9A-Za-z]+[0-9A-Za-z_+.-]*$` (again, excluding files generated by
-`mkiocccentry(1)`).</p>
-* <p class="leftbar">**NOT** have a directory/file depth > 4.</p>
-* <p class="leftbar">**NOT** have a total **path** length > 99 characters.</p>
+`mkiocccentry(1)`).
+- **NOT** have a directory/file depth > 4.
+- **NOT** have a total **path** length > 99 characters.
 
-<p class="leftbar">
-The submission tarball created by `mkiocccentry(1)` **MUST** have
-the additional files that are generated by the `mkiocccentry(1)` tool:
-</p>
+Again, the submission tarball **MUST** have the mkiocccentry(1) created JSON
+files:
 
-* <p class="leftbar">`.auth.json` which contains information about the author or
+- `.auth.json` which contains information about the author or
 authors (that will only be looked at if the submission wins).</p>
-* <p class="leftbar">`.info.json` which contains information about the
+- `.info.json` which contains information about the
 submission.</p>
 
-<p class="leftbar">
-The `chkentry(1)` tool will validate these two JSON files, and do other checks
+The `chksubmit(1)` tool will validate these two JSON files, and do other checks
 on your submission directory as well, _prior to_ `mkiocccentry(1)` forming the
-tarball.
-</p>
+tarball. See the
+FAQ on "[chksubmit&lpar;1&rpar;](#chksubmit)"
+for more details on this tool.
 
-<p class="leftbar">
 Files and directories in your submission tarball **MUST** be specific
 permissions and `mkiocccentry(1)` does this for you. In particular: directories
-**MUST** be `drwxr-xr-x` (i.e. `0755`); the optional files, not counting
-`prog.alt.c` (i.e. `try.sh` and `try.alt.sh`), if provided, **MUST** be
+**MUST** be `drwxr-xr-x` (i.e. `0755`); any file ending with `.sh` **MUST** be
 `-r-xr-xr-x` (i.e. `0555`); and all other files **MUST** be `-r--r--r--` (i.e.
-`0444`).  If any file or directory does not have the correct permissions, your submission **WILL**
-be rejected for violating [Rule 17](next/rules.html#rule17)!
-</p>
+`0444`).  If any file or directory does not have the correct permissions, your
+submission **WILL** be rejected for violating [Rule 17](next/rules.html#rule17)!
 
-<p class="leftbar">
 After `mkiocccentry(1)` creates the directories and copies the files with these
 modes, it also verifies them after the fact and if they are not correct it is an
 **error**.
-</p>
 
-<p class="leftbar">
 If you do need different permissions, then see the
 FAQ on "[file permissions](#file_perms)". Also keep in mind
 [Rule 4](next/rules.html#rule4), [Rule 5](next/rules.html#rule5) and [Rule 21](next/rules.html#rule21).
-</p>
 
-<p class="leftbar">
 The `txzchk(1)` tool will also verify file/directory permissions (and many other
-things) for you, and so will `chkentry(1)` (along with other checks on files and
+things) for you, and so will `chksubmit(1)` (along with other checks on files and
 directories in your submission directory, including the two required JSON files,
 `.auth.json` and `.info.json`). If these checks fail it is an **error**
 and `mkiocccentry(1)` will abort. In this case (it fails and you used
 `mkiocccentry(1)`) it is very **possibly** a bug; please [report it as a bug at
 the mkiocccentry issues
 page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
-</p>
 
-<p class="leftbar">
 The tarball filename **MUST** pass `fnamchk(1)`; the tool `txzchk(1)`
 will run `fnamchk(1)` as part of its algorithm. If you use `mkiocccentry(1)`
 there should be no problem but if you were to package things manually it is
 possible there could be a problem and this poses a big risk of violating [Rule
 17](next/rules.html#rule17).
-</p>
 
-<p class="leftbar">
 The `fnamchk(1)`, which `txzchk(1)` executes, will verify that the
 filename is correct. But if you do package your tarball manually, and you have a
 mismatch in what is in the tarball and the name, `txzchk(1)` will flag the
 discrepancy as an error and exit with non-zero.
-</p>
 
-<p class="leftbar">
 These checks **MUST PASS**. If they do not you stand a significant chance of
 having your submission rejected for violating [Rule 17](next/rules.html#rule17)!
-</p>
-
 
 <div id="max-files">
 #### Maximum number of files per submission
 </div>
 
-<p class="leftbar">
 The maximum number of files your submission tarball may contain, not counting
-the optional files (`prog.alt.c`, `try.sh`, `try.alt.sh`) and the mandatory
-files (`prog.c`, `Makefile`, `remarks.md` plus the `mkiocccentry(1)` generated
-files `.auth.json` and `.info.json`), is 31. This is defined in the macro
+the free files (`prog.c`, `remarks.md`, `Makefile`, `prog.alt.c`, `try.sh`,
+`try.alt.sh`,, `.info.json` and `.auth.json`) is 31. This is defined in the macro
 `MAX_EXTRA_FILE_COUNT` in
 [soup/limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)
 in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry). See the
 FAQ on "[what extra files are and how to include more](#extra-files)"
 if you need to include more files.
-</p>
 
-<p class="leftbar">
 If you do include a tarball that takes your extra files count over the maximum,
 you **MUST** explain this in your `remarks.md` file! **PLEASE** do not include a
 tarball with extra files for a test-suite; instead mention in your remarks that
 you have extra files for a test-suite that can be included should your
 submission win. Of course if you don't need that many files for a test-suite you
 are more than welcome to include those files in your submission.
-</p>
 
-<p class="leftbar">
 If you need to extract a tarball by some Makefile, or perhaps the program
 itself, then `make clobber` **MUST** remove everything that the extraction
 created!
-</p>
 
-<p class="leftbar">
 Tarballs **MUST** only create files and directories _under_ the submission
 directory. They may **NOT** contain absolute paths (paths that start with `/`)!
 `txzchk` does **NOT** check other tarballs so **YOU MUST** verify these details
 yourself.
-</p>
 
-<p class="leftbar">
 **IMPORTANT REMINDER**: **MAKE SURE** your tarball does not reveal who you are!
 The `mkiocccentry(1)` tool uses the v7 format. For instance you might try:
-</p>
 
 ``` <!---sh-->
     tar --format=v7 -cJf foo.txz directory
@@ -1266,32 +1157,24 @@ The `mkiocccentry(1)` tool uses the v7 format. For instance you might try:
 
 <hr style="width:50%;text-align:left;margin-left:0">
 
-
-<p class="leftbar">
 **IMPORTANT**: where [Rule 17](next/rules.html#rule17) and the tools from the latest
 release of the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 conflict, the [IOCCC judges](judges.html) will use their best judgment which
 is likely to favor [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) code.
-</p>
 
-<p class="leftbar">
 This means you should **MAKE SURE** that you use `mkiocccentry(1)` to
 package your submission; `mkiocccentry(1)` will run the above mentioned tools
 (that do not act on the tarball) **before** creating the tarball and after the
 tarball is created it will then verify that the tarball is okay by running
 `txzchk(1)` on it. If any step fails it is an error and submitting the
 submission will result in violating this rule.
-</p>
 
-<p class="leftbar">
 **MAKE SURE** you use the correct release of the repository; you should do this
 **AFTER** the contest opens (pull any changes or if you prefer download the
 repository via the download option at GitHub). See the
 FAQ on "[obtaining the latest release of mkiocccentry](#obtaining_mkiocccentry)"
 for more help on ensuring you do have the most up to date release.
-</p>
 
-<p class="leftbar">
 We recommend that you run `make` and then install the tools (and man pages) via
 `make install` (as root or using `sudo(8)`) to help you run these tools from
 your submission's directory (or any other directory). The `make install` will
@@ -1299,32 +1182,27 @@ install in `/usr/local`.  However, **you do not have** to install them, but in
 that case you'll have to run it from the toolkit's directory or use the correct
 options to specify the path to the necessary tools, and also specify the path to
 your files, which can be problematic.
-</p>
 
-<p class="leftbar">
 These tools will link in the `jparse(3)` library, the `dbg` library and the
-`dyn_array` library; `chkentry(1)` uses the JSON parser (`jparse(3)`) to
-validate and parse the [JSON](https://www.json.org/json-en.html) files but the
-other tools use parts of the `jparse` utility functions as well.
-</p>
+`dyn_array` library as well as the `pr(3)` and `soup(3)` libraries;
+`chksubmit(1)` uses the JSON parser (`jparse(3)`) to validate and parse the
+[JSON](https://www.json.org/json-en.html) files but the other tools use parts of
+the `jparse` utility functions as well.
 
-<p class="leftbar">
 If you run into a problem with one or more of these tools, **PLEASE** [report it
 as a bug at the mkiocccentry issues
 page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E),
 **making sure to run `bug_report.sh`**. See the [guidelines](next/guidelines.html)
 for help here and also read our
 FAQ on "[mkiocccentry repo bugs](#mkiocccentry_bugs)".
-</p>
 
-<p class="leftbar">At the risk of stating the obvious: submissions that violate [Rule
+At the risk of stating the obvious: submissions that violate [Rule
 17](next/rules.html#rule17) **WILL BE REJECTED**, so **BE SURE** to use the latest release of the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry), to form and test
 your submission's xz compressed tarball. Do **NOT** assume you have the most
 recent release without pulling or downloading via GitHub and do **MAKE SURE** you
 do this **AFTER** the [contest status](status.html) has changed to
 [open](#open).
-</p>
 
 
 Jump to: [top](#)
@@ -1332,7 +1210,7 @@ Jump to: [top](#)
 
 <div id="uuid">
 <div id="uuid_file">
-### Q 1.9: How can I avoid re-entering my UUID to mkiocccentry?
+### Q 1.8: How can I avoid re-entering my UUID to mkiocccentry?
 </div>
 </div>
 
@@ -1368,7 +1246,7 @@ FAQ on "[the answers file](#answers_file)".
 Jump to: [top](#)
 
 <div id="submission_dir">
-### Q 1.10: How can I avoid having to move or delete my submission directory for the same workdir?
+### Q 1.9: How can I avoid having to move or delete my submission directory for the same workdir?
 </div>
 
 If you wish to not have to worry about removing or moving the submission
@@ -1389,7 +1267,7 @@ specify the path by the `-r rm` option.
 Jump to: [top](#)
 
 <div id="download_submission">
-### Q 1.11: Can I download my submission tarball from the submit server?
+### Q 1.10: Can I download my submission tarball from the submit server?
 </div>
 
 We do not support this. If you need to verify your submission, then
@@ -1871,306 +1749,10 @@ Jump to: [top](#)
 Jump to: [top](#)
 
 
-<div id="mkiocccentry_process">
-### Q 3.0: What is the `mkiocccentry(1)` process and what sort of checks does it perform?
-</div>
-
-**TL;DR**: the program will make a submission directory (name based on the
-username and slot number you provide) under the workdir and then switch to the
-topdir. It will then create lists of files and directories to present to you, to
-verify everything is in order. If something is not allowed (bad filename for
-example) or an error occurs (missing required file for example) you will be
-notified of this. After you verify everything is okay the files/directories
-found will be copied/made and it will then switch to the submission directory.
-In the submission directory it first runs `make clobber` and then scans the
-directory hierarchy again, verifying things are still okay. When done it will
-ask you to verify things still look OK to you too. If all is good it'll ask you
-for more information about the author(s). Next the two required JSON files
-`.auth.json` and `.info.json` will be created. After that `chkentry(1)` will be
-run on the directory. If all is good it'll give you another chance to say the
-files/directories look good and if you answer yes it'll create the tarball and
-run `txzchk` on it.
-
-In most cases the program will prompt you to verify your input is correct. In
-the case of author information (which will only be looked at if you win) you
-will be asked to verify country code prior to being asked the other questions.
-If you fail to enter other author information correctly you will be prompted
-right away to fix it. Afterwards, when the author information is collected, it
-will ask you to confirm. This procedure happens for each author.
-
-In the case of `-i answers` option being used, you will not have to put in most
-information but you will have to confirm the lists of files and directories are
-correct, unless you use `-Y` (which we do not recommend).
-
-If `topdir` is not a readable (`+r`), searchable (`+x`) directory it is an error.
-
-If `workdir` is not a writable (`+w`), searchable (`+x`) directory it is an error.
-
-If `workdir` is in `topdir` the program will not descend into it (the workdir).
-
-If `topdir` is the same (by device and inode) as `workdir` it is an error.
-If somehow `topdir` or `workdir` is found under the submission directory (by
-device and inode) it is an error (and you should report it as a bug.
-
-In more detail the `mkiocccentry(1)` tool performs the below steps.
-
-0. Ask the user for a submission ID (see the [how to register](next/register.html)
-for more details on how to obtain this and [Rule 17](next/rules.html#rule17) for
-the importance of this).
-    * If this is an invalid UUID (malformed), you will be asked to correct it
-    until it is.
-    * If the `-u uuidfile` option is used and the UUID in the file `uuidfile` is not malformed,
-    the user will not be prompted for a UUID.
-    * If the `-U uuidstr` option is used and the UUID is not malformed, the user
-    will not be prompted for a UUID.
-    * The `-u` and `-U` options may not be used with any option that reads from
-    an answers file (`-i answers`, `-d`, `-s seed`).
-1. Ask the user for the submission slot (the submission number; see [how to
-register](next/register.html) and [Rule 17](next/rules.html#rule17) for more details).
-    * If this is out of range (see `MAX_SUBMIT_SLOT` in
-    [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h))
-    you will be asked to correct it until it is.
-2. Make the submission directory under `topdir` in the form of
-`workdir/submit.USERNAME-SLOT`.
-    * If this directory already exists it is an error, unless the `-x` option is
-    used, in which case it'll be deleted.
-    * If for some reason the default `rm` paths do not work, you may use `-r rm`
-    to specify the path to a working `rm` command.
-3. Change to the `topdir`.
-4. Traverse the directory, creating lists of ignored/forbidden
-files/directories/symlinks as well as a list directories to make and a list of
-files to copy to the submission directory (and if (sub)directories are found
-with files, copy those files to their respective directory). Note the following:
-    * If the depth is too deep it is an error (see `MAX_PATH_DEPTH` in
-    [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-    * If there are too many extra directories (total count not including the
-    submission directory itself, unrelated to `MAX_PATH_DEPTH` above) it is an
-    error (see `MAX_EXTRA_DIR_COUNT` in
-    [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-    * If the max path length is <= 0 it is an error (and a bug!).
-    * If the max depth is <= 0 it is an error (and a bug!).
-    * If the max filename length is <= 0 it is an error (and a bug!).
-    * If a path is NULL it is an error.
-    * If a path is an empty string it is an error.
-    * If the path length (i.e. `strlen(path)` where path starts after the
-    initial `./` of the path in the `topdir`) is too long it is an error (see `MAX_PATH_LEN` in
-    [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-    * If a filename (last component of the path) is too long it is an error (see `MAX_FILENAME_LEN` in
-    [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-    * If a filename or directory name is not a sane relative path, not allowed
-    or will not be added for some other reason, it will be added to a relevant list to show to
-    the user later, to let them know it will not be added to the submission. By `relative` we mean it
-    must not start with `/` (which shouldn't happen even if you give an absolute
-    path) and by `sane` we mean that each component must match the regexp: `^[0-9A-Za-z]+[0-9A-Za-z_+.-]*$`.
-    * If a directory is unreadable it is an error.
-    * If a directory causes a cycle in the tree it is an error.
-    * If `stat(2)` on the path fails it is an error.
-    * If `prog.c`, `Makefile` or `remarks.md` is/are not found it is an error.
-    * If too many files that are not `prog.c`, `Makefile`, `remarks.md`,
-    `try.sh`, `prog.alt.c` or `try.alt.sh` are found, it is an error (see
-    `MAX_EXTRA_FILE_COUNT` in
-    [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-    * Symlinks are not allowed but it is not an error (they will be added to a
-    list and ignored).
-    * If any file type other than a regular file, a directory or a symlink is
-    encountered it is an error.
-    * If there is an unknown error it is an error :-)
-5. Show each list to the user, asking if this is okay. The lists include:
-    * Ignored directories (those like `.git`, `CVS`, `RCCS`, `.svn` and various
-    others).
-    * Unsafe directory names that will not be added (i.e. those that are not
-    POSIX plus + safe chars only; see above step (4)). This includes directories
-    starting with a `.`.
-    * Forbidden files such as `index.html`, `README.md`, `prog`, `prog.alt`.
-    * Unsafe filenames that will not be added (i.e. those that are not POSIX
-    plus + safe chars only; see above step (4)). This includes files starting
-    with `.`.
-    * Symlinks found (these are not allowed).
-    * Directories to be made.
-    * Required files (`prog.c`, `Makefile` and `remarks.md`) to be copied.
-    * Non-required files to be copied.
-    * The user is asked to verify each list, including the lists of directories
-    and files to be made/copied, and if the user says it is not OK the program will abort.
-6. Make any directories if necessary (under
-`workdir/submit.USERNAME-SLOT` i.e. the submission directory).
-    * Directories **MUST** be and are made with mode `0755`.
-    * If any directory is not this mode `txzchk(1)` will flag it (and so will
-    `mkiocccentry(1)`).
-7. The non-ignored files are copied to their respective directories under the
-submission directory.
-    * `try.sh` and `try.alt.sh` **MUST** be and are copied as mode `0555`.
-    * All other files **MUST** be and are copied as mode `0444`.
-    * Anything else will be flagged by `txzchk(1)` (and it'll be flagged by
-    `mkiocccentry(1)` too).
-8. `cd submit.USERNAME-SLOT` (i.e. switch to submission directory).
-9. `make -f Makefile clobber`.
-    * If this fails it is not an error but you are warned about it (it is an error only if the `Makefile`
-    does not a regular readable file but; even so, see [Rule 20](next/rules.html#rule20).
-10. Traverse the new tree from `.` (the submission directory) with additional steps from (4).
-    * If any file has an ignored directory name in it, it is an error.
-    * If a symlink is found it is an error.
-    * If any file type other than a directory or regular file exists it is an
-    error.
-    * If a forbidden filename exists it is an error.
-    * If any file or directory starts with `/` or is not POSIX plus + safe chars
-    only (see (4) above) it is an error (though this should not actually happen
-    unless you're doing something funny).
-    * If the directory depth becomes too deep it is an error.
-    * If `prog.c`, `Makefile` or `remarks.md` are missing (or not readable
-    regular files) it is an error.
-    * If an optional file is a directory it is an error.
-    * If a file or directory is in the submission directory that was not found
-    in the topdir it is an error.
-    * If a file or directory found in the topdir is not in the submission
-    directory it is an error.
-    * If a file or directory in the submission directory is a different type
-    from the topdir (e.g. if `foo` was a directory in topdir but in the submission
-    directory it is a file) it is an error.
-    * If a file (based on the name) or directory has the wrong permission it is
-    an error (see (7) above).
-    * If `fts_read(3)` reports something as a directory but it's not a directory
-    it is an error (and likewise if it reports something as a file and it's not
-    a file it is an error) - though this should never happen.
-    * If a directory name (full path from the submission directory) is the name
-    of a mandatory file it is an error.
-    * If a directory name (full path from the submission directory) is the name
-    of of an optional file it is an error.
-    * `iocccsize(1)` (via the `mkiocccentry(1)` function `check_prog_c()`) will
-    be run on your `prog.c`, allowing you to override any warnings; if you do not
-    override an issue flagged it is an error but if warnings from `check_prog_c()`
-    are ignored you risk violating the [Rules](next/rules.html), including [Rule
-    2](next/rules.html#rule2).
-    * `check_Makefile()` will be run on `Makefile`; if it is a non-readable or
-    empty file it is an error but otherwise you may override any warnings
-    (risking violating the [Rules](next/rules.html), especially [Rule
-    17](next/rules.html#rule17) and [Rule 20](next/rules.html#rule20)).
-    * `check_remarks_md()` will be run on your `remarks.m`; if it is not a
-    regular readable file or it is empty it is an error. Otherwise it will
-    proceed. Note it does not check that there is any text in the file, just
-    that the file size is not 0, and having a `remarks.md` that is not size 0
-    but has no content is violating [Rule 17](next/rules.html#rule17) and [Rule
-    19](next/rules.html#rule19).
-    * If any other error condition from step (4) occurs it is also an error.
-11. Present the list of non-dot files that remain and ask the user to confirm.
-12. Ask the user for a submission title.
-13. Ask the user for a one line abstract of the submission.
-14. Ask the user for the number of authors and for each author ask a variety of
-questions (see below for more information on what kind of questions).
-15. Create `.info.json`.
-16. Create `.auth.json`.
-17. Run `chkentry(1)` on your submission directory to verify things look good,
-including that the `.info.json` and `.auth.json` files are okay.
-    * It also checks that the manifest in `.info.json` matches what is in the
-    submission directory and it verifies file permissions too; if you wish to
-    know what else it does we suggest you read the source code.
-18. Show the output of `ls -lakR .`, asking the user to confirm that the listing
-is okay.
-19. Create the tarball with the name in the form of
-`submit.USERNAME-SLOT.TIMESTAMP`.
-20. Run `txzchk(1)` on the tarball.
-
-If any of the steps fail or if the user says something is not okay, it aborts.
-Some of the other checks that are made:
-
-- If `prog.c` violates [Rule 2](next/rules.html#rule2) (see
-[iocccsize.c](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c)).
-- If `prog.c` is empty (see [Rule 1](next/rules.html#rule1) and the
-[Guidelines](next/guidelines.html)).
-- If `prog.c` has any NUL (`\0`) char (see
-[rule_count.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c)).
-- If `prog.c` has any unknown or invalid trigraph (see
-[rule_count.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c)).
-- If `prog.c` triggers a word buffer overflow (see
-[rule_count.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c)).
-- If `prog.c` triggers an `ungetc(3)` error (see
-[rule_count.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/rule_count.c)).
-- If the first rule in the `Makefile` is not `all`.
-- If the `Makefile` does not have a `clean` rule.
-- If the `Makefile` does not have a `clobber` rule.
-- If the `Makefile` does not have a `try` rule.
-
-Conditions that one **MUST** correct, and which `mkiocccentry(1)` will prompt until
-they are correct, are:
-
-- Your _contest ID_ is invalidly formed.
-- Your _submit slot_ is < 0 or > `MAX_SUBMIT_SLOT` (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- Your _title_ is not in the range of 1 through `MAX_TITLE_LEN` chars (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- Your _title_ does not match the regexp `^[0-9a-z][0-9a-z._+-]*$`.
-- Your _abstract_ is not between 1 and `MAX_ABSTRACT_LEN` chars
-(see [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- The author count is not 1 through `MAX_AUTHORS` (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- An author _name_ is not 1 through `MAX_NAME_LEN` chars (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- Duplicate author _name_.
-- _Country code_ is invalid (i.e. it is not a ISO 3166-1 2 character code).
-- An _email_, if provided, is not in the format of `x@y` or
-if `x` or `y` contain a `@`, are empty or if the total length is longer than
-`MAX_EMAIL_LEN` (see [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- A _URL_ or _alt URL_, if provided, does not start with `http://`
-or `https://` or is longer than `MAX_URL_LEN` chars (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h))
-or does not have anything after the `http://` or `https://`.
-- A _mastodon handle_, if provided, is not in the form of
-`@user@site` (i.e. starts with an `@`, has text following it and then another
-`@` followed by more text and has no other `@`), or if it is longer than `MAX_MASTODON_LEN` (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- A _GitHub account_, if provided, does not start with an `@`,
-has more than one `@`, does not have any text after the `@` or is longer than `MAX_GITHUB_LEN` (see
-[limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- An _affiliation_, if provided, is longer than
-`MAX_AFFILIATION_LEN` (see [limit_ioccc.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/limit_ioccc.h)).
-- An _author handle_, if the default is not accepted, does
-not match the regexp `^[0-9A-Za-z][0-9A-Za-z._+-]*$`.
-- An _author handle_ is repeated.
-
-The program does confirm that the information for each author is correct,
-allowing you to correct the information without having to start the program
-over.
-
-Although the `mkiocccentry(1)` tool will verify everything for you, you may wish
-to validate different parts individually with the different tools. As the
-[rules](next/rules.html) state, each of these tools has a `-h` option.
-
-See the
-FAQ on "[jparse](#jparse)",
-the
-FAQ on "[.auth.json](#auth_json)",
-the
-FAQ on "[.info.json](#info_json)",
-the
-FAQ on "[chkentry](#chkentry)",
-the
-FAQ on "[txzchk](#txzchk)"
-and the
-FAQ on "[fnamchk](#fnamchk)"
-for more details on the tools that `mkiocccentry` either executes directly or
-indirectly as part of the packaging process, especially if you wish to run one
-or more of these tools manually.
-
-See also the
-FAQ on "[how to test everything at once without having to answer
-questions](#mkiocccentry_test)".
-
-See also the [Guidelines](next/guidelines.html) and the [Rules](next/rules.html)
-(especially [Rule 1](next/rules.html#rule1), [Rule 2](next/rules.html#rule2), [Rule
-17](next/rules.html#rule17), [Rule 19](next/rules.html#rule19) and [Rule
-20](next/rules.html#rule20)).
-
-Finally, if you wish to not have to enter the same answers just to update a
-submission, see the
-FAQ on the "[answers file feature](#answers_file)".
-
-
-Jump to: [top](#)
-
-
 <div id="txzchk">
 <div id="tarball">
 <div id="xz">
-### Q 3.1: How can I validate my submission tarball?
+### Q 3.0: How can I validate my submission tarball?
 </div>
 </div>
 </div>
@@ -2210,7 +1792,7 @@ Jump to: [top](#)
 
 <div id="fnamchk">
 <div id="tarball_filename">
-### Q 3.2: What is the `fnamchk` tool?
+### Q 3.1: What is the `fnamchk` tool?
 </div>
 </div>
 
@@ -2238,15 +1820,15 @@ for more information.
 Jump to: [top](#)
 
 
-<div id="chkentry">
-### Q 3.3: How can I validate my submission directory?
+<div id="chksubmit">
+### Q 3.2: How can I validate my submission directory?
 </div>
 
 If you want to validate your submission directory manually, including but not
-limited to the `.auth.json` and `.info.json` files, you should use `chkentry(1)`
+limited to the `.auth.json` and `.info.json` files, you should use `chksubmit(1)`
 from the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
 
-The `chkentry(1)` tool runs a variety of checks on your submission directory,
+The `chksubmit(1)` tool runs a variety of checks on your submission directory,
 including, but not limited to, using the [jparse
 API](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3)
 to validate the two IOCCC specific JSON files (as valid JSON) and additional
@@ -2254,7 +1836,7 @@ checks on those files as well. An important thing that it does is verify that
 your files are the right permissions and that the manifest in the `.info.json`
 files match what is in the directory. What all the checks are is out of scope of this
 document; if you wish to know we recommend you read the [source
-code](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c).
+code](https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c).
 
 **NOTE**: the IOCCC [jparse
 API](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/man/man3/jparse.3)
@@ -2267,7 +1849,7 @@ and
 FAQ on "[.info.json](#info_json)"
 for more details on the two required and very important JSON files.
 
-The `chkentry(1)` tool accepts a single arg, a directory that **MUST** have the
+The `chksubmit(1)` tool accepts a single arg, a directory that **MUST** have the
 two JSON files, `.auth.json` and `.info.json` as well as the `prog.c`,
 `Makefile` and `remarks.md` files along with all the other files listed in the
 `.info.json` manifest. (Okay there is an option to skip files but this is for
@@ -2279,18 +1861,18 @@ As an example, if your submission directory is
 command:
 
 ``` <!---sh-->
-    chkentry 00000000-0000-4000-0000-000000000000-3
+    chksubmit 00000000-0000-4000-0000-000000000000-3
 ```
 
 If there is a [JSON](https://www.json.org/json-en.html) issue detected by the
-`jparse(3)` API (i.e. it is not valid JSON) it is an error and `chkentry(1)`
+`jparse(3)` API (i.e. it is not valid JSON) it is an error and `chksubmit(1)`
 will report this, exiting with a non-zero exit code. If the parsing is OK (i.e.
 valid JSON) but there is an issue in one or both of the
 [JSON](https://www.json.org/json-en.html) files in **the context of the IOCCC**,
 it will report this as an **error**. It also does, as briefly noted above, other
 checks.
 
-If `chkentry(1)` fails to validate your submission directory your submission
+If `chksubmit(1)` fails to validate your submission directory your submission
 **WILL** be **REJECTED**! This is why you **MUST** make sure you use the
 `mkiocccentry(1)` tool to form your submission directory.
 
@@ -2300,12 +1882,17 @@ and the
 FAQ on "[.info.json](#info_json)"
 as well as [Rule 17](next/rules.html#rule17) for more information.
 
+**NOTE**: the `chksubmit(1)` tool invokes `chkentry(1)` but as a contestant  you
+do not need to worry about those details. One should use `chksubmit(1)` instead
+of `chkentry(1)` when validating a directory; `chkentry(1)` is for the judges
+and is what was used in IOCCC28. For IOCCC29 and beyond, `mkiocccentry(1)` uses
+`chksubmit(1)` and so should you.
 
 Jump to: [top](#)
 
 
 <div id="auth_json">
-### Q 3.4: What is a `.auth.json` file?
+### Q 3.3: What is a `.auth.json` file?
 </div>
 
 This file is constructed by the `mkiocccentry(1)` **prior to** forming the xz
@@ -2365,11 +1952,11 @@ In order of the file's contents we describe each required field, below:
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
 
-- `chkentry_version` (double quoted string)
-    * The version of `chkentry` that was used to validate the submission
+- `chksubmit_version` (double quoted string)
+    * The version of `chksubmit` that was used to validate the submission
     directory, including the `.auth.json` file.
 
-    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chkentry` version, defined
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chksubmit` version, defined
     as `CHKENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
@@ -2526,7 +2113,7 @@ After the `authors` **array** the remaining of a `.auth.json` file holds:
     `test_formed_timestamp_usec()` in
     [soup/entry_util.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
-    this is not the case `chkentry(1)` will report an **error** and your
+    this is not the case `chksubmit(1)` will report an **error** and your
     submission **WILL BE** rejected!
 
 - `timestamp_epoch` (double quoted string)
@@ -2546,7 +2133,7 @@ After the `authors` **array** the remaining of a `.auth.json` file holds:
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
 
-This file will be validated with the `chkentry(1)` tool and if there are any
+This file will be validated with the `chksubmit(1)` tool and if there are any
 problems with it or the submission directory, **it is an error**. If there is an
 error the tarball will **NOT** be formed by `mkiocccentry`; otherwise the
 `txzchk(1)` tool will be executed on the tarball.
@@ -2554,24 +2141,24 @@ error the tarball will **NOT** be formed by `mkiocccentry`; otherwise the
 This file will **NOT** be looked at unless the submission wins! Nonetheless, the
 file **MUST** be present in the submission directory and it **MUST** be valid
 JSON and it **MUST** pass all IOCCC semantics checks and all other checks
-`chkentry(1)` perform. `chkentry(1)` is used by `mkiocccentry(1)` and the judges
+`chksubmit(1)` perform. `chksubmit(1)` is used by `mkiocccentry(1)` and the judges
 will use it on the submission directory as part of the judging process.
 
 At the risk of stating the obvious, if your `.auth.json` file is invalid JSON or
-is reported invalid by `chkentry(1)`, or if your submission directory is
-reported invalid by `chkentry(1)`, your submission will almost certainly be
+is reported invalid by `chksubmit(1)`, or if your submission directory is
+reported invalid by `chksubmit(1)`, your submission will almost certainly be
 rejected for violating the [Rules](next/rules.html) and in particular [Rule
 17](next/rules.html#rule17).
 
-An obvious example where `chkentry(1)` would fail to validate `.auth.json` is if
+An obvious example where `chksubmit(1)` would fail to validate `.auth.json` is if
 there is a mismatch of type in the JSON file with what is expected, for
 instance, if in `.auth.json` the `no_comment` that we chose to not comment on is
 not a string or is the wrong string. Another obvious example is when things are
 out of range (see above for list). Two more examples would be if a field is
 missing or if an unknown filed is in the file. In these cases (and any others
-that must be established as valid by `chkentry(1)`) your submission would be
+that must be established as valid by `chksubmit(1)`) your submission would be
 rejected for violating [Rule 17](next/rules.html#rule17) and in particular
-because `chkentry(1)` would not validate the `.auth.json` file (and maybe other
+because `chksubmit(1)` would not validate the `.auth.json` file (and maybe other
 things too).
 
 If you wish to **verify** that your `.auth.json` file is valid **JSON** then see the
@@ -2582,7 +2169,7 @@ Jump to: [top](#)
 
 
 <div id="info_json">
-### Q 3.5: What is a `.info.json` file?
+### Q 3.4: What is a `.info.json` file?
 </div>
 
 This file is constructed by the `mkiocccentry(1)` **prior to** forming the xz
@@ -2660,11 +2247,11 @@ In order of the file's contents we describe each required field, below:
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
 
-- `chkentry_version` (double quoted string)
-    * The version of `chkentry` that was used to validate the submission
+- `chksubmit_version` (double quoted string)
+    * The version of `chksubmit` that was used to validate the submission
     directory, including the `.info.json` file.
 
-    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chkentry` version, defined
+    **IMPORTANT:** this **MUST** be >= **THIS** IOCCC's `chksubmit` version, defined
     as `CHKENTRY_VERSION` in
     [soup/version.h](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/version.h)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
@@ -2935,7 +2522,7 @@ The `manifest` **array** also **OPTIONALLY** has one or more of the field:
     * Any additional file that you need or want to include with your submission.
 
     **IMPORTANT:** this MUST **NOT** match a mandatory filename (see above list)
-    and `chkentry` will verify this for you; it is **ALSO** an **error** if the
+    and `chksubmit` will verify this for you; it is **ALSO** an **error** if the
     filenames are not unique, not POSIX plus + safe chars only, if they are the
     wrong permission and various other things. In these cases you stand a great
     risk of having your submission rejected for violating [Rule
@@ -2965,7 +2552,7 @@ Finally, after the `manifest` **array**, the following fields **MUST** exist:
     `test_formed_timestamp_usec()` in
     [soup/entry_util.c](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/entry_util.c)
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
-    this is not the case `chkentry(1)` will report an **error** and your
+    this is not the case `chksubmit(1)` will report an **error** and your
     submission **WILL BE** rejected!
 
 - `timestamp_epoch` (double quoted string)
@@ -2985,24 +2572,24 @@ Finally, after the `manifest` **array**, the following fields **MUST** exist:
     in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry/). If
     this is not the case your submission **WILL BE** rejected!
 
-This file will be validated with the `chkentry(1)` tool and if there are any
+This file will be validated with the `chksubmit(1)` tool and if there are any
 problems with it or the submission directory, **it is an error**. If there is an
 error the tarball will **NOT** be formed by `mkiocccentry`; otherwise the
 `txzchk(1)` tool will be executed on the tarball.
 
-When the [Judges](judges.html) use `chkentry(1)` on your submission directory,
+When the [Judges](judges.html) use `chksubmit(1)` on your submission directory,
 if this JSON file is invalid JSON or does not match the requirements outlined
 above, or if any other is found, your submission **WILL BE** rejected.
 
-An obvious example where `chkentry` would fail to validate `.info.json` is if
+An obvious example where `chksubmit` would fail to validate `.info.json` is if
 there is a mismatch of type in the JSON file with what is expected, for
 instance, if in `.info.json` the `no_comment` that we chose to not comment on is
 not a string or is the wrong string. Another obvious example is when things are
 out of range (see above for list). Two more examples would be if a field is
 missing or if an unknown filed is in the file. In these cases (and any others
-that must be established as valid by `chkentry`) your submission would be
+that must be established as valid by `chksubmit`) your submission would be
 rejected for violating [Rule 17](next/rules.html#rule17) and in particular
-because `chkentry` would not validate the `.info.json` file.
+because `chksubmit` would not validate the `.info.json` file.
 
 If you wish to **verify** that your `.info.json` file is valid **JSON** then see the
 FAQ on "[validating JSON documents](#validating_json)".
@@ -3013,7 +2600,7 @@ Jump to: [top](#)
 
 <!-- we cannot use id="author_handle" because of a header in FAQ 6.6 -->
 <div id="author_handle_faq">
-### Q 3.6: What is an `author_handle`?
+### Q 3.5: What is an `author_handle`?
 </div>
 
 An `author_handle` is string that refers to a given author and is unique to the
@@ -3083,7 +2670,7 @@ Jump to: [top](#)
 
 <div id="author_json">
 <div id="author_handle_json">
-### Q 3.7: What is an `author_handle.json` file and how are they used?
+### Q 3.6: What is an `author_handle.json` file and how are they used?
 </div>
 </div>
 
@@ -3641,7 +3228,7 @@ Jump to: [top](#)
 
 
 <div id="find_author_handle">
-### Q 3.8: How can I find my author handle?
+### Q 3.7: How can I find my author handle?
 </div>
 
 If you are an _author_ of a winning _entry_, you may find your own _author_handle_
@@ -3688,7 +3275,7 @@ Jump to: [top](#)
 
 <!-- we cannot use id="entry_id" because of a header in FAQ 6.6 -->
 <div id="entry_id_faq">
-### Q 3.9: What is an `entry_id`?
+### Q 3.8: What is an `entry_id`?
 </div>
 
 An `entry_id` is a string that identifies a winning entry of the IOCCC.
@@ -3706,7 +3293,7 @@ Jump to: [top](#)
 
 
 <div id="entry_json">
-### Q 3.10: What is a `.entry.json` file and how is it used?
+### Q 3.9: What is a `.entry.json` file and how is it used?
 </div>
 
 **TL:DR**: The contents of this JSON file contain information about each winning
@@ -4223,7 +3810,7 @@ Jump to: [top](#)
 
 <div id="validating_json">
 <div id="jparse">
-### Q 3.11: How can I validate any JSON document?
+### Q 3.10: How can I validate any JSON document?
 </div>
 </div>
 
@@ -4271,7 +3858,7 @@ the tool.
 repo](https://github.com/xexyl/jparse/issues) but we recommend you compile and
 install via the `mkiocccentry` repo because it has the dependencies built in,
 and because the `mkiocccentry` copy is that which is used by the current IOCCC,
-as the two can be different at times.
+as the two can sometimes be different.
 
 
 Jump to: [top](#)

--- a/next/guidelines.html
+++ b/next/guidelines.html
@@ -488,12 +488,10 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 </div>
 </div>
 <p class="leftbar">
-These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.48 2025-09-28</strong>.
+These <a href="guidelines.html">IOCCC guidelines</a> are version <strong>28.49 2025-11-17</strong>.
 </p>
-<p class="leftbar">
-The markdown form of these guidelines <a href="guidelines.md"
-download="guidelines.md">is available for download</a>.
-</p>
+<p>The markdown form of these guidelines <a href="guidelines.md"
+download="guidelines.md">is available for download</a>.</p>
 <p><strong>IMPORTANT</strong>: Be <strong>SURE</strong> to read the <a href="rules.html">IOCCC rules</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="change_marks">
@@ -519,11 +517,9 @@ about them. The <a href="guidelines.html">IOCCC guidelines</a> should be viewed 
 <a href="guidelines.html">guidelines</a> <em>but remain within the <a href="rules.html">rules</a></em></strong> <em>are
 allowed</em>. Even so, you are safer if you remain within the <a href="guidelines.html">IOCCC
 guidelines</a>.</p>
-<p class="leftbar">
-Of course if a guideline is talking about a rule and you break that guideline,
+<p>Of course if a guideline is talking about a rule and you break that guideline,
 you stand a good chance of having your submission rejected for breaking the
-rule, not the guideline.
-</p>
+rule, not the guideline.</p>
 <p>You <strong>SHOULD read the CURRENT <a href="rules.html">IOCCC rules</a></strong>, <em>prior</em> to submitting
 code to the contest.</p>
 <p>Jump to: <a href="#">top</a></p>
@@ -547,128 +543,97 @@ When this happens, you may begin uploading your submissions to the IOCCC.
 This contest will enter the <strong><a href="../faq.html#judging">judging</a></strong> state on <strong>2025-06-05 04:03:02.010099 UTC</strong>.
 When this happens, you may no longer upload your submissions to the IOCCC.
 </p>
-<p class="leftbar">
-<strong>IMPORTANT NOTE</strong>: Until the contest enters the <strong><a href="../faq.html#open">open</a></strong> state, any or all
-of the above <strong>dates and times may change <em>AT ANY TIME</em></strong>!
-</p>
+<p><strong>IMPORTANT NOTE</strong>: Until the contest enters the <strong><a href="../faq.html#open">open</a></strong> state, any or all
+of the above <strong>dates and times may change <em>AT ANY TIME</em></strong>!</p>
 <p class="leftbar">
 The reason for the times of day are so that key IOCCC events are <strong>calculated</strong>
 to be a <strong>fun</strong>ctional UTC time. :-)
 </p>
-<p class="leftbar">
-Until the contest status becomes <strong><a href="../faq.html#open">open</a></strong>,
+<p>Until the contest status becomes <strong><a href="../faq.html#open">open</a></strong>,
 the <a href="rules.html">IOCCC rules</a>,
 <a href="guidelines.html">IOCCC guidelines</a> and the tools in the
 <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a> <strong>SHOULD be
 considered</strong> provisional <strong>BETA</strong> versions and <strong>may be adjusted <em>AT ANY TIME</em></strong>
-before the contest status becomes <strong><a href="../faq.html#open">open</a></strong>.
-</p>
-<p class="leftbar">
-See the
+before the contest status becomes <strong><a href="../faq.html#open">open</a></strong>.</p>
+<p>See the
 FAQ on “<a href="../quick-start.html#enter">how to register and submit to the IOCCC</a>”
 for instructions on registering and participating in the IOCCC, as the process
-may change from contest to contest.
-</p>
-<p class="leftbar">
-To assist in the formation of the xz compressed tarball for submission, use the
-<code>mkiocccentry(1)</code> tool as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.
-</p>
-<p class="leftbar">
-See FAQs regarding:
-</p>
+may change from contest to contest.</p>
+<p>To assist in the formation of the xz compressed tarball for submission, use the
+<code>mkiocccentry(1)</code> tool as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
+<p>See FAQs regarding:</p>
 <ul>
 <li><a href="../faq.html#obtaining_mkiocccentry">obtaining the latest mkiocccentry tools</a></li>
 <li><a href="../faq.html#compiling_mkiocccentry">compiling the mkiocccentry tools</a></li>
 <li><a href="../faq.html#install">installing the mkiocccentry tools</a></li>
 <li><a href="../faq.html#using_mkiocccentry">using the mkiocccentry tools</a></li>
 </ul>
-<p class="leftbar">
-Uploading a tarball not formed by <code>mkiocccentry(1)</code> puts you at a very big risk of
+<p>Uploading a tarball not formed by <code>mkiocccentry(1)</code> puts you at a very big risk of
 violating <a href="rules.html#rule17">Rule 17</a>, especially as <code>mkiocccentry(1)</code> does a
 great number of things that are required, and it also runs many checks, and if
 any of those checks fail, you are at a very great risk of having your submission
-rejected for violating <a href="rules.html#rule17">Rule 17</a>.
-</p>
-<p class="leftbar">
-We <strong>STRONGLY</strong> recommend you <strong>do</strong> install the
-<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry toolkit</a>.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT NOTE</strong>: the tools that require other tools, <code>mkiocccentry(1)</code> and
+rejected for violating <a href="rules.html#rule17">Rule 17</a>.</p>
+<p>We <strong>STRONGLY</strong> recommend you <strong>do</strong> install the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry toolkit</a>.</p>
+<p><strong>IMPORTANT NOTE</strong>: the tools that require other tools, <code>mkiocccentry(1)</code> and
 <code>txzchk(1)</code>, will, as of version <code>2.0.2 2025-03-11</code>, search under <code>$PATH</code>. If
 you have an earlier version and you have not installed the tools and run the
 tools from outside the repo directory, you will have to use the options to the
-tools to set the path to the required tools.
-</p>
-<p class="leftbar">
-See the
+tools to set the path to the required tools.</p>
+<p>See the
 FAQ on “<a href="../faq.html#mkiocccentry">obtaining and compiling the most recent mkiocccentry tools</a>”
 and the
 FAQ on “<a href="../quick-start.html#enter">how to enter the IOCCC</a>”
 as that FAQ has important details on
 <a href="../next/register.html">how to register</a>
 as well as
-<a href="../next/submit.html">how to upload your submission</a> to the IOCCC.
-</p>
-<p class="leftbar">
-See also the
-FAQ on “<a href="../faq.html#minimum_versions">what the minimum required versions are for this
-contest</a>”
-for more details on how to verify you have the correct versions for this
-contest.
-</p>
-<p class="leftbar">
-While the contest is <strong><a href="../faq.html#open">open</a></strong>, you may modify your
+<a href="../next/submit.html">how to upload your submission</a> to the IOCCC.</p>
+<p>While the contest is <strong><a href="../faq.html#open">open</a></strong>, you may modify your
 previously uploaded submission by rebuilding your submission with the
 <code>mkiocccentry(1)</code> tool and then re-uploading it to <strong>the same slot number</strong> on the
-<a href="https://submit.ioccc.org">submit server</a>.
-</p>
-<p class="leftbar">
-<strong>HINT:</strong> so that you do not have to repeatedly answer all the
+<a href="https://submit.ioccc.org">submit server</a>.</p>
+<p><strong>HINT:</strong> so that you do not have to repeatedly answer all the
 questions, the <code>mkiocccentry(1)</code> tool has the options <code>-a answers</code>, <code>-A answers</code>
 and <code>-i answers</code>, where <code>-a</code> will write to an answers file (if it does not
 already exist), <code>-A</code> <strong>WILL OVERWRITE THE FILE</strong> and <code>-i</code> will read the answers from
-the file. If you use <code>-A</code>, <strong>BE SURE</strong> you don’t overwrite another file by accident!
-</p>
-<p class="leftbar">
-Be aware that even with the <code>-i answers</code> you will still be required to confirm
+the file. If you use <code>-A</code>, <strong>BE SURE</strong> you don’t overwrite another file by accident!</p>
+<p>Be aware that even with the <code>-i answers</code> you will still be required to confirm
 most if not all <code>y/n</code> questions - you just don’t have to input the name of the
 submission, the abstract, the author details etc. If you really wish to
 circumvent this you can use the <code>-Y</code> option but we do not recommend this because
-if your update breaks a rule or there is some problem, you might not see it.
-</p>
-<p class="leftbar">
-To help with not having to repeatedly enter a UUID, whether for the same
+if your update breaks a rule or there is some problem, you might not see it.</p>
+<p>To help with not having to repeatedly enter a UUID, whether for the same
 submission or multiple submissions, you can use the <code>-u uuidfile</code> or <code>-U UUID</code>
 option. See the
 FAQ on “<a href="../faq.html#uuid">how to avoid re-entering your UUID</a>”
 for more details. Note that the <code>-i answers</code> option cannot be used with the UUID
-options as the answers file includes the UUID.
-</p>
-<p class="leftbar">
-The overall size limit (see <a href="rules.html#rule2a">Rule 2a</a>) on <code>prog.c</code> has been
+options as the answers file includes the UUID.</p>
+<p>The overall size limit (see <a href="rules.html#rule2a">Rule 2a</a>) on <code>prog.c</code> has been
 <strong>increased from 4096 to 4993</strong> bytes.
 The <a href="rules.html#rule2a">Rule 2a</a> size was changed from
 <strong>4096</strong> to <strong>4993</strong> to keep the “2b to 2a” size ratio to a
 value similar to the <a href="../faq.html#size_rule2001-2012">2001-2012</a> and
-<a href="../faq.html#size_rule2013-2020">2013-2020</a> IOCCC eras.
+<a href="../faq.html#size_rule2013-2020">2013-2020</a> IOCCC eras.</p>
+<p>The <a href="rules.html#rule2b">Rule 2b</a> size has <strong>increased from 2053 to 2503</strong>
+bytes.</p>
+<p class="leftbar">
+However, you should pay especial attention to our remarks in the <a href="../2024/index.html">IOCCC28
+index.html</a>:
 </p>
 <p class="leftbar">
-The <a href="rules.html#rule2b">Rule 2b</a> size has <strong>increased from 2053 to 2503</strong>
-bytes.
+<blockquote>
+<p><strong>IMPORTANT HINT</strong>: Only 3 of the 23 <strong>IOCCC28 winners</strong> came close to the
+<a href="../next/rules.html#rule2">Rule 2 size limit</a>. Large code size isn’t
+everything. :-) Those submitting to future contents should <strong>take a careful
+note</strong> of that fact.</p>
+</blockquote>
 </p>
-<p class="leftbar">
-Your submission must satisfy <strong>BOTH</strong> the maximum size
-<a href="rules.html#rule2a">Rule 2a</a> <strong>AND</strong> the IOCCC size <a href="rules.html#rule2b">Rule 2b</a>.
-</p>
-<p class="leftbar">
-To check your code against <a href="rules.html#rule2">Rule 2</a>, use the <code>iocccentry(1)</code> tool.
-For example:
-</p>
+<p>Your submission must satisfy <strong>BOTH</strong> the maximum size
+<a href="rules.html#rule2a">Rule 2a</a> <strong>AND</strong> the IOCCC size <a href="rules.html#rule2b">Rule 2b</a>.</p>
+<p>To check your code against <a href="rules.html#rule2">Rule 2</a>, use the <code>iocccentry(1)</code> tool.
+For example:</p>
 <pre><code>    iocccsize prog.c</code></pre>
-<p class="leftbar">
-The IOCCC size tool algorithm can be summarized as follows:
-</p>
+<p>The IOCCC size tool algorithm can be summarized as follows:</p>
 <blockquote>
 <p>The size tool counts most C reserved words (keyword, secondary, and selected
 preprocessor keywords) as 1. The size tool counts all other bytes as 1
@@ -678,34 +643,26 @@ before the end of file.</p>
 </blockquote>
 <p>ASCII whitespace includes ASCII tab, ASCII space, ASCII newline,
 ASCII formfeed, and ASCII carriage return.</p>
-<p class="leftbar">
-When ‘<code>;</code>’, ‘<code>{</code>’ or ‘<code>}</code>’ are within a C string, they may still not be
-counted by the IOCCC size tool. This is a <strong>feature</strong>, not a bug!
-</p>
-<p class="leftbar">
-In cases where the above summary and the algorithm implemented by
+<p>When ‘<code>;</code>’, ‘<code>{</code>’ or ‘<code>}</code>’ are within a C string, they may still not be
+counted by the IOCCC size tool. This is a <strong>feature</strong>, not a bug!</p>
+<p>In cases where the above summary and the algorithm implemented by
 the IOCCC size tool <code>iocccsize(1)</code> conflict, the algorithm implemented
-by the current version of <code>iocccsize(1)</code> is preferred by the <a href="../judges.html">IOCCC judges</a>.
-</p>
-<p class="leftbar">
-In other words, make sure <code>iocccsize</code> does not flag any issues with your
-<code>prog.c</code>.
-</p>
-<p class="leftbar">
-There are at least 2 other reasons for selecting 2503 as the 2nd limit besides
+by the current version of <code>iocccsize(1)</code> is preferred by the <a href="../judges.html">IOCCC judges</a>.</p>
+<p>In other words, make sure <code>iocccsize</code> does not flag any issues with your
+<code>prog.c</code>.</p>
+<p>There are at least 2 other reasons for selecting 2503 as the 2nd limit besides
 the fact that 2503 is a prime. These reasons may be searched for and discovered
 if you are <a href="https://t5k.org/curios/page.php/2503.html">“Curios!” about 2503</a>.
 :-) Moreover, 2053 was the number of the kernel disk pack of one of the judge’s
-BESM-6, and 2503 is a decimal anagram of 2053.
-</p>
+BESM-6, and 2503 is a decimal anagram of 2053.</p>
 <p>Take note that this secondary limit imposed by the IOCCC size tool
 obviates some of the need to <code>#define</code> C reserved words in an effort
 to get around the size limits of <a href="rules.html#rule2">Rule 2</a>.</p>
 <p>Yes Virginia, <strong>that is a hint</strong>!</p>
+<p>The <strong>official locale</strong> of the <strong>IOCCC</strong> is <strong>C</strong>.</p>
 <p class="leftbar">
-The <strong>official locale</strong> of the <strong>IOCCC</strong> is <strong>C</strong>.
+Did you really think anything else? :-)
 </p>
-<p class="leftbar">
 The <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry toolkit</a>,
 as of <a href="https://github.com/ioccc-src/mkiocccentry/releases/tag/2.4.4">Release version 2.4.4 2025-03-15</a>,
 will run with a locale set to <strong>C</strong>.
@@ -747,8 +704,7 @@ requirements document or a customer request is important. For this reason, we
 often award ‘<strong>Best abuse of the <a href="rules.html">rules</a></strong>’ or ‘<strong>Worst abuse of the
 <a href="rules.html">rules</a></strong>’ or some variation to a submission that illustrates this
 point in an ironic way.</p>
-<p class="leftbar">
-The IOCCC has a rich history of remarkable winning entries created by
+<p>The IOCCC has a rich history of remarkable winning entries created by
 authors who skillfully employed various techniques to develop their code.
 While it is <strong>NOT</strong> required, you are allowed to use tools to develop
 and test your submission. These tools may include, but are not limited
@@ -756,67 +712,48 @@ to code generators, code analysis tools, static code analysis tools,
 runtime analysis tools, machine learning tools, natural language models,
 code copilot tools, so-called AI services, large language models (LLMS), etc.
 If you do make use of such tools or services, then we <strong>ENCOURAGE you to describe
-how you used such tools</strong> in your <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-You may use git, or services such as <a href="https://www.github.com">GitHub</a>
+how you used such tools</strong> in your <code>remarks.md</code> file.</p>
+<p>You may use git, or services such as <a href="https://www.github.com">GitHub</a>
 to develop and maintain your submission. However, we <strong>DISLIKE</strong>
-submissions that <strong>require</strong> them in order to build/compile your submission.
-</p>
-<p class="leftbar">
-Submissions will be judged in an environment that has no <strong>IDE</strong>.
+submissions that <strong>require</strong> them in order to build/compile your submission.</p>
+<p>Submissions will be judged in an environment that has no <strong>IDE</strong>.
 Any submission that fails to compile/build because it requires
-an <strong>IDE</strong> will be rejected.
-</p>
-<p class="leftbar">
-We will use the <code>make(1)</code> tool, your <code>Makefile</code>, and other tools found in
+an <strong>IDE</strong> will be rejected.</p>
+<p>We will use the <code>make(1)</code> tool, your <code>Makefile</code>, and other tools found in
 <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX Specification</a>
 environments and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
-in the building and compiling of your submission.
-</p>
+in the building and compiling of your submission.</p>
 <p>We do realize that there are holes in the <a href="rules.html">rules</a>, and invite
 submitters to attempt to exploit them. We may award ‘<strong>Worst abuse of the
 <a href="rules.html">rules</a></strong>’ or ‘<strong>Best abuse of the <a href="rules.html">rules</a></strong>’ or some
 variation and then plug the hole next year.</p>
-<p class="leftbar">
-When we do need to plug a hole in the <a href="rules.html">IOCCC rules</a> or <a href="guidelines.html">IOCCC
+<p>When we do need to plug a hole in the <a href="rules.html">IOCCC rules</a> or <a href="guidelines.html">IOCCC
 guidelines</a>, we will attempt to use a very small plug, if not
-smaller. Or, maybe not. :-)
-</p>
-<p class="leftbar">
-There may be fewer than 2^7+1 reasons why these <a href="guidelines.html">IOCCC
-guidelines</a> seem obfuscated.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT:</strong> Be sure that <strong>your submission works</strong> as documented in your
+smaller. Or, maybe not. :-)</p>
+<p>There may be fewer than 2^7+1 reasons why these <a href="guidelines.html">IOCCC
+guidelines</a> seem obfuscated.</p>
+<p><strong>IMPORTANT:</strong> Be sure that <strong>your submission works</strong> as documented in your
 <code>remarks.md</code> file. We sometimes make an effort to debug a submission
 that has a slight problem, particularly in or near the final round.
 On the other hand, we have seen some otherwise excellent submissions
-fall down because they didn’t work as documented.
-</p>
-<p class="leftbar">
-If you submission has bugs and/or mis-features, you are <strong>MUCH BETTER</strong> off
-documenting such bugs and/or mis-features in your <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-Consider an example of a <a href="https://en.wikipedia.org/wiki/Prime_number">prime number</a>
+fall down because they didn’t work as documented.</p>
+<p>If you submission has bugs and/or mis-features, you are <strong>MUCH BETTER</strong> off
+documenting such bugs and/or mis-features in your <code>remarks.md</code> file.</p>
+<p>Consider an example of a <a href="https://en.wikipedia.org/wiki/Prime_number">prime number</a>
 printing program that claims that 16 is a prime number.
-Noting such a bug in your <code>remarks.md</code> file could save your submission:
-</p>
+Noting such a bug in your <code>remarks.md</code> file could save your submission:</p>
 <blockquote>
 <p>“<em>this submission sometimes prints the 4th power of a prime by mistake</em>”</p>
 </blockquote>
 <p>Sometimes a strange bug or (mis-)feature can even help the submission! Of course, a correctly
 working submission might be better.</p>
-<p class="leftbar">
-We tend to look down on a <a href="https://en.wikipedia.org/wiki/Prime_number">prime
+<p>We tend to look down on a <a href="https://en.wikipedia.org/wiki/Prime_number">prime
 number</a> printer that claims that
 16 is a prime number.
 Clever people will note that 16 might be prime
 under certain conditions. ;-) Wise people, when submitting something clever
-will fully explain such cleverness in their submission’s <code>remarks.md</code> file.
-</p>
+will fully explain such cleverness in their submission’s <code>remarks.md</code> file.</p>
 <p>People who are considering to just use some complex mathematical
 function or state machine to spell out something such as “<em>hello,
 world!</em>” <strong>really really, <em>and we do mean REALLY</em>, do need to be more creative</strong>.</p>
@@ -828,26 +765,17 @@ misleading comments and variable names might be a <strong>VERY GOOD START</stron
 to a great submission!</p>
 <p>Jump to: <a href="#">top</a></p>
 <h1 id="mkiocccentry"><code>mkiocccentry</code></h1>
-<p class="leftbar">
-<a href="rules.html#rule17">Rule 17</a> (the <code>mkiocccentry(1)</code> rule) states that
-you <strong>REALLY SHOULD</strong> use the <code>mkiocccentry(1)</code> tool to package your submission tarball.
-</p>
-<p class="leftbar">
-See the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
-for the <code>mkiocccentry(1)</code> tool and below for more details.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT NOTE</strong>: make <strong>CERTAIN</strong> you have the most recent version of the
+<p><a href="rules.html#rule17">Rule 17</a> (the <code>mkiocccentry(1)</code> rule) states that
+you <strong>REALLY SHOULD</strong> use the <code>mkiocccentry(1)</code> tool to package your submission tarball.</p>
+<p>See the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
+for the <code>mkiocccentry(1)</code> tool and below for more details.</p>
+<p><strong>IMPORTANT NOTE</strong>: make <strong>CERTAIN</strong> you have the most recent version of the
 <code>mkiocccentry</code> toolkit! See the
-FAQ on “<a href="../faq.html#obtaining_mkiocccentry">obtaining the mkiocccentry toolkit</a>”.
-</p>
-<p class="leftbar">
-<code>mkiocccentry</code> runs a number of checks, by the tool itself and by executing
+FAQ on “<a href="../faq.html#obtaining_mkiocccentry">obtaining the mkiocccentry toolkit</a>”.</p>
+<p><code>mkiocccentry</code> runs a number of checks, by the tool itself and by executing
 other tools, <em>before</em> packaging your xz compressed tarball, including running
-<code>chksubmit(1)</code> on the submission directory.
-</p>
-<p class="leftbar">
-If <code>mkiocccentry</code> encounters an <strong>error</strong>, the program will exit and the xz
+<code>chksubmit(1)</code> on the submission directory.</p>
+<p>If <code>mkiocccentry</code> encounters an <strong>error</strong>, the program will exit and the xz
 compressed tarball <strong>will not be formed</strong>. For instance, if
 <a href="#chksubmit">chksubmit</a> fails to validate the submission directory, either because
 of a validation error in the <code>.auth.json</code> or <code>.info.json</code>
@@ -857,151 +785,111 @@ something else that <code>mkiocccentry(1)</code> creates or does, it is an
 mkiocccentry bug report
 page</a>.
 <strong>PLEASE run the <code>bug_report.sh</code> script to help us out here!</strong> See the
-FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.
-</p>
-<p class="leftbar">
-Once the tarball is packaged it will
-run <code>txzchk(1)</code>, which will also run <code>fnamchk(1)</code>, as part of its algorithm.
-</p>
-<p class="leftbar">
-However, even if <code>mkiocccentry</code> or one of the tools it invokes reports an error,
+FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.</p>
+<p>Once the tarball is packaged it will
+run <code>txzchk(1)</code>, which will also run <code>fnamchk(1)</code>, as part of its algorithm.</p>
+<p>However, even if <code>mkiocccentry</code> or one of the tools it invokes reports an error,
 it <strong>does not</strong> necessarily mean it is a bug in the code. It might be an issue with
 your submission. Thus if you report an error as a bug it might not be something
-that will be fixed as there might not be anything wrong with the tools.
-</p>
-<p class="leftbar">
-On the other hand, some conditions flagged by <code>mkiocccentry(1)</code> are <strong>warnings</strong>
+that will be fixed as there might not be anything wrong with the tools.</p>
+<p>On the other hand, some conditions flagged by <code>mkiocccentry(1)</code> are <strong>warnings</strong>
 and it allows you to override these, if you wish. If you’re brave enough you can
 use the <code>-W</code> option to ignore all warnings but this is a big risk; the <code>-y</code>
 option will assume ‘<em>yes</em>’ to most questions but this is also a big risk. Using
 <code>-Y</code> will say ‘<em>yes</em>’ to even more prompts. Needless to say, we do <strong>NOT</strong>
-recommend these options.
-</p>
-<p class="leftbar">
-In many places it will prompt you to verify what you input, allowing you to
+recommend these options.</p>
+<p>In many places it will prompt you to verify what you input, allowing you to
 correct details as you go along. Be advised that there is a default answer and
 if you press enter it will proceed with that default, so make sure you have
-provided the correct answer.
-</p>
-<p class="leftbar">
-If you wish to <strong>test</strong> that your submission passes the <code>mkiocccentry(1)</code> tests
+provided the correct answer.</p>
+<p>If you wish to <strong>test</strong> that your submission passes the <code>mkiocccentry(1)</code> tests
 without having to type in in answers each time, you can use the <code>-d</code> or <code>-s seed</code>
 option to <code>mkiocccentry</code> for the tool to pseudo-randomly create answers for you.
-For example:
-</p>
+For example:</p>
 <pre><code>    mkiocccentry -d workdir topdir</code></pre>
-<p class="leftbar">
-<strong>IMPORTANT NOTE</strong>: if you run an IOCCC related tool outside the repo directory
+<p><strong>IMPORTANT NOTE</strong>: if you run an IOCCC related tool outside the repo directory
 (specifying the absolute or relative path to the tool) and you have not
 installed the tools (and we <strong>STRONGLY</strong> recommend you <strong>do</strong> install them),
 then you will have to specify the options (such as paths) for the tools that are required like
-<code>chksubmit(1)</code>, <code>txzchk(1)</code> and <code>fnamchk(1)</code>.
-</p>
-<p class="leftbar">
-Make sure you have
+<code>chksubmit(1)</code>, <code>txzchk(1)</code> and <code>fnamchk(1)</code>.</p>
+<p>Make sure you have
 the latest version of of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry toolkit</a>
-so that you do not violate <a href="rules.html#rule17">Rule 17</a> by mistake.
-</p>
+so that you do not violate <a href="rules.html#rule17">Rule 17</a> by mistake.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="mkiocccentry-synopsis">
 <h2 id="mkiocccentry1-synopsis"><code>mkiocccentry(1)</code> synopsis</h2>
 </div>
-<p class="leftbar">
-The synopsis of the <code>mkiocccentry(1)</code> tool is:
-</p>
+<p>The synopsis of the <code>mkiocccentry(1)</code> tool is:</p>
 <pre><code>    mkiocccentry [options] workdir topdir</code></pre>
-<p class="leftbar">
-To help you with editing a submission, the <code>mkiocccentry(1)</code> tool has
+<p>To help you with editing a submission, the <code>mkiocccentry(1)</code> tool has
 some options to write <em>OR</em> read from an answers file so you do not have to input
 the information about the author(s) and the submission more than once, unless of
 course you need to make some changes, in which case you can use the option that
 overwrites the file. If you do use the overwrite option, <strong>MAKE SURE</strong> you do
-not overwrite another file!
-</p>
-<p class="leftbar">
-See the
+not overwrite another file!</p>
+<p>See the
 FAQ on the
 “<a href="../faq.html#mkiocccentry">mkiocccentry tool</a>”
 for how to use this tool and the
 FAQ on the
 “<a href="../faq.html#mkiocccentry_details">finer details of mkiocccentry</a>”
-for even more information.
-</p>
+for even more information.</p>
 <div id="tools">
 <h1 id="other-mkiocccentry-tools">Other mkiocccentry tools</h1>
 </div>
-<p class="leftbar">
-The <code>mkiocccentry(1)</code> tool will execute a number of tools, some of which will
-execute one or more additional tools.
-</p>
+<p>The <code>mkiocccentry(1)</code> tool will execute a number of tools, some of which will
+execute one or more additional tools.</p>
 <h2 id="iocccsize"><code>iocccsize</code></h2>
-<p class="leftbar">
-<code>mkiocccentry(1)</code> will use code from <code>iocccsize(1)</code> which detects a number of
+<p><code>mkiocccentry(1)</code> will use code from <code>iocccsize(1)</code> which detects a number of
 issues (such as <a href="rules.html#rule2">Rule 2</a>) that you may ignore, if you wish, as
-noted above.
-</p>
-<p class="leftbar">
-In other words, you no longer need to run <code>iocccsize</code> manually. However, the
-checks described above are still made but through the <code>mkiocccentry(1)</code> tool itself.
-</p>
+noted above.</p>
+<p>In other words, you no longer need to run <code>iocccsize</code> manually. However, the
+checks described above are still made but through the <code>mkiocccentry(1)</code> tool itself.</p>
 <p>Jump to: <a href="#">top</a></p>
-<h2 id="chkentry"><code>chkentry</code></h2>
-<p class="leftbar">
-<code>mkiocccentry(1)</code> will write two JSON files: <code>.auth.json</code> and
+<h2 id="chksubmit"><code>chksubmit</code></h2>
+<p><code>mkiocccentry(1)</code> will write two JSON files: <code>.auth.json</code> and
 <code>.info.json</code>. These files contain information about the author(s) and about the
-submission. After these files are formed, the <code>chkentry(1)</code> tool will be run on
+submission. After these files are formed, the <code>chksubmit(1)</code> tool will be run on
 the submission directory; this tool not only validates the two JSON files
 (and runs specific checks on them after validating the JSON), but it also
 verifies that what is in the manifest in <code>.info.json</code> matches the contents of
-the directory, in addition to other checks. If <code>chkentry(1)</code> fails to validate
-anything at all, your submission <strong>WILL BE</strong> rejected!
-</p>
-<p class="leftbar">
-<strong>IMPORTANT</strong>: although <code>chkentry(1)</code> validates the files in the directory, it
+the directory, in addition to other checks. If <code>chksubmit(1)</code> fails to validate
+anything at all, your submission <strong>WILL BE</strong> rejected!</p>
+<p><strong>IMPORTANT</strong>: although <code>chksubmit(1)</code> validates the files in the directory, it
 only inspects the contents of the two JSON files; it performs other kinds of
 checks on the other files, and those checks are run on the two JSON files as
-well.
-</p>
-<p class="leftbar">
-If you submit your own JSON files (other than <code>.auth.json</code> and
+well.</p>
+<p>If you submit your own JSON files (other than <code>.auth.json</code> and
 <code>.info.json</code>) then they do <strong>NOT</strong> have to be valid JSON.
 However, if you do provide such invalid JSON files, <strong>PLEASE</strong>
-document and explain this in your <code>remarks.md</code> file.
-</p>
+document and explain this in your <code>remarks.md</code> file.</p>
 <p class="leftbar">
-If <code>chkentry</code> does not pass and you used <code>mkiocccentry(1)</code> it is <strong>very likely</strong> a
+On the other hand, some people might question what actually constitutes a valid
+JSON file. :-)
+</p>
+<p>If <code>chksubmit</code> does not pass and you used <code>mkiocccentry(1)</code> it is <strong>very likely</strong> a
 bug and you should <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it as a bug at the mkiocccentry issues
 page</a>.
-<strong>PLEASE</strong> run the command:
-</p>
+<strong>PLEASE</strong> run the command:</p>
 <pre><code>    make bug_report</code></pre>
-<p class="leftbar">
-from the top level repo directory itself and attach the bug report file (it will
+<p>from the top level repo directory itself and attach the bug report file (it will
 tell you the name of the file). See also the
-FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.
-</p>
-<p class="leftbar">
-Assuming that <code>chkentry(1)</code> successfully validates your submission directory,
+FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.</p>
+<p>Assuming that <code>chksubmit(1)</code> successfully validates your submission directory,
 the tarball will be formed and then <code>txzchk(1)</code> will be executed on it. In this
 case, there should be no problems, as <code>mkiocccentry(1)</code> should <strong>NOT</strong> form a
-tarball if there are any issues.
-</p>
-<p class="leftbar">
-If <code>mkiocccentry(1)</code> is used and <code>chkentry(1)</code> fails to validate your submission
+tarball if there are any issues.</p>
+<p>If <code>mkiocccentry(1)</code> is used and <code>chksubmit(1)</code> fails to validate your submission
 directory, then unless it is a system specific problem, it could be a bug in
-<code>mkiocccentry(1)</code>, <code>chkentry(1)</code> or possibly <code>jparse</code>, although this is unlikely.
-Nonetheless, if you believe there is a bug, you may report it as explained above.
-</p>
-<p class="leftbar">
-If you want to know what <code>.auth.json</code> is, see the
+<code>mkiocccentry(1)</code>, <code>chksubmit(1)</code> or possibly <code>jparse</code>, although this is unlikely.
+Nonetheless, if you believe there is a bug, you may report it as explained above.</p>
+<p>If you want to know what <code>.auth.json</code> is, see the
 FAQ on “<a href="../faq.html#auth_json">.auth.json</a>”.
 If you want to know what the <code>.info.json</code> file is, see the
 FAQ on “<a href="../faq.html#info_json">.info.json</a>”.
-On the other hand, if you want to know a bit more details about <code>chkentry(1)</code>, see the
-FAQ about “<a href="../faq.html#chkentry">chkentry</a>”.
-</p>
-<p class="leftbar">
-<code>chkentry</code> uses the <code>jparse</code> library. See the
+On the other hand, if you want to know a bit more details about <code>chksubmit(1)</code>, see the
+FAQ about “<a href="../faq.html#chksubmit">chksubmit</a>”.</p>
+<p><code>chksubmit</code> uses the <code>jparse</code> library. See the
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md">jparse
 README.md</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/tree/master/jparse">mkiocccentry GitHub repo subdirectory
@@ -1010,56 +898,45 @@ the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jparse
 file</a>
 in the <a href="https://github.com/ioccc-src/mkiocccentry/tree/master/jparse">mkiocccentry GitHub repo subdirectory
 jparse</a>, for more
-details.
-</p>
-<p class="leftbar">
-The <code>jparse</code> parser, library and tools were co-developed by <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone
+details.</p>
+<p>The <code>jparse</code> parser, library and tools were co-developed by <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone
 Ferguson</a> and <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a> in 2022-2025 and come from the
 <a href="https://github.com/xexyl/jparse">jparse repo</a>. However, the <strong>mkiocccentry
 tools use a <em>clone</em></strong> of the <a href="https://github.com/xexyl/jparse">jparse repo</a> <strong>at
 a <em>specific</em> release</strong>. Thus the <code>mkiocccentry</code> will at times be behind the
-<a href="https://github.com/xexyl/jparse">jparse repo</a>!
-</p>
-<p class="leftbar">
-You do <strong>NOT need to install</strong> <code>jparse</code> from the <a href="https://github.com/xexyl/jparse">jparse
+<a href="https://github.com/xexyl/jparse">jparse repo</a>!</p>
+<p>You do <strong>NOT need to install</strong> <code>jparse</code> from the <a href="https://github.com/xexyl/jparse">jparse
 repo</a>! The <code>mkiocccentry</code> tools link in the
-static library from <code>mkiocccentry</code>’s <em>clone</em>.
-</p>
-<p class="leftbar">
-The <code>mkiocccentry</code> toolkit <em>also</em> has a clone of <em>both</em> the <a href="https://github.com/lcn2/dbg">dbg
+static library from <code>mkiocccentry</code>’s <em>clone</em>.</p>
+<p>The <code>mkiocccentry</code> toolkit <em>also</em> has a clone of <em>both</em> the <a href="https://github.com/lcn2/dbg">dbg
 library</a> and the
 <a href="https://github.com/lcn2/dyn_array">dyn_array library</a>; the <a href="https://github.com/lcn2/dyn_array">dyn_array
 library</a> uses the <a href="https://github.com/lcn2/dbg">dbg
 library</a> and the <a href="https://github.com/xexyl/jparse">jparse
 library</a> uses both libraries but unlike in the
 <a href="https://github.com/xexyl/jparse">jparse repo</a>, the libraries do not need to be
-installed separately, in order to use the tools in <code>mkiocccentry</code>.
-</p>
-<p class="leftbar">
-In other words, <code>mkiocccentry</code> <strong>contains everything</strong> you need, and <em>even if you
+installed separately, in order to use the tools in <code>mkiocccentry</code>.</p>
+<p>In other words, <code>mkiocccentry</code> <strong>contains everything</strong> you need, and <em>even if you
 do install</em> the libraries from their respective repos, it/they will <strong>not be
 used</strong> when compiling the <code>mkiocccentry</code> tools. This is important to
 make sure that you’re using the correct versions, which is also verified by
-<code>chkentry</code> (in the JSON files created by <code>mkiocccentry(1)</code>). See <a href="rules.html#rule17">Rule
-17</a>!
-</p>
+<code>chksubmit</code> (in the JSON files created by <code>mkiocccentry(1)</code>). See <a href="rules.html#rule17">Rule
+17</a>!</p>
 <p class="leftbar">
-Please see the
-FAQ on “<a href="../faq.html#chkentry">validating your submission directory</a>
-for more details on <code>chkentry(1)</code>.
+We <strong>HIGHLY</strong> recommend you install the <code>mkiocccentry</code> toolkit, however.
 </p>
-<p class="leftbar">
-You might also wish to see the
+<p>Please see the
+FAQ on “<a href="../faq.html#chksubmit">validating your submission directory</a>
+for more details on <code>chksubmit(1)</code>.</p>
+<p>You might also wish to see the
 FAQ on “<a href="../faq.html#auth_json">.auth.json</a>”
 and the
 FAQ on “<a href="../faq.html#info_json">.info.json</a>”
-for much more information on these files.
-</p>
+for much more information on these files.</p>
 <p>Jump to: <a href="#">top</a></p>
 <h2 id="txzchk"><code>txzchk</code></h2>
-<p class="leftbar">
-<code>txzchk(1)</code> performs a wide number of sanity checks on the xz compressed
+<p><code>txzchk(1)</code> performs a wide number of sanity checks on the xz compressed
 tarball; if any issues are found (‘<code>feathers are stuck in the tarball</code>’ :-) )
 <strong>AND if and <em>ONLY IF</em> you used <code>mkiocccentry(1)</code></strong>, then it is <strong>possibly</strong> a
 bug in one of the tools and you might want to <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it as a bug at the
@@ -1067,108 +944,86 @@ mkiocccentry bug report
 page</a>.
 <strong>PLEASE run the <code>bug_report.sh</code> script to help us out here!</strong> You may do this
 by running from the top level directory of the repo <code>make bug_report</code>. See the
-FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.
-</p>
-<p class="leftbar">
-As part of its algorithm, <code>txzchk(1)</code> will run <code>fnamchk(1)</code> on the
+FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.</p>
+<p>As part of its algorithm, <code>txzchk(1)</code> will run <code>fnamchk(1)</code> on the
 <em>tarball</em> to verify that the <em>filename</em> is valid. See the
 FAQ on “<a href="../faq.html#fnamchk">fnamchk</a>”
-and the <a href="#fnamchk">fnamchk section</a> below for more details on this tool.
-</p>
-<p class="leftbar">
-It is beyond the scope of this document to discuss the many tests that
+and the <a href="#fnamchk">fnamchk section</a> below for more details on this tool.</p>
+<p>It is beyond the scope of this document to discuss the many tests that
 <code>txzchk(1)</code> performs; if you wish to know, we refer you to the <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">source
 code</a> or the man
-page. You might just find a fun option if you do either of these!
-</p>
-<p class="leftbar">
-Of course, as <code>txzchk</code> does not extract the tarball, it is possible that if you
+page. You might just find a fun option if you do either of these!</p>
+<p>Of course, as <code>txzchk</code> does not extract the tarball, it is possible that if you
 manually package your submission tarball and/or find and exploit a missing
-check, you could still be violating <a href="rules.html#rule17">Rule 17</a>.
-</p>
+check, you could still be violating <a href="rules.html#rule17">Rule 17</a>.</p>
 <div id="extra-files">
 <h2 id="including-optional-and-extra-files">Including optional and extra files</h2>
 </div>
 <p class="leftbar">
-The maximum total number of files that may be submitted has changed to <strong>39</strong> files.
-However, of those files, <strong>5</strong> are mandatory (<code>prog.c</code>, <code>Makefile</code>, <code>remarks.md</code> and
-the two JSON files generated by <code>mkiocccentry(1)</code>, <code>.info.json</code> and
-<code>.auth.json</code>).
+The maximum total number of <em>extra files</em> that may be submitted is 31.
 </p>
 <p class="leftbar">
-Additionally, three of the files, if included, <strong>MUST</strong> be
-specific file(name)s <strong>AND</strong> in the top level directory, or they will be counted as
-an extra file, not an optional file.
+An <em>extra file</em> is defined as a file that is not <code>prog.c</code>, <code>prog.alt.c</code>,
+<code>try.sh</code>, <code>try.alt.sh</code>, <code>remarks.md</code>, <code>Makefile</code>, <code>.auth.json</code> and <code>.info.json</code>:
+unless it’s not in the top level directory, in which case it <strong>IS</strong> an <em>extra
+file</em>. The non-extra files are considered <em>free files</em>.
 </p>
 <p class="leftbar">
-In particular, any file that is not <code>prog.c</code>, <code>Makefile</code>, <code>remarks.md</code>,
-<code>try.sh</code>, <code>prog.alt.c</code> or <code>try.alt.sh</code> will be counted as an extra file, and if
-<code>try.sh</code>, <code>prog.alt.c</code> or <code>try.alt.sh</code> are not in the top level submission
-directory they will also be counted as an extra file. The <code>.info.json</code> and
-<code>.auth.json</code> files are not counted as extra files but are required.
+Of course any dot file that is not <code>.auth.json</code> and <code>.info.json</code> will result in
+a violation of <a href="rules.html#rule17">Rule 17</a>, regardless of its depth.
 </p>
-<p class="leftbar">
-In other words, the actual amount of <strong>EXTRA</strong> files is <strong>31</strong>.
-</p>
-<p class="leftbar">
-If you use an optional filename for something other than their intended use
+<p>If you use an optional filename for something other than their intended use
 in order to get past the file limit, we will consider that an
-abuse of rules. For more details on the optional files, see the
+abuse of rules.</p>
+<p class="leftbar">
+For information on the <code>try</code> script files see the
 FAQ on the “<a href="../faq.html#try_script">try.sh script system</a>”
-and the
+and for more details on alt code (including the <code>try.alt.sh</code> script) see the
 FAQ on “<a href="../faq.html#alt_code">alt code</a>”.
 </p>
 <p class="leftbar">
-If you <strong>REALLY MUST</strong> include more files than the limit allows, then you may do so by including as an extra
-file, a tarball. This does <strong>NOT</strong> have to pass <code>txzchk(1)</code> tests; only the
-submission tarball must pass the <code>txzchk(1)</code> tests.
+If you really <strong>MUST</strong> include more files than the limit allows, then you may do
+so by including as an extra file, a tarball. This does <strong>NOT</strong> have to pass
+<code>txzchk(1)</code> tests; only the submission tarball must pass the <code>txzchk(1)</code> tests.
 </p>
 <p class="leftbar">
-If you <strong>DO</strong> include a tarball, and the build process or the program extracts
-said tarball(s), the make <code>clobber</code> rule <strong>MUST</strong> remove the extracted files. Even so, if you
-include a tarball to get past the limit on the number of files, you <strong>MUST</strong>
-justify this in your <code>remarks.md</code> file.
+You <strong>MUST</strong> justify including extra files beyond the limit, should you do so.
+Even so this does not mean it will be considered valid.
 </p>
 <p class="leftbar">
-<strong>IMPORTANT REMINDER</strong>: make <strong>SURE</strong> your tarball does <strong>NOT</strong> reveal who you are!
+If you use a tarball for a depth beyond the maximum, you <strong>MUST</strong> justify this
+as well. Even so this does not mean it will be considered valid.
+</p>
+<p>If you <strong>DO</strong> include a tarball, and the build process or the program extracts
+said tarball(s), the make <code>clobber</code> rule <strong>MUST</strong> remove the extracted files.</p>
+<p><strong>IMPORTANT REMINDER</strong>: make <strong>SURE</strong> your tarball does <strong>NOT</strong> reveal who you are!
 The <code>mkiocccentry(1)</code> tool creates a v7 format tarball to prevent this. You can
-do the same like:
-</p>
+do the same like:</p>
 <pre><code>    tar --format=v7 -cJf foo.txz directory</code></pre>
-<p class="leftbar">
-See <a href="rules.html#rule17">Rule 17</a> and in particular the part about the <a href="../faq.html#max-files">maximum
-number of files</a>. If you do not follow these points, you
-are at a great risk of violating <a href="rules.html#rule17">Rule 17</a>!
-</p>
-<p class="leftbar">
-<strong>NOTE</strong>: if you want to include a test-suite that requires a lot of files,
+<p>See <a href="rules.html#rule17">Rule 17</a> and also the
+FAQ on “<a href="../faq.html#max-files">maximum number of files</a>”.</p>
+<p>If you do not follow these points, you
+are at a great risk of violating <a href="rules.html#rule17">Rule 17</a>!</p>
+<p><strong>NOTE</strong>: if you want to include a test-suite that requires a lot of files,
 please suggest this in your <code>remarks.md</code> and if your submission wins it can
-be done. In other words you should not use a tarball for a test-suite unless you
+be done. In other words you should NOT use a tarball for a test-suite unless you
 have a very good reason for this (and if you do, make <strong>SURE</strong> you specify why
-in your <code>remarks.md</code> file).
-</p>
-<p class="leftbar">
-See also the
-FAQ on “<a href="../faq.html#txzchk">txzchk</a>”.
-</p>
+in your <code>remarks.md</code> file).</p>
+<p>See also the
+FAQ on “<a href="../faq.html#txzchk">txzchk</a>”.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="fnamchk">
 <h2 id="fnamchk1"><code>fnamchk(1)</code></h2>
 </div>
-<p class="leftbar">
-As an important part of its algorithm, <a href="#txzchk">txzchk(1)</a> directly executes
+<p>As an important part of its algorithm, <a href="#txzchk">txzchk(1)</a> directly executes
 <code>fnamchk(1)</code>. If the filename is invalid (or the filename does not match the
 directory name of the tarball) then it is an <strong>error</strong> and you risk violating
 <a href="rules.html#rule17">Rule 17</a>. Nevertheless, you can run the tool manually,
-should you wish to.
-</p>
-<p class="leftbar">
-For more information on <code>fnamchk</code> and how to manually validate your submission
+should you wish to.</p>
+<p>For more information on <code>fnamchk</code> and how to manually validate your submission
 tarball filename, see the
-FAQ on “<a href="../faq.html#fnamchk">fnamchk</a>”.
-</p>
-<p class="leftbar">
-It is extremely unlikely that <code>fnamchk(1)</code> reporting an invalid filename is a
+FAQ on “<a href="../faq.html#fnamchk">fnamchk</a>”.</p>
+<p>It is extremely unlikely that <code>fnamchk(1)</code> reporting an invalid filename is a
 bug in <code>fnamchk(1)</code> and as such, ignoring such an issue risks violating <a href="rules.html#rule17">Rule
 17</a> which is a big risk. Of course, using <code>mkiocccentry(1)</code>
 would prevent this from happening as it would not create such a file anyway. If
@@ -1176,111 +1031,86 @@ would prevent this from happening as it would not create such a file anyway. If
 you should <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">report it as a bug at the mkiocccentry issues
 page</a>.
 See the
-FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.
-</p>
-<p class="leftbar">
-As you can see, the use of <code>mkiocccentry(1)</code> is <strong>HIGHLY RECOMMENDED</strong>, and at
+FAQ on “<a href="../faq.html#mkiocccentry_bugs">reporting mkiocccentry bugs</a>”.</p>
+<p>As you can see, the use of <code>mkiocccentry(1)</code> is <strong>HIGHLY RECOMMENDED</strong>, and at
 the risk of stating the obvious, you run <strong>A VERY BIG RISK</strong> of having
 your submission rejected if you package your own tarball, and there are <strong>ANY
-problems</strong>. For instance, if <code>chkentry(1)</code> found a problem in your <code>.info.json</code>
+problems</strong>. For instance, if <code>chksubmit(1)</code> found a problem in your <code>.info.json</code>
 file, the <code>mkiocccentry(1)</code> tool would not package it. But if you were to package
 it manually, you would be violating <a href="rules.html#rule17">Rule 17</a>. But even if
-everything checks out OK you should <strong>NOT</strong> assume that everything <strong>IS</strong> OK.
-</p>
+everything checks out OK you should <strong>NOT</strong> assume that everything <strong>IS</strong> OK.</p>
 <div id="bugs">
-<h1 id="problems-andor-bugs-in-tools">Problems and/or bugs in tools</h1>
+<h1 id="problems-andor-bugs-in-the-mkiocccentry-toolkit">Problems and/or bugs in the mkiocccentry toolkit</h1>
 </div>
-<p class="leftbar">
-Although the tools have been tested extensively, it is nonetheless possible for bugs to
+<p>Although the tools have been tested extensively, it is nonetheless possible for bugs to
 exist in the code, as all programmers know. In this case, <strong>please</strong> ask for help or report what
 you think is a bug via the <a href="https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&amp;labels=bug&amp;projects=&amp;template=bug_report.yml&amp;title=%5BBug%5D+%3Ctitle%3E">bug report issues page in the mkiocccentry
-repo</a>.
-</p>
-<p class="leftbar">
-Of course, it is also possible for <code>mkiocccentry(1)</code>, or one or more of the
+repo</a>.</p>
+<p>Of course, it is also possible for <code>mkiocccentry(1)</code>, or one or more of the
 tools it executes (or another tool executes), to fail, but <strong>NOT</strong> because of a
 bug. An example problem is if there is not enough memory available or if some
 other library or syscall fails. Nonetheless it might be worth reporting as a
 bug; it is a judgement call: if it’s a bug it’ll be addressed and if it’s not
-that’s OK too!
-</p>
+that’s OK too!</p>
 <div id="make">
 <div id="makefile">
 <h1 id="makefiles">Makefiles</h1>
 </div>
 </div>
-<p class="leftbar">
-We <strong>recommend</strong> AND <strong>encourage</strong> you to use the example Makefile,
-as the starting point for your submission’s required <code>Makefile</code>:
-</p>
+<p>We <strong>recommend</strong> AND <strong>encourage</strong> you to use the example Makefile,
+as the starting point for your submission’s required <code>Makefile</code>:</p>
 <ul>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/next/Makefile.example">view example Makefile</a></li>
 <li><a href="Makefile.example" download="Makefile">download example Makefile</a></li>
 </ul>
-<p class="leftbar">
-Feel free to modify the <code>Makefile</code> to suit your obfuscation
-needs.
-</p>
-<p class="leftbar">
-<strong>Please</strong> add a space between the <code>=</code> and the value of variables, in the
+<p>Feel free to modify the <code>Makefile</code> to suit your obfuscation
+needs.</p>
+<p><strong>Please</strong> add a space between the <code>=</code> and the value of variables, in the
 <code>Makefile</code>, making sure that the <code>=</code> comes immediately after the name. See the
-example <code>Makefile</code> for examples.
-</p>
+example <code>Makefile</code> for examples.</p>
 <p class="leftbar">
-The rest of this section and its subsections will assume that you are using some
-variant of the example <code>Makefile</code>, again renamed as <code>Makefile</code>.
+This helps us fit the Makefile into a winning entry, should your submission win.
 </p>
-<p class="leftbar">
-We suggest that you compile your submission with a commonly available
+<p>The rest of this section and its subsections will assume that you are using some
+variant of the example <code>Makefile</code>, again renamed as <code>Makefile</code>.</p>
+<p>We suggest that you compile your submission with a commonly available
 <code>-std=gnu17</code> (ISO C 2017 with GNU extensions) C compiler, via <code>clang(1)</code>
-and/or <code>gcc(1)</code>.
-</p>
+and/or <code>gcc(1)</code>.</p>
 <div id="cflags">
 <div id="flags">
 <h2 id="default-compiler-flags">Default compiler flags</h2>
 </div>
 </div>
-<p class="leftbar">
-Unless you <strong>clearly state</strong> otherwise in your <code>remarks.md</code> file, <strong>AND</strong> put in
-your submission’s <code>Makefile</code>, we <strong>will</strong> compile using <code>-std=gnu17 -O3</code>!
-</p>
-<p class="leftbar">
-It <strong>is OK</strong> if you need to require your submission to <strong>NOT be</strong> compiled
+<p>Unless you <strong>clearly state</strong> otherwise in your <code>remarks.md</code> file, <strong>AND</strong> put in
+your submission’s <code>Makefile</code>, we <strong>will</strong> compile using <code>-std=gnu17 -O3</code>!</p>
+<p>It <strong>is OK</strong> if you need to require your submission to <strong>NOT be</strong> compiled
 using the default <code>-std=gnu17 -O3</code> settings. Simply <strong>explain why</strong>
 your submission should NOT be compiled using <code>-std=gnu17 -O3</code> in
-your <code>remarks.md</code> file, <strong>AND</strong> adjust your <code>Makefile</code> accordingly.
-</p>
+your <code>remarks.md</code> file, <strong>AND</strong> adjust your <code>Makefile</code> accordingly.</p>
 <p class="leftbar">
-One reason that you might have to change the flags, is that the optimiser is
+You really should <strong>NOT</strong> redefine <code>CC</code> because doing so makes it less portable. &lt;– <strong>Hint!</strong>
+</p>
+<p>One reason that you might have to change the flags, is that the optimiser is
 known to break some programs, but there are certainly other possible valid
 reasons. Again, just update the <code>Makefile</code> and explain it in your <code>remarks.md</code>.
 See the <a href="#optimiser">optimiser section</a> for details for changing optimiser
-flags.
-</p>
-<p class="leftbar">
-For more fun when it comes to optimisers breaking code, see
-<a href="../1986/marshall/compilers.html">1986/marshall/compilers.html</a>.
-</p>
+flags.</p>
+<p>For more fun when it comes to optimisers breaking code, see
+<a href="../1986/marshall/compilers.html">1986/marshall/compilers.html</a>.</p>
 <div id="compilers">
 <h2 id="default-compiler">Default compiler</h2>
 </div>
-<p class="leftbar">
-<strong>IMPORTANT NOTE</strong>: The use of <code>-std=gnu17</code> does <strong>NOT</strong> imply the use of the <code>gcc</code>
-compiler! We often start by compiling using the <strong>clang</strong> C compiler instead.
-</p>
-<p class="leftbar">
-<strong>PLEASE NOTE</strong>: in macOS, the compiler <code>gcc</code> found at <code>/usr/bin/gcc</code> is
-in truth the <code>clang</code> compiler, as <code>/usr/bin/gcc --version</code> will show!
-</p>
+<p><strong>IMPORTANT NOTE</strong>: The use of <code>-std=gnu17</code> does <strong>NOT</strong> imply the use of the <code>gcc</code>
+compiler! We often start by compiling using the <strong>clang</strong> C compiler instead.</p>
+<p><strong>PLEASE NOTE</strong>: in macOS, the compiler <code>gcc</code> found at <code>/usr/bin/gcc</code> is
+in truth the <code>clang</code> compiler, as <code>/usr/bin/gcc --version</code> will show!</p>
 <div id="cstd">
 <div id="standard">
 <h2 id="c-standard">C standard</h2>
 </div>
 </div>
-<p class="leftbar">
-You may change the standard under which your submission is compiled
-by modifying the <code>CSTD</code> Makefile variable. For example, to use <code>c99</code> instead:
-</p>
+<p>You may change the standard under which your submission is compiled
+by modifying the <code>CSTD</code> Makefile variable. For example, to use <code>c99</code> instead:</p>
 <pre><code>    CSTD= -std=c99</code></pre>
 <div id="opt">
 <div id="optimization">
@@ -1293,277 +1123,209 @@ by modifying the <code>CSTD</code> Makefile variable. For example, to use <code>
 </div>
 </div>
 </div>
-<p class="leftbar">
-You may change the level of optimization and compiler debug level
+<p>You may change the level of optimization and compiler debug level
 that your submission is compiled with, by modifying the <code>OPT</code> Makefile variable.
-For example, to compile without optimization, and to include debug symbols:
-</p>
+For example, to compile without optimization, and to include debug symbols:</p>
 <pre><code>    OPT= -O0 -g3</code></pre>
 <div id="warnings">
 <div id="cwarn">
 <h2 id="compiler-warnings">Compiler warnings</h2>
 </div>
 </div>
-<p class="leftbar">
-The default warning flags are set via the <code>CWARN</code> variable, as shown in the
-example <code>Makefile</code>:
-</p>
+<p>The default warning flags are set via the <code>CWARN</code> variable, as shown in the
+example <code>Makefile</code>:</p>
 <pre><code>    # Common C compiler warning flags
     #
     CWARN= -Wall -Wextra ${CSILENCE} ${CUNKNOWN}</code></pre>
-<p class="leftbar">
-For details on <code>CSILENCE</code> and <code>CUNKNOWN</code>, see the <a href="#disabling-warnings">section on disabling
-warnings</a>.
-</p>
+<p>For details on <code>CSILENCE</code> and <code>CUNKNOWN</code>, see the <a href="#disabling-warnings">section on disabling
+warnings</a>.</p>
 <div id="weverything">
 <h3 id="the--weverything-option">The <code>-Weverything</code> option</h3>
 </div>
-<p class="leftbar">
-For compilers, such as <code>clang</code>, that have the <code>-Weverything</code> option,
+<p>For compilers, such as <code>clang</code>, that have the <code>-Weverything</code> option,
 while you may wish to try it, you should read our
 FAQ on “<a href="../faq.html#weverything">clang -Weverything</a>”.
 We do <strong>NOT</strong> recommend that you put
 the use of <code>-Weverything</code> into your submission’s <code>Makefile</code> for the reasons
 cited there. This goes even if your version does not trigger a warning as some
-other version might!
-</p>
-<p class="leftbar">
-On the other hand, if <code>${CC}</code> has “<code>clang</code>” in the name, the example <code>Makefile</code> will
+other version might!</p>
+<p>On the other hand, if <code>${CC}</code> has “<code>clang</code>” in the name, the example <code>Makefile</code> will
 automatically enable <code>-Weverything</code>, so you might have to use <code>-Wno-foo</code>
 options anyway, as detailed below. See the
 FAQ on “<a href="../faq.html#weverything">-Weverything</a>”
-for more details.
-</p>
-<p class="leftbar">
-If “<code>clang</code>” is NOT in <code>${CC}</code>, the <code>CWARN</code> variable will not be further
-modified.
-</p>
-<p class="leftbar">
-There is no real penalty for compiler warnings. Sometimes
+for more details.</p>
+<p>If “<code>clang</code>” is NOT in <code>${CC}</code>, the <code>CWARN</code> variable will not be further
+modified.</p>
+<p>There is no real penalty for compiler warnings. Sometimes
 compiler warnings cannot be helped: especially in the case of
 obfuscated C. :-) So if you cannot easily get rid of a compiler
-warning, try not to fret too much.
-</p>
-<p class="leftbar">
-We <strong>LIKE</strong> code that has a minimum of warnings, especially under the
-more strict <code>-Wall -Wextra -pedantic</code> mode:
-</p>
+warning, try not to fret too much.</p>
+<p>We <strong>LIKE</strong> code that has a minimum of warnings, especially under the
+more strict <code>-Wall -Wextra -pedantic</code> mode:</p>
 <pre><code>    CWARN= -Wall -Wextra -pedantic</code></pre>
-<p class="leftbar">
-The two previous guidelines might be thought by some as being somewhat
+<p>The two previous guidelines might be thought by some as being somewhat
 contradictory. Isn’t life, and isn’t trying to satisfy “contradictory customer
 requirements” all too often like that? :-) Try to minimize warnings if you
-can.
-</p>
-<p class="leftbar">
-If you manage to produce very few warnings, or perhaps no warnings at
+can.</p>
+<p>If you manage to produce very few warnings, or perhaps no warnings at
 all under the <code>-Wall -Wextra -pedantic</code> mode, then by all means brag about it in
 your <code>remarks.md</code> file <strong>AND BE SURE TO TELL US</strong> the OS, OS version, compiler
 and compiler version in which you observed this occurring (in case our OS and
 compiler produces a different result: so your submission won’t be penalized for
-not meeting your claims).
-</p>
-<p class="leftbar">
-On the other hand, some warnings cannot be disabled and are enabled by compilers
+not meeting your claims).</p>
+<p>On the other hand, some warnings cannot be disabled and are enabled by compilers
 without any warning option specified. These are sometimes inevitable in
 obfuscated code and even in some non-obfuscated code, and you should not worry
-about this, though it might be worth pointing out.
-</p>
-<p class="leftbar">
-For instance, some compilers like to warn about use of pointers as arrays, which seems to
+about this, though it might be worth pointing out.</p>
+<p>For instance, some compilers like to warn about use of pointers as arrays, which seems to
 be dubious, as it obviously can’t (always) be avoided, being a big part of C, so
 you should not worry about this either; this is the warning
 <code>-Wunsafe-buffer-usage</code> and the way to disable it is <code>-Wno-unsafe-buffer-usage</code>.
 See also the
 FAQ on “<a href="../faq.html#forced_warnings">forced warnings</a>”
 and the
-FAQ on “<a href="../faq.html#weverything">-Weverything</a>”.
-</p>
+FAQ on “<a href="../faq.html#weverything">-Weverything</a>”.</p>
 <h2 id="disabling-warnings">Disabling warnings</h2>
 <p class="leftbar">
 If you do have to disable warnings due to <code>-Weverything</code> automatically being
 included, you might wish to state this fact in your <code>remarks.md</code> file.
 And even without <code>-Weverything</code> there can be warnings, as noted above.
 </p>
-<p class="leftbar">
-If your submission issues lots of warnings but is otherwise
+<p>If your submission issues lots of warnings but is otherwise
 marvelously obfuscated in multiple levels, don’t worry about it. Nevertheless,
 be sure that the warnings do not constitute a potential “<strong>show stopper</strong>”
 compiler problem. Be sure that compilers such as both <code>gcc</code> and <code>clang</code> won’t
 produce a compiler <strong>error</strong> and refuse to compile your code: unless for some
 reason that is what you intend to happen in which case document that too in your
-<code>remarks.md</code> file. :-)
-</p>
+<code>remarks.md</code> file. :-)</p>
 <p>All other things being equal, a program that must turn off fewer
 warnings will be considered better, for certain values of better.</p>
-<p class="leftbar">
-To turn off a compiler warning, in your submission’s <code>Makefile</code>,
-try something such as:
-</p>
+<p>To turn off a compiler warning, in your submission’s <code>Makefile</code>,
+try something such as:</p>
 <pre><code>    CSILENCE= -Wno-some-thing -Wno-another-thing</code></pre>
 <p class="leftbar">
 For instance:
 </p>
 <pre><code>    CSILENCE= -Wno-parentheses -Wno-binding-in-condition -Wno-misleading-indentation</code></pre>
-<p class="leftbar">
-If you do add “<code>-Wno-foo</code>” to your Makefile, consider changing:
-</p>
-<pre><code>    CUNKNOWN=</code></pre>
-<p class="leftbar">
-to:
-</p>
-<pre><code>    CUNKNOWN= -Wno-unknown-warning-option</code></pre>
-<p class="leftbar">
-Some compilers have reported this as an error, however, and if you have
-such a compiler you might want to not add it, or at least note in your
-<code>remarks.md</code> file, which OS, OS version, compiler and compiler version
-that has such a problem.
-</p>
 <div id="macros">
 <h2 id="defining-macros-in-the-makefile">Defining macros in the Makefile</h2>
 </div>
-<p class="leftbar">
-If you need to define something on the compile line, use
-the <code>CDEFINE</code> Makefile variable. For example:
-</p>
+<p>If you need to define something on the compile line, use
+the <code>CDEFINE</code> Makefile variable. For example:</p>
 <pre><code>    CDEFINE= -Dfoo -Dbar=baz</code></pre>
-<p class="leftbar">
-<strong>NOTE</strong>: just because we offer a default way to use the <code>-D</code> option, we still
+<p><strong>NOTE</strong>: just because we offer a default way to use the <code>-D</code> option, we still
 do not like excess use of <code>-D</code> to get past size limits, especially since you
-could use <code>#define</code> in your code instead.
-</p>
+could use <code>#define</code> in your code instead.</p>
 <div id="include">
 <h2 id="include-files-in-the-makefile">Include files in the Makefile</h2>
 </div>
-<p class="leftbar">
-If you need to include a file (as in <code>#include</code>) on the command line, use the
-<code>CINCLUDE</code> Makefile variable. For example:
-</p>
+<p>If you need to include a file (as in <code>#include</code>) on the command line, use the
+<code>CINCLUDE</code> Makefile variable. For example:</p>
 <pre><code>    CINCLUDE= -include stdio.h</code></pre>
 <div id="magic">
 <h2 id="magic-in-the-makefile">Magic in the Makefile</h2>
 </div>
-<p class="leftbar">
-If you need to add other “<strong>magic</strong>” flags to your compile line,
-use the <code>COTHER</code> Makefile variable. For example:
-</p>
+<p>If you need to add other “<strong>magic</strong>” flags to your compile line,
+use the <code>COTHER</code> Makefile variable. For example:</p>
 <pre><code>    COTHER= -fno-math-errno</code></pre>
-<p class="leftbar">
-<strong>NOTE</strong>: <strong>We only recommend using “<em>magic</em>” flags if <em>BOTH</em> <code>gcc</code>
-<em>and</em> <code>clang</code></strong> support it.
-</p>
-<p class="leftbar">
-Again, please note that in macOS, <code>/usr/bin/gcc</code> is actually <code>clang</code>!
-</p>
+<p><strong>NOTE</strong>: <strong>We only recommend using “<em>magic</em>” flags if <em>BOTH</em> <code>gcc</code>
+<em>and</em> <code>clang</code></strong> support it.</p>
+<p>Again, please note that in macOS, <code>/usr/bin/gcc</code> is actually <code>clang</code>!</p>
 <div id="clobber">
 <h2 id="the-clobber-rule">The clobber rule</h2>
 </div>
-<p class="leftbar">
-When <code>make clobber</code> is invoked, we request that submissions be restored
+<p>When <code>make clobber</code> is invoked, we request that submissions be restored
 to their original submission state. For example, any temporary files
 (<strong>including</strong> the compiled program(s)) created during the build process, or
 during execution should be removed by the <code>clobber</code> rule. In other words, the
 only things that should be in the directory after running <code>make clobber</code> is what
-is in your submission tarball itself.
-</p>
-<p class="leftbar">
-While people are free to manage their submission under <code>git(1)</code> or even use a
+is in your submission tarball itself.</p>
+<p>While people are free to manage their submission under <code>git(1)</code> or even use a
 GitHub repo, dot-files and dot-directories such as <code>.git</code> are not allowed in a
-submission.
-</p>
-<p class="leftbar">
-The <code>mkiocccentry(1)</code> tool will ignore dot-files and dot-directories (such as
+submission.</p>
+<p>The <code>mkiocccentry(1)</code> tool will ignore dot-files and dot-directories (such as
 <code>.vimrc</code>, <code>.bashrc</code>, <code>.git</code> and <code>.github</code>) and not put them in the submission’s
 compressed tarball. So while you may use such files and
 directories to help develop your submission, they won’t be included when you run
-the <code>mkiocccentry(1)</code> tool.
-</p>
-<p class="leftbar">
-Even if you did manage to get dot files or dot directories in the tarball
+the <code>mkiocccentry(1)</code> tool.</p>
+<p>Even if you did manage to get dot files or dot directories in the tarball
 somehow, <code>txzchk(1)</code> will flag it as an error. When the judges run <code>txzchk(1)</code>
 on the uploaded submission compressed tarball, if anything is wrong, for
 instance if you “sneak in” any dot files or dot directories, the submission
-<strong>WILL BE REJECTED</strong> for violating <a href="rules.html#rule17">Rule 17</a>!
-</p>
-<p class="leftbar">
-You may use whatever tools you need to develop your submission, including the
+<strong>WILL BE REJECTED</strong> for violating <a href="rules.html#rule17">Rule 17</a>!</p>
+<p>You may use whatever tools you need to develop your submission, including the
 use of <code>git(1)</code> or <code>gh(1)</code>, just be sure that your submission code and your
-submission Makefile don’t depend on such tools.
+submission Makefile don’t depend on such tools.</p>
+<p>Of course if you do use GitHub to work on your submission, you might want to
+make the repo private so you don’t reveal who you are. :-)</p>
+<p class="leftbar">
+In other words, make <strong>SURE</strong> you keep anonymous who submitted the code!
 </p>
 <p class="leftbar">
-Of course if you do use GitHub to work on your submission, you might want to
-make the repo private so you don’t reveal who you are. :-)
-</p>
-<p class="leftbar">
-If this is not clear, please do <strong>NOT</strong> use these tools to help with the
+Please do <strong>NOT</strong> use these tools to help with the
 <code>clobber</code> rule! For instance, do <strong>NOT</strong> use <code>git clean</code>! Not only does this
 depend on the user having <code>git(1)</code> but it also does not account for the
 submission tarballs. Even worse is when someone does have it in a <code>git(1)</code> repo
 it will remove files that are not under <code>git(1)</code> control! Instead, see the
 <code>clobber</code> rule in the example Makefile to see how to manage this.
 </p>
-<p class="leftbar">
-In other words, for <code>make clobber</code>, do something like:
-</p>
+<p>In other words, for <code>make clobber</code>, do something like:</p>
 <pre><code>    clobber:
             ${RM} -f foo bar baz</code></pre>
 <p>and <strong>NOT</strong> something like this:</p>
 <pre><code>    # do NOT do this!
     clobber:
             -git clean -f   # WRONG !!!</code></pre>
-<p class="leftbar">
-And do <strong>NOT</strong> use <code>git</code> for any other <code>Makefile</code> rule either.
-</p>
-<p class="leftbar">
-<strong>NOTE</strong>: <code>mkiocccentry(1)</code> will directly run <code>make clobber</code> in the submission
+<p>And do <strong>NOT</strong> use <code>git</code> for any other <code>Makefile</code> rule either.</p>
+<p><strong>NOTE</strong>: <code>mkiocccentry(1)</code> will directly run <code>make clobber</code> in the submission
 directory. And although it is not an error if this fails, if it fails because the
 Makefile does not have a clobber rule, it will be flagged by <code>mkiocccentry(1)</code>
-(you may ignore this but it does put you at a risk of violating the rules).
-</p>
+(you may ignore this but it does put you at a risk of violating the rules).</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="likes">
 <div id="dislikes">
 <h1 id="our-likes-and-dislikes">OUR LIKES AND DISLIKES:</h1>
 </div>
 </div>
-<p class="leftbar">
-We <strong>VERY MUCH LIKE</strong> submissions that use an edited variant of the
+<p>We <strong>VERY MUCH LIKE</strong> submissions that use an edited variant of the
 example Makefile, as described and linked to in the <a href="#makefile">Makefile section</a>,
 renamed as <code>Makefile</code> of course. This makes it easier for the <a href="../judges.html">IOCCC judges</a>
 to test your submission. And if your submissions wins, it makes it easier to integrate it into
-the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.
-</p>
-<p class="leftbar">
-We <strong>VERY MUCH LIKE</strong> submissions that have some educational value. This does <strong>NOT</strong> mean
+the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
+<p>We <strong>VERY MUCH LIKE</strong> submissions that have some educational value. This does <strong>NOT</strong> mean
 that your submission should not be obfuscated but rather that the IOCCC has moved away from
-the idea of “spoilers”. You should not encrypt or rot13 content in your <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-It is <strong>VERY MUCH</strong> appreciated if your remarks have some educational
+the idea of “spoilers”. You should not encrypt or rot13 content in your <code>remarks.md</code> file.</p>
+<p>It is <strong>VERY MUCH</strong> appreciated if your remarks have some educational
 value. And although educational value is not required, it is an
-<strong>EXCELLENT</strong> bonus.
-</p>
-<p class="leftbar">
-We <strong>LIKE</strong> submissions that use an edited version of the
+<strong>EXCELLENT</strong> bonus.</p>
+<p>We <strong>LIKE</strong> submissions that use an edited version of the
 <code>try.sh</code> example script (and if you have alternate code,
-the same applies with the <code>try.alt.sh</code> script):
-</p>
+the same applies with the <code>try.alt.sh</code> script):</p>
 <ul>
 <li><p><a href="https://github.com/ioccc-src/winner/blob/master/next/try.sh">view example try.sh</a></p></li>
 <li><p><a href="try.sh">download example try.sh</a></p></li>
 <li><p><a href="https://github.com/ioccc-src/winner/blob/master/next/try.alt.sh">view example try.alt.sh</a></p></li>
 <li><p><a href="try.alt.sh">download example try.alt.sh</a></p></li>
 </ul>
-<p class="leftbar">
-Of course, it is quite possible that only one invocation is
+<p>Of course, it is quite possible that only one invocation is
 possible, so it is not necessarily detrimental to your submission if you do not
 include one, though we do like interesting and creative uses of submissions. See
 also the
-FAQ on “<a href="../faq.html#try_scripts">submitting try.sh and try.alt.sh scripts</a>”.
+FAQ on “<a href="../faq.html#try_scripts">submitting try.sh and try.alt.sh scripts</a>”.</p>
+<p class="leftbar">
+Even if it only has one invocation we still <strong>LIKE</strong> the try scripts.
 </p>
 <p class="leftbar">
-You might wish to add <code>./try.sh</code> to the <code>try</code> rule in the Makefile you submit.
-If you have alternate code, then you can use the <code>try.alt</code> rule as well.
+If you do include a <code>try.sh</code> then <strong>PLEASE</strong> remove the <code>try</code> rule in the
+Makefile.
+</p>
+<p class="leftbar">
+If you do include a <code>try.alt.sh</code> then <strong>PLEASE</strong> remove the <code>try.alt</code> rule in
+the Makefile.
+</p>
+<p class="leftbar">
+If you don’t have a prog.alt.c, then <strong>PLEASE</strong> remove the <code>try.alt</code> rule as
+well.
 </p>
 <p>Doing masses of <code>#define</code>s to obscure the source has become ‘old’. We
 tend to ‘see thru’ masses of <code>#define</code>s due to our pre-processor tests
@@ -1572,27 +1334,19 @@ as a program that is more well rounded in confusion.</p>
 <p><strong>Many</strong> C compilers <strong>DISLIKE</strong> the following code, and so do we:</p>
 <pre><code>    #define d define
     #d foo             /* &lt;-- don&#39;t expect this to turn into #define foo */</code></pre>
-<p class="leftbar">
-In other words, it is a compilation error, and in order to get older
-IOCCC winning entries that did this to compile, we had to update them to not do this.
-</p>
+<p>In other words, it is a compilation error, and in order to get older
+IOCCC winning entries that did this to compile, we had to update them to not do this.</p>
 <p>When declaring local or global variables, you should declare the type:</p>
 <pre><code>    int this_is_fine;
     this_is_not;       /* &lt;-- Try to avoid implicit type declarations */</code></pre>
-<p class="leftbar">
-We tend to <strong>like <em>less</em></strong> a submission that requires either
+<p>We tend to <strong>like <em>less</em></strong> a submission that requires either
 <code>gcc</code> <strong>OR</strong> <code>clang</code>. <strong>We <em>prefer</em> submissions</strong> that can compile
-under <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.
-</p>
-<p class="leftbar">
-We <strong>RECOMMEND</strong> that the compiler flags you use in your
-submission’s <code>Makefile</code> are supported by <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.
-</p>
-<p class="leftbar">
-We <strong>DISLIKE</strong> the use of obscure compiler flags, especially
+under <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>. <strong>Hint!</strong></p>
+<p>We <strong>RECOMMEND</strong> that the compiler flags you use in your
+submission’s <code>Makefile</code> are supported by <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.</p>
+<p>We <strong>DISLIKE</strong> the use of obscure compiler flags, especially
 if <code>gcc</code> and/or <code>clang</code> do not support it. We <strong>suggest</strong>
-that you not use any really obscure compiler flags if you can help it.
-</p>
+that you not use any really obscure compiler flags if you can help it.</p>
 <p>One side effect of the above is that you cannot assume the use
 of nested functions such as:</p>
 <pre><code>     int main() {
@@ -1605,9 +1359,7 @@ of nested functions such as:</p>
 nested functions. Such constructions, while interesting and sometimes
 amusing, will have to wait until they are required by a C standard that are
 actually implemented in <strong>BOTH</strong> <code>gcc</code> <strong>AND</strong> <code>clang</code>.</p>
-<p class="leftbar">
-We <strong>DISLIKE</strong> submissions that require the use of <code>-fnested-functions</code>.
-</p>
+<p>We <strong>DISLIKE</strong> submissions that require the use of <code>-fnested-functions</code>.</p>
 <p>We prefer programs that do not require a fish license: crayons and
 cat detector vans not withstanding.</p>
 <p>If your submission uses functions that have a variable number of
@@ -1623,17 +1375,15 @@ not portable and <em>must not</em> be used</strong>:</p>
 <li>using <code>va_list</code> as a structure or union</li>
 </ul>
 <p>In particular, do not treat <code>va_list</code> variables as if they were a <code>char **</code>.</p>
-<p class="leftbar">
-We <strong>DISLIKE</strong> the use of <code>varargs.h</code>. Use <code>stdarg.h</code> instead.
-</p>
-<p class="leftbar">
-We <strong>DISLIKE</strong> the use of <code>gets(3)</code>. Use <code>fgets(3)</code> instead.
-</p>
-<p class="leftbar">
-We tend to <strong>DISLIKE</strong> the blatant use of tarballs in an attempt to simply get
+<p>We <strong>DISLIKE</strong> the use of <code>varargs.h</code>. Use <code>stdarg.h</code> instead.</p>
+<p>We <strong>DISLIKE</strong> the use of <code>gets(3)</code>. Use <code>fgets(3)</code> instead.</p>
+<p>We tend to <strong>DISLIKE</strong> the blatant use of tarballs in an attempt to simply get
 around the extra file number limit. We realize there may be cases where a
 tarball containing a number of extra files may be needed. Such a need for a
-tarball <strong>MUST</strong> be explained in the <code>remarks.md</code> file.
+tarball <strong>MUST</strong> be explained in the <code>remarks.md</code> file.</p>
+<p class="leftbar">
+Using a mass of <code>goto</code>s to obfuscate your code has become ‘old’ and is unlikely
+to make it through the final rounds, if it even gets that far.
 </p>
 <p>On 28 January 2007, the Judges rescinded the requirement that the
 <code>#</code> in a C preprocessor directive must be the 1st non-whitespace byte.</p>
@@ -1647,19 +1397,15 @@ While such programs are not as complex as other winners, they do
 serve a useful purpose: they are often the only program that people
 attempt to completely understand. For this reason, we look for
 programs that are compact, and are instructional.</p>
-<p class="leftbar">
-While those who are used to temperatures found on <a href="https://science.nasa.gov/dwarf-planets/">dwarf
+<p>While those who are used to temperatures found on <a href="https://science.nasa.gov/dwarf-planets/">dwarf
 planets</a>
 (<strong>yes Virginia, dwarf planets <em>ARE</em> planets!</strong>), such as
 <a href="https://science.nasa.gov/dwarf-planets/pluto/">Pluto</a>, might be able to
 explain to the Walrus why our seas are boiling hot, the question of
-whether pigs have wings is likely to remain a debatable point to most.
-</p>
-<p class="leftbar">
-One line programs should be short one line programs: say around <strong>80</strong> to <strong>132</strong>
+whether pigs have wings is likely to remain a debatable point to most.</p>
+<p>One line programs should be short one line programs: say around <strong>80</strong> to <strong>132</strong>
 bytes long. Going well beyond <strong>132</strong> bytes is a bit too long to be called
-a one-liner in our vague opinion.
-</p>
+a one-liner in our vague opinion.</p>
 <p>We tend to <strong>DISLIKE</strong> programs that:</p>
 <ul>
 <li>are very hardware specific</li>
@@ -1667,53 +1413,30 @@ a one-liner in our vague opinion.
 sockets/streams specific code is likely not to be)</li>
 <li>dump core or have compiler warnings (it is OK only if
 you warn us in your <code>remarks.md</code> file)</li>
-<li><p class="leftbar">
-won’t compile or run in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+<li>won’t compile or run in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
-environment
-</p></li>
-<li><p class="leftbar">
-depend on a utility or application not normally found
+environment</li>
+<li>depend on a utility or application not normally found
 in systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
-Specification</a>
-</p></li>
-<li>abuse the build file to get around the size limit<br></li>
-<li><p class="leftbar">
-obfuscate by use of ANSI trigraphs
-</p></li>
-<li><p class="leftbar">
-obfuscate by use of digraphs
-</p></li>
-<li><p class="leftbar">
-are larger than they need to be
-</p></li>
-<li><p class="leftbar">
-have more lines than they need to have
-</p></li>
-<li><p class="leftbar">
-are “blob-ier” (just a pile of unformatted C code)
-than they need to be
-</p></li>
-<li><p class="leftbar">
-are rather similar to <strong><a href="../years.html">previous
-winners</a></strong> :-(
-</p></li>
-<li><p class="leftbar">
-are <strong>identical</strong> to <strong><a href="https://en.wikipedia.org/wiki/Null_device">previous
-losers</a></strong> :-)
-</p></li>
+Specification</a></li>
+<li>abuse the build file to get around the size limit</li>
+<li>obfuscate by use of ANSI trigraphs</li>
+<li>obfuscate by use of digraphs</li>
+<li>are larger than they need to be</li>
+<li>have more lines than they need to have</li>
+<li>are “blob-ier” (just a pile of unformatted C code) than they need to be</li>
+<li>are rather similar to <strong><a href="../years.html">previous winners</a></strong> :-(</li>
+<li>are <strong>identical</strong> to <strong><a href="https://en.wikipedia.org/wiki/Null_device">previous losers</a></strong> :-)</li>
 <li>that mandate the exclusive use of a specific Integrated Development Environment (IDE)</li>
 </ul>
 <p>In order to encourage submission portability, we <strong>DISLIKE</strong> submissions that
 fail to build unless one is using an IDE. For example, do not
 mandate that one must use Microsoft Visual Studio to compile
 your submission.</p>
-<p class="leftbar">
-The program must compile and link cleanly in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+<p>The program must compile and link cleanly in a <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environment. Therefore do not assume the system has a
-<a href="https://en.wikipedia.org/wiki/Windows.h">windows.h</a> include file:
-</p>
+<a href="https://en.wikipedia.org/wiki/Windows.h">windows.h</a> include file:</p>
 <pre><code>    #include &lt;windows.h&gt;  /* we DISLIKE this */</code></pre>
 <p>Unless you are cramped for space, or unless you are entering the
 ‘<strong>Best one liner</strong>’ category, we suggest that you format your program
@@ -1730,29 +1453,21 @@ is quite another to use many bytes of <code>-D</code>s in order to try and squee
 source under the size limit.</p>
 <p>Your source code, post-pre-processing, should not exceed the size of
 <a href="https://en.wikipedia.org/wiki/Microsoft_Windows">Microsoft Windows</a>. :-)</p>
-<p class="leftbar">
-Other windows, on the other hand, might be OK: especially where “<strong>X
+<p>Other windows, on the other hand, might be OK: especially where “<strong>X
 marks the spot</strong>”. Yet on the third hand, windows are best when they are
-“unseen” (i.e., not dirty). :-)
-</p>
-<p class="leftbar">
-The <a href="../judges.html">IOCCC judges</a>, as a group, have a history giving wide degree of latitude
+“unseen” (i.e., not dirty). :-)</p>
+<p>The <a href="../judges.html">IOCCC judges</a>, as a group, have a history giving wide degree of latitude
 to reasonable submissions. And recently they have had as much longitudinal
-variation as it is possible to have on <a href="https://science.nasa.gov/earth/">Earth</a>. :-)
-</p>
-<p class="leftbar">
-You should try to restrict commands used in the build file to commands found in
+variation as it is possible to have on <a href="https://science.nasa.gov/earth/">Earth</a>. :-)</p>
+<p>You should try to restrict commands used in the build file to commands found in
 <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environments and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
-Specification</a>.
-</p>
-<p class="leftbar">
-You may compile and use your own programs. If you do, try to build and execute
+Specification</a>.</p>
+<p>You may compile and use your own programs. If you do, try to build and execute
 from the current directory. This restriction is not a hard and
 absolute one. The intent is to ensure that the building of your
-program is reasonably portable.
-</p>
+program is reasonably portable.</p>
 <p>We prefer programs that are portable across a wide variety of UNIX-like
 operating systems (e.g., Linux, GNU Hurd, BSD, UNIX, etc.).</p>
 <blockquote>
@@ -1782,25 +1497,25 @@ bytes. <strong>REALLY TRY</strong> to be more creative than blob coding. <strong
 Please try to be much more creative.</p>
 <p>We really <strong>DISLIKE</strong> submissions that make blatant use of including
 large data files to get around the source code size limit.</p>
-<p>We do not recommend submitting <a href="https://systemd.io">systemd</a> source code to the IOCCC,
+<p class="leftbar">
+We do not recommend submitting <a href="https://systemd.io">systemd</a> source code to the IOCCC,
 if nothing else because that code is likely to exceed <a href="rules.html#rule2">the source code
 size limit</a>. This isn’t to say that another highly compact and obfuscated
-replacement of <code>init</code> would not be an interesting submission.</p>
+replacement of <code>init(8)</code> would not be an interesting submission.
+</p>
 <p>Did we remember to indicate that programs that blatantly use
 some complex state machine to do something simple, are boring?
 We think we did. :-)</p>
 <blockquote>
 <p>All generalizations are false, including this one. – <strong>Mark Twain</strong></p>
 </blockquote>
-<p class="leftbar">
-Given two versions of the same program, one that is a compact blob
+<p>Given two versions of the same program, one that is a compact blob
 of code, and the other that is formatted more like a typical C
 program, we tend to favor the second version. Of course, a third
 version of the same program that is formatted in an interesting
 and/or obfuscated way, would definitely win over the first two!
 Remember, you can submit more than one submission. See the <a href="rules.html">IOCCC
-rules</a> for details (in particular, <a href="rules.html#rule9">Rule 9</a>).
-</p>
+rules</a> for details (in particular, <a href="rules.html#rule9">Rule 9</a>).</p>
 <p>We suggest that you avoid trying for the ‘<strong>smallest self-replicating</strong>’
 source. The smallest, a <a href="../1994/smr/index.html">zero byte entry</a>, won in
 <a href="../years.html#1994">1994</a>.</p>
@@ -1810,25 +1525,17 @@ they do not work as documented.</p>
 <p>Please note that the C source below, besides lacking in obfuscation,
 is <strong>NOT</strong> the smallest C source file that when compiled and run, dumps core:</p>
 <pre><code>    main;</code></pre>
-<p class="leftbar">
-Unless you specify <code>-fwritable-strings</code> (see <code>COTHER</code> in the example
+<p>Unless you specify <code>-fwritable-strings</code> (see <code>COTHER</code> in the example
 Makefile, described in the <a href="#makefile">Makefile section</a>), do not assume this
-sort of code will work:
-</p>
+sort of code will work:</p>
 <pre><code>    char *T = &quot;So many primes, so little time!&quot;;
     ...
     T[14] = &#39;;&#39;;    /* modifying a string requires: -fwritable-strings */</code></pre>
-<p class="leftbar">
-Even so, one should probably not assume that this is universally accepted.
-</p>
-<p class="leftbar">
-Initialized char arrays are OK to write over. For instance, this is OK:
-</p>
+<p>Even so, one should probably not assume that this is universally accepted.</p>
+<p>Initialized char arrays are OK to write over. For instance, this is OK:</p>
 <pre><code>    char b[] = &quot;Is this OK&quot;;
     b[9] = &#39;k&#39;;     /* modifying an initialized char array is OK */</code></pre>
-<p class="leftbar">
-There are more than 1 typos in this very sentence.
-</p>
+<p>There are more than 1 typos in this very sentence.</p>
 <p>X client submissions should be as portable as possible. Submissions that
 adapt to a wide collection of environments will be favored. For
 example, don’t depend on a particular type or size of display.
@@ -1840,51 +1547,35 @@ in the OS. Instead, make use of a well known and widely available open
 source program (one that actually works) to display audio/visual data.</p>
 <p>X client submissions should avoid using X related libraries and
 software that are not in wide spread use.</p>
-<p class="leftbar">
-As of Red Hat RHEL9.0, the X.org server is deprecated. See the
+<p>As of Red Hat RHEL9.0, the X.org server is deprecated. See the
 FAQ on “<a href="../faq.html#Xorg_deprecated">Xorg deprecation”</a>”
 for more details. This does not mean that a submission using this will
 necessarily be rejected, but it would be better if it can support Wayland in
-some way or another.
-</p>
+some way or another.</p>
 <p>This could be the only <em>guideline</em> that contains the word
 <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>.</p>
-<p class="leftbar">
-However, do you know how to play <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>?
-You do?!? (Except on Tuesday?)
-</p>
-<p class="leftbar">
-OK, there are actually 2 <em>guidelines</em> that contain the word
+<p>However, do you know how to play <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>?
+You do?!? (Except on Tuesday?)</p>
+<p>OK, there are actually 2 <em>guidelines</em> that contain the word
 <a href="https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin">fizzbin</a>,
-unless you count this one, in which case there are 3. :-)
-</p>
+unless you count this one, in which case there are 3. :-)</p>
 <p>We <strong>DISLIKE</strong> submissions that use proprietary toolkits such as the <code>M*tif</code>,
 <code>Xv*ew</code>, or <code>OpenL*ok</code> toolkits, since not everyone has them. Use an
 open source toolkit that is widely and freely available instead.</p>
 <p><strong>NOTE</strong>: The previous <em>guideline</em> in this spot has been replaced by this <em>guideline</em>:</p>
-<p class="leftbar">
-X client submissions should try to not to depend on particular items in
+<p>X client submissions should try to not to depend on particular items in
 <code>.Xdefaults</code>. If you must do so, be sure to note the required lines
 in the your <code>remarks.md</code> file. They should also not depend on any
-particular window manager.
-</p>
-<p class="leftbar">
-Try to avoid submissions that play music that some people believe is copyrighted
-music.
-</p>
-<p class="leftbar">
-While we recognize that UNIX is not a universal operating system, the contest
+particular window manager.</p>
+<p>Try to avoid submissions that play music that some people believe is copyrighted
+music.</p>
+<p>While we recognize that UNIX is not a universal operating system, the contest
 does have a bias towards such systems. In an effort to expand the scope of the
 contest, we phrase our bias to favor the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
-Specification</a>.
-</p>
-<p class="leftbar">
-You are <strong>well advised</strong> to submit code that conforms to the <a href="https://unix.org/version4/overview.html">Single UNIX
-Specification Version 4</a>.
-</p>
-<p class="leftbar">
-To quote the <a href="../judges.html">IOCCC judges</a>:
-</p>
+Specification</a>.</p>
+<p>You are <strong>well advised</strong> to submit code that conforms to the <a href="https://unix.org/version4/overview.html">Single UNIX
+Specification Version 4</a>.</p>
+<p>To quote the <a href="../judges.html">IOCCC judges</a>:</p>
 <blockquote>
 <p>You very well might not be completely prohibited from failing to not partly
 misunderstand this particular <em>guideline</em>, but of course, we could not possibly
@@ -1909,23 +1600,17 @@ parliament should you have one.</p>
 <p>Some types of programs can’t excel (anti-tm) in some areas. Your
 program doesn’t have to excel in all areas, but doing well in several
 areas really does help.</p>
-<p class="leftbar">
-You are better off explaining what your submission does in your
+<p>You are better off explaining what your submission does in your
 <code>remarks.md</code> file section rather than leaving it obscure for the
 <a href="../judges.html">IOCCC judges</a> as we might miss something and/or be too tired to
-notice.
-</p>
-<p class="leftbar">
-Please avoid this specific individual <em>guideline</em>, if it at all possible.
-</p>
-<p class="leftbar">
-We freely admit that interesting, creative or humorous comments in
+notice.</p>
+<p>Please avoid this specific individual <em>guideline</em>, if it at all possible.</p>
+<p>We freely admit that interesting, creative or humorous comments in
 your <code>remarks.md</code> file help your chances of winning. If you had to
 read so many twisted submissions, you too would enjoy a good laugh or two.
 We think the readers of the contest winners do as well. We do read
 your <code>remarks.md</code> content during the judging process, so it is worth your
-while to write a remarkable <code>remarks.md</code> file.
-</p>
+while to write a remarkable <code>remarks.md</code> file.</p>
 <p>We <strong>DISLIKE</strong> C code with trailing control-M’s (<code>\r</code> or <code>\015</code>) that results
 in compilation failures. Some non-UNIX/non-Linux tools such as
 MS Visual C and MS Visual C++ leave trailing control-M’s on lines.
@@ -1935,15 +1620,15 @@ prevent such trailing control-M’s being added.</p>
 <p>One should restrict libcurses to portable features found on BSD
 or Linux curses.</p>
 <p class="leftbar">
-<a href="rules.html#rule13">Rule 13</a> no longer discourages the use of UTF-8
-characters in C code.
+If you do <code>#include &lt;curses.h&gt;</code> make <strong>CERTAIN</strong> you link in curses (i.e.
+<code>-lcurses</code>) and not ncurses (i.e. <code>-lncurses</code>).
 </p>
-<p class="leftbar">
-It is a very good idea to, in your <code>remarks.md</code> file, tell us why you
+<p><a href="rules.html#rule13">Rule 13</a> no longer discourages the use of UTF-8
+characters in C code.</p>
+<p>It is a very good idea to, in your <code>remarks.md</code> file, tell us why you
 think your submission is obfuscated. This is particularly true if
 your submission has some very subtle obfuscations that we might
-otherwise overlook. <strong>&lt;&lt;– Hint!</strong>
-</p>
+otherwise overlook. <strong>&lt;&lt;– Hint!</strong></p>
 <p>Anyone can format their code into a dense blob. A really clever
 author will try format their submission using a “normal” formatting style
 such that at first glance (if you squint and don’t look at the details)
@@ -1955,38 +1640,31 @@ suggest you remark on this point in your <code>remarks.md</code> where you talk
 about why you think your submission is obfuscated. On the other hand,
 if you are pushing up against the size limits, you may be forced
 into creating a dense blob. Such are the trade-offs that obfuscators face!</p>
-<p class="leftbar">
-We prefer code that can run on either a 64-bit or 32-bit
+<p>We prefer code that can run on either a 64-bit or 32-bit
 processor. However, it is <strong>UNWISE </strong>to assume it will run on an
-some Intel-like x86 architecture**.
-</p>
+some Intel-like x86 architecture**.</p>
 <p>We believe that Mark Twain’s quote:</p>
 <blockquote>
 <p>Get your facts first, then you can distort them as you please.</p>
 </blockquote>
 <p>… is a good motto for those writing code for the IOCCC.</p>
-<p class="leftbar">
-The IOCCC size tool source is not an original work, unless you are <a href="../authors.html#Anthony_C_Howe">Anthony C
+<p>The IOCCC size tool source is not an original work, unless you are <a href="../authors.html#Anthony_C_Howe">Anthony C
 Howe</a>, in which case it is original! :-)
 Submitting source code that uses the contents of
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">iocccsize.c</a>,
 <em>unless</em> you are <a href="../authors.html#Anthony_C_Howe">Anthony C Howe</a>, might run the
-risk of violating <a href="rules.html#rule7">Rule 7</a>.
-</p>
-<p class="leftbar">
-The IOCCC submission tarball validator source is not an original work,
+risk of violating <a href="rules.html#rule7">Rule 7</a>.</p>
+<p>The IOCCC submission tarball validator source is not an original work,
 unless you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, in
 which case it is original! :-) Submitting source code that uses the contents of
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk.c</a>,
 <em>unless</em> you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone Ferguson</a>, might
-run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
-</p>
-<p class="leftbar">
-In addition to the above tools, none of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+run the risk of violating <a href="rules.html#rule7">Rule 7</a>.</p>
+<p>In addition to the above tools, none of the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
 tools</a>, <em>including, <strong>but not
 limited</strong></em> to
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry</a>,
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry</a>,
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c">chksubmit</a>,
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c">chksubmit</a>,
 <a href="https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c">fnamchk</a>
 and
@@ -2004,28 +1682,22 @@ are original! :-) Submitting source code that uses the content of any of these t
 library, <em>unless</em> you are <a href="../authors.html#Cody_Boone_Ferguson">Cody Boone
 Ferguson</a> or <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, might run the risk of violating
-<a href="rules.html#rule7">Rule 7</a>.
-</p>
-<p class="leftbar">
-And unless you are <a href="https://en.wikipedia.org/wiki/Landon_Curt_Noll">Landon Curt Noll</a>,
+<a href="rules.html#rule7">Rule 7</a>.</p>
+<p>And unless you are <a href="https://en.wikipedia.org/wiki/Landon_Curt_Noll">Landon Curt Noll</a>,
 the code in
 <a href="https://github.com/ioccc-src/mkiocccentry/tree/master/dbg">dbg</a> and
 <a href="https://github.com/ioccc-src/mkiocccentry/tree/master/dyn_array">dyn_array</a> are
 not original works. Submitting source code that uses the contents of those
 libraries, <em>unless</em> you <a href="https://en.wikipedia.org/wiki/Landon_Curt_Noll">Landon Curt Noll</a>,
-might run the risk of violating <a href="rules.html#rule7">Rule 7</a>.
-</p>
-<p class="leftbar">
-<a href="rules.html#rule7">Rule 7</a> does not prohibit you from writing your own
+might run the risk of violating <a href="rules.html#rule7">Rule 7</a>.</p>
+<p><a href="rules.html#rule7">Rule 7</a> does not prohibit you from writing your own
 obfuscated versions of these tools, unless of course you are <a href="http://www.isthe.com/chongo/index.html">Landon Curt
 Noll</a>, in which case you <em>probably</em>
 won’t win since <a href="../judges.html">IOCCC judges</a> should not enter the IOCCC! :-)
 However, <strong><em>if</em></strong> you do write your own version, you <strong><em>might</em></strong> wish to make it do something
 <strong><em>more</em> interesting</strong> than simply implementing the <a href="../index.html">IOCCC</a>
-tools’ algorithms.
-</p>
-<p class="leftbar">
-Even so, we do not recommend you try and submit a JSON parser due to
+tools’ algorithms.</p>
+<p>Even so, we do not recommend you try and submit a JSON parser due to
 the fact it will likely exceed <a href="rules.html#rule2">the source code size limit</a>
 and because you likely can’t beat <a href="https://github.com/westes/flex">flex</a> and
 <a href="https://www.gnu.org/software/bison/">bison</a> in obfuscation. This isn’t to
@@ -2036,34 +1708,25 @@ obfuscate a JSON parser more than <a href="https://github.com/westes/flex">flex<
 because of the <a href="rules.html#rule2">source code size limit</a> or because it is not
 as obfuscated as the <a href="https://github.com/westes/flex">flex</a> and <a href="https://www.gnu.org/software/bison/">bison</a>
 generated code of
-<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse">jparse</a>.
-</p>
+<a href="https://github.com/ioccc-src/mkiocccentry/blob/master/jparse">jparse</a>.</p>
 <p>While programs that only run in a specific word size are OK, if you have
 to pick, choose a 64-bit word size.</p>
-<p class="leftbar">
-If the <a href="../judges.html">IOCCC judges</a> are feeling ornery we
+<p>If the <a href="../judges.html">IOCCC judges</a> are feeling ornery we
 might choose to compile your program for running on an Arduino or
 a PDP-11. Heck, should we ever find an emulator of 60-bit CDC Cyber
-CPU, we might just try your submission on that emulator as well :-)
-</p>
-<p class="leftbar">
-If your submission <strong>MUST</strong> run only on a 64-bit or 32-bit architecture,
+CPU, we might just try your submission on that emulator as well :-)</p>
+<p>If your submission <strong>MUST</strong> run only on a 64-bit or 32-bit architecture,
 then you <strong>MUST</strong> specify the <code>-arch</code> on your command line
 (see <code>ARCH</code> in the example
 Makefile, described in <a href="#makefile">Makefile section</a>). Do not assume a
-processor word size without specifying <code>-arch</code>. For example:
-</p>
+processor word size without specifying <code>-arch</code>. For example:</p>
 <pre><code>    ARCH= -m64</code></pre>
-<p class="leftbar">
-Note, however, that some platforms will not necessarily support some
+<p>Note, however, that some platforms will not necessarily support some
 architectures. For instance, more recent versions of <code>macOS</code> do <strong>NOT</strong> support
-32-bit!
-</p>
-<p class="leftbar">
-If there are limitations in your submission, you are highly encouraged
+32-bit!</p>
+<p>If there are limitations in your submission, you are highly encouraged
 to note such limitations in your <code>remarks.md</code> file. For example if your
-submission factors values up to a certain size, you might want to state:
-</p>
+submission factors values up to a certain size, you might want to state:</p>
 <blockquote>
 <p>This submission factors values up <code>2305567963945518424753102147331756070</code>.
 Attempting to factor larger values will produce unpredictable results.</p>
@@ -2080,9 +1743,7 @@ produce unpredictable results.</p>
 <code>2305567963945518424753102147331756070</code>. Attempting to factor values outside
 that range will produce unpredictable results.</p>
 </blockquote>
-<p class="leftbar">
-Moreover they might try to also factor 3.5 or 0x7, or Fred, so you want to might state:
-</p>
+<p>Moreover they might try to also factor 3.5 or 0x7, or Fred, so you want to might state:</p>
 <blockquote>
 <p>This submission factors integers between 1 and
 <code>2305567963945518424753102147331756070</code>. Attempting to factor anything else
@@ -2109,42 +1770,28 @@ and state:</p>
 program is given enough time and memory. If the value is not a proper integer,
 the program might insult a fish named Eric.</p>
 </blockquote>
-<p class="leftbar">
-Do not fear if you’re not 100% sure of the significance of
+<p>Do not fear if you’re not 100% sure of the significance of
 <code>2305567963945518424753102147331756070</code> as it is not of prime importance: or is
-it? :-)
-</p>
-<p class="leftbar">
-We <strong>DISLIKE</strong> the use of ASCII tab characters in markdown files, such as in the required <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-We don’t mind the use of ASCII tab characters in your C code. Feel free
+it? :-)</p>
+<p>We <strong>DISLIKE</strong> the use of ASCII tab characters in markdown files, such as in the required <code>remarks.md</code> file.</p>
+<p>We don’t mind the use of ASCII tab characters in your C code. Feel free
 to use ASCII tab characters if that suits your obfuscation needs. If is
 perfectly <strong>OK</strong> to use tab characters elsewhere in your submission, just not in
 markdown files as this tends annoy us when it comes time to
-rendering your markdown content as it complicates the process.
-</p>
-<p class="leftbar">
-If you do use ASCII tab characters in your non-markdown files, be
+rendering your markdown content as it complicates the process.</p>
+<p>If you do use ASCII tab characters in your non-markdown files, be
 aware that some people may use a tab stop that is different than the common 8
-character tab stop.
-</p>
-<p class="leftbar">
-<strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC markdown guidelines</a>
+character tab stop.</p>
+<p><strong>PLEASE</strong> observe our <a href="../markdown.html">IOCCC markdown guidelines</a>
 when forming your submission’s <code>remarks.md</code> file. And if your submission
 contains additional markdown files, please follow those same guidelines for
 those files. See also <a href="rules.html#rule19">Rule 19</a> and our
-FAQ on “<a href="../faq.html#markdown">markdown</a>”.
-</p>
-<p class="leftbar">
-We <strong>LIKE</strong> reading <code>remarks.md</code> files, especially if they contain
+FAQ on “<a href="../faq.html#markdown">markdown</a>”.</p>
+<p>We <strong>LIKE</strong> reading <code>remarks.md</code> files, especially if they contain
 useful, informative, and even humorous content about your submission. Yes, this
-is a <strong>hint</strong>. :-)
-</p>
-<p class="leftbar">
-We <strong>RECOMMEND</strong> you put a reasonable amount effort into the content of the
-<code>remarks.md</code> file: it is a required file for a reason. :-)
-</p>
+is a <strong>hint</strong>. :-)</p>
+<p>We <strong>RECOMMEND</strong> you put a reasonable amount effort into the content of the
+<code>remarks.md</code> file: it is a required file for a reason. :-)</p>
 <p>Try to be even more creative!</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rules_abuse">
@@ -2166,31 +1813,24 @@ disqualified. <strong><em>RULE ABUSE CARRIES A CERTAIN LEVEL OF RISK!</em></stro
 have a submission that might otherwise be interesting, you might want to
 submit two versions; one that does not abuse the <a href="rules.html">IOCCC rules</a> and one that
 does.</p>
-<p class="leftbar">
-If you intend to abuse the <a href="rules.html">IOCCC rules</a>,
+<p>If you intend to abuse the <a href="rules.html">IOCCC rules</a>,
 indicate so in your <code>remarks.md</code> file. You <strong>MUST</strong> try to justify
 why you consider your rule abuse to be allowed under the
 <a href="rules.html">IOCCC rules</a>. That is, you must plead your case as to why
 your submission is valid. Humor and/or creativity help plead a case.
 As there is no guarantee that you will succeed, you might consider
 submitting an alternate version that conforms to the
-<a href="rules.html">IOCCC rules</a>.
-</p>
-<p class="leftbar">
-If you do bypass the <code>mkiocccentry(1)</code> warnings about <a href="rules.html#rule2a">Rule
+<a href="rules.html">IOCCC rules</a>.</p>
+<p>If you do bypass the <code>mkiocccentry(1)</code> warnings about <a href="rules.html#rule2a">Rule
 2a</a> and/or about <a href="rules.html#rule2b">Rule 2b</a> or any other
 rule and submit a submission anyway, you <strong>MUST</strong> try to justify why the IOCCC
 <a href="../judges.html">IOCCC judges</a> should not reject your submission due to a rule
 violation, and you would be wise to do this towards the top of your <code>remarks.md</code>
-file.
-</p>
-<p class="leftbar">
-Abusing the web submission procedure tends to annoy us more
+file.</p>
+<p>Abusing the web submission procedure tends to annoy us more
 than amuse us. Spend your creative energy on content of your
-submission rather than on the submission process itself.
-</p>
-<p class="leftbar">
-We are often asked why the contest <a href="rules.html">IOCCC rules</a> and <a href="guidelines.html">IOCCC
+submission rather than on the submission process itself.</p>
+<p>We are often asked why the contest <a href="rules.html">IOCCC rules</a> and <a href="guidelines.html">IOCCC
 guidelines</a> seem strange or contain mistakes, flaws or
 grammatical errors. One reason is that we sometimes make genuine mistakes. But
 in many cases such problems, flaws or areas of confusion are deliberate.
@@ -2199,10 +1839,8 @@ response to rule abuses, are done in a minimal fashion. Often we will
 deliberately leave behind holes (or introduce new ones) so that future rule
 abuse can continue. A clever author should be able to read them and “drive a
 truck through the holes” in the <a href="rules.html">IOCCC rules</a> and <a href="guidelines.html">IOCCC
-guidelines</a>.
-</p>
-<p class="leftbar">
-At the risk of stating the obvious, this contest is a parody of the software
+guidelines</a>.</p>
+<p>At the risk of stating the obvious, this contest is a parody of the software
 development process. The <a href="rules.html">IOCCC rules</a> and <a href="guidelines.html">IOCCC guidelines</a>
 are only part of the overall contest. Even so, one might think the
 contest <a href="rules.html">IOCCC rules</a> and <a href="guidelines.html">IOCCC guidelines</a> process as a parody
@@ -2211,20 +1849,17 @@ and what engineering delivers. Real programmers must face obfuscated and
 sometimes conflicting specifications and requirements from marketing, sales,
 product management and even from customers themselves on an all too regular basis.
 This is one of the reasons why the <a href="rules.html">IOCCC rules</a> and
-<a href="guidelines.html">IOCCC guidelines</a> are written in obfuscated form.
-</p>
+<a href="guidelines.html">IOCCC guidelines</a> are written in obfuscated form.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="judging">
 <h1 id="judging-process">JUDGING PROCESS:</h1>
 </div>
 <p>Submissions are judged by Leonid A. Broukhis and Landon Curt Noll.</p>
-<p class="leftbar">
-Each submission submitted is given a random string and subdirectory. The
+<p>Each submission submitted is given a random string and subdirectory. The
 submission files including, but not limited to <code>prog.c</code>, <code>Makefile</code>,
 <code>remarks.md</code>, <code>.info.json</code>, <code>.auth.json</code> as well as any data files that you
 submit, are all placed under their own directory and stored and judged from this
-directory.
-</p>
+directory.</p>
 <p>Any information about the authors is not read by the <a href="../judges.html">IOCCC judges</a> until
 the judging process is complete, and then only from entries that have
 won an award. Because we do not read this information for entries that
@@ -2232,11 +1867,9 @@ do not win, we do not know who did not win.</p>
 <p>The above process helps keep us biased for/against any one particular
 individual. Therefore you <strong>MUST</strong> refrain from putting any information
 that reveals your identity in your submission.</p>
-<p class="leftbar">
-Now some people point out that coding and/or writing style might reveal the
+<p>Now some people point out that coding and/or writing style might reveal the
 information about the authors. However we consider this to be simply
-circumstantial and outside the scope of the above paragraph.
-</p>
+circumstantial and outside the scope of the above paragraph.</p>
 <p>Some people, in the past, have attempted to obfuscate their identity by
 including comments of famous Internet personalities such as <a href="http://www.citi.umich.edu/u/honey">Peter
 Honeyman</a>. The <a href="../judges.html">IOCCC judges</a> are on to this trick
@@ -2264,15 +1897,11 @@ Because the main ‘prize’ of winning is being announced, we make all
 attempts to send non-winners into oblivion. We remove all non-winning
 files, and shred all related printouts. By tradition, we do not even
 reveal the number of submissions that we receive.</p>
-<p class="leftbar">
-During the judging process, a process that spans multiple sessions over
+<p>During the judging process, a process that spans multiple sessions over
 a few weeks, we post general updates from our <a href="https://fosstodon.org/@ioccc">Mastodon
-account</a>.
-</p>
-<p class="leftbar">
-<strong>Make sure you reload the feed</strong> every so often <strong>because unless you
-are mentioned you will NOT get a push notification!</strong>
-</p>
+account</a>.</p>
+<p><strong>Make sure you reload the feed</strong> every so often <strong>because unless you
+are mentioned you will NOT get a push notification!</strong></p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rounds">
 <h2 id="judging-rounds">JUDGING ROUNDS:</h2>
@@ -2289,12 +1918,8 @@ often more than two.</p>
 </div>
 <p>A reading consists of a number of actions:</p>
 <ul>
-<li><p class="leftbar">
-Reading <code>prog.c</code>, the C source and reviewing the <code>remarks.md</code> information
-</p></li>
-<li><p class="leftbar">
-Briefly looking at any supplied data files
-</p></li>
+<li>Reading <code>prog.c</code>, the C source and reviewing the <code>remarks.md</code> information</li>
+<li>Briefly looking at any supplied data files</li>
 <li>Passing the source thru the C pre-processor skipping over any <code>#include</code>d files</li>
 <li>Performing a number of C beautify/cleanup edits on the source</li>
 <li>Passing the beautified source thru the C pre-processor skipping over any <code>#include</code>d files</li>
@@ -2304,13 +1929,9 @@ Briefly looking at any supplied data files
 </ul>
 <p>In later rounds, other actions are performed including performing
 miscellaneous tests on the source and binary.</p>
-<p class="leftbar">
-This is the very <strong>guideline</strong> that goes, <strong>BING!</strong>
-</p>
-<p class="leftbar">
-Okay, technically that was the <em>second</em> <strong>guideline</strong> that goes <strong>BING</strong>, and this
-is the third. :-)
-</p>
+<p>This is the very <strong>guideline</strong> that goes, <strong>BING!</strong></p>
+<p>Okay, technically that was the <em>second</em> <strong>guideline</strong> that goes <strong>BING</strong>, and this
+is the third. :-)</p>
 <p>Until we reduce the stack of submissions down to about 25 submissions,
 submissions are judged on an individual basis. A submission is set aside because it
 does not, in our opinion, meet the standard established by the round.
@@ -2327,11 +1948,8 @@ we receive. A typical category list might be:</p>
 <li><strong>best game that is obfuscated</strong></li>
 <li><strong>most creatively obfuscated program</strong></li>
 <li><strong>most deceptive C code</strong> (code with deceptive comments and source code)</li>
-<li><p class="leftbar">
-<strong>best X program</strong> (see <a href="#likes">OUR LIKES AND DISLIKES</a>
-and the
-FAQ on “<a href="../faq.html#Xorg_deprecated">Xorg being deprecated</a>”)
-</p></li>
+<li><strong>best X program</strong> (see <a href="#likes">OUR LIKES AND DISLIKES</a> and the FAQ on “<a href="../faq.html#Xorg_deprecated">Xorg
+being deprecated</a>”)</li>
 <li><strong>best abuse of ISO C or ANSI C standard</strong> (see above about compilers)</li>
 <li><strong>best abuse of the C preprocessor</strong></li>
 <li><strong>worst/best abuse of the rules</strong> (or some variation)</li>
@@ -2352,23 +1970,22 @@ similar, but slightly better submission. For this reason, it is sometimes
 worthwhile to resubmit an improved version of a submission that failed to win in
 a previous year, the next year. This assumes, of course, that the submission is
 worth improving in the first place!</p>
-<p class="leftbar">
-Over the years, more than one <a href="../judges.html">IOCCC judge</a>
+<p>Over the years, more than one <a href="../judges.html">IOCCC judge</a>
 has been known to <strong>bribe</strong> another <a href="../judges.html">IOCCC judge</a> into voting for a
 winning submissions by offering a bit of high quality chocolate, or
-other fun item.
-</p>
+other fun item.</p>
 <p class="leftbar">
-One <strong>should NOT</strong> attempt to <strong>bribe</strong> an <a href="../judges.html">IOCCC
+Over the years some judges have submitted code that had to be rejected once it
+was discovered to be a judge.
+</p>
+<p>One <strong>should NOT</strong> attempt to <strong>bribe</strong> an <a href="../judges.html">IOCCC
 judge</a>, <strong>unless you are an <a href="../judges.html">IOCCC judge</a></strong>,
 because <strong>bribing</strong> an <a href="../judges.html">IOCCC judge</a> by a non-judge
 has been shown to <strong>NOT</strong> be effective when the <strong>person <em>attempting</em>
 the <em>bribe</em> is made known</strong> to the <a href="../judges.html">IOCCC judges</a>
 (i.e., they are not anonymous) AND/OR the <strong>bribe</strong> is otherwise
-associated with a submission to the <a href="../index.html">IOCCC</a>.
-</p>
-<p class="leftbar">
-With the previous guideline in mind: <strong>anonymous</strong> gifts
+associated with a submission to the <a href="../index.html">IOCCC</a>.</p>
+<p>With the previous guideline in mind: <strong>anonymous</strong> gifts
 for the <a href="../judges.html">IOCCC judges</a> that are <strong>NOT ASSOCIATED
 WITH</strong> a submission to the <a href="../index.html">IOCCC</a> may be sent to the
 <a href="../judges.html">IOCCC judges</a> via the
@@ -2376,20 +1993,15 @@ WITH</strong> a submission to the <a href="../index.html">IOCCC</a> may be sent 
 It has been shown that receiving <strong>anonymous</strong> gifts provides the
 <a href="../judges.html">IOCCC judges</a> with a nice
 <a href="https://en.wikipedia.org/wiki/Dopamine">dopamine</a> boost, and happy
-<a href="../judges.html">IOCCC judges</a> help make the <a href="../index.html">IOCCC</a> better for everyone. :-)
-</p>
-<p class="leftbar">
-See the
-FAQ on “<a href="../faq.html#support">supporting the IOCCC</a>”.
-</p>
+<a href="../judges.html">IOCCC judges</a> help make the <a href="../index.html">IOCCC</a> better for everyone. :-)</p>
+<p>See the
+FAQ on “<a href="../faq.html#support">supporting the IOCCC</a>”.</p>
 <p>More often than not, we select a small submission (usually one line) and a
 strange/creative layout submission. We sometimes also select a
 submission that abuses the <a href="guidelines.html">IOCCC guidelines</a> in an interesting way,
 or that stretches the contest <a href="rules.html">rules</a> that while legal, it
 nevertheless goes against the <strong>intent</strong> of the <a href="rules.html">rules</a>.</p>
-<p class="leftbar">
-Nevertheless, see <a href="rules.html#rule12">Rule 12</a>.
-</p>
+<p>Nevertheless, see <a href="rules.html#rule12">Rule 12</a>.</p>
 <p>In the end, we traditionally pick one submission as ‘<strong>best</strong>’. Sometimes such
 a submission simply far exceeds any of the other submissions. More often, the
 ‘<strong>best</strong>’ is picked because it does well in a number of categories.</p>
@@ -2400,44 +2012,28 @@ Winning source is called <code>prog.c</code>. A compiled binary is called <code>
 <div id="announcements">
 <h1 id="announcement-of-winners">ANNOUNCEMENT OF WINNERS:</h1>
 </div>
-<p class="leftbar">
-The <a href="../judges.html">IOCCC judges</a> will toot initial announcement of who won, the name
+<p>The <a href="../judges.html">IOCCC judges</a> will toot initial announcement of who won, the name
 of their award, and a very brief description (award title) of the winning entry
-from the <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> Mastodon account</a>.
-</p>
-<p class="leftbar">
-We recommend that you follow us on mastodon but <strong>please make sure to
+from the <a href="https://fosstodon.org/@ioccc"><span class="citation" data-cites="IOCCC">@IOCCC</span> Mastodon account</a>.</p>
+<p>We recommend that you follow us on mastodon but <strong>please make sure to
 refresh the feed</strong> every so often (if not more often) because unless you are
-mentioned or someone boosts your post you will not get a push notification.
-</p>
+mentioned or someone boosts your post you will not get a push notification.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="winners">
 <h2 id="how-the-new-ioccc-winners-will-be-announced">How the new IOCCC winners will be announced</h2>
 </div>
-<p class="leftbar">
-The <a href="../status.html">current status of the IOCCC</a> will change from
-<strong><a href="../faq.html#judging">judging</a></strong> to <strong><a href="../faq.html#closed">closed</a></strong> .
-</p>
-<p class="leftbar">
-The <strong>contest_status</strong> in the <a href="../status.json">status.json</a> file will change
-from <strong>judging</strong> to <strong>closed</strong> as well.
-</p>
-<p class="leftbar">
-When the above happens, the winning entries have been selected by the <a href="../judges.html">IOCCC
-judges</a>.
-</p>
-<p class="leftbar">
-The <a href="../judges.html">IOCCC judges</a> will begin to prepare to release the source
-code of the new IOCCC winners.
-</p>
-<p class="leftbar">
-The <a href="../judges.html">IOCCC judges</a> will commit the winning source to the
+<p>The <a href="../status.html">current status of the IOCCC</a> will change from
+<strong><a href="../faq.html#judging">judging</a></strong> to <strong><a href="../faq.html#closed">closed</a></strong> .</p>
+<p>The <strong>contest_status</strong> in the <a href="../status.json">status.json</a> file will change
+from <strong>judging</strong> to <strong>closed</strong> as well.</p>
+<p>When the above happens, the winning entries have been selected by the <a href="../judges.html">IOCCC
+judges</a>.</p>
+<p>The <a href="../judges.html">IOCCC judges</a> will begin to prepare to release the source
+code of the new IOCCC winners.</p>
+<p>The <a href="../judges.html">IOCCC judges</a> will commit the winning source to the
 <a href="https://github.com/ioccc-src/winner">IOCCC winner repo</a> which will update the
-<a href="https://www.ioccc.org/index.html">Official IOCCC website</a>.
-</p>
-<p class="leftbar">
-The <a href="../news.html">IOCCC news</a> will also contain an announcement of the winners.
-</p>
+<a href="https://www.ioccc.org/index.html">Official IOCCC website</a>.</p>
+<p>The <a href="../news.html">IOCCC news</a> will also contain an announcement of the winners.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="mastodon">
 <h2 id="an-important-update-to-how-winners-are-announced">An important update to how winners are announced</h2>
@@ -2454,27 +2050,21 @@ In addition a note is posted to the <a href="https://fosstodon.org/@ioccc">IOCCC
 <p class="leftbar">
 We will also post a notice to the IOCCC discord server.
 </p>
-<p class="leftbar">
-Consider joining the IOCCC discord community via this link:
-<a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a>
-</p>
+<p>Consider joining the IOCCC discord community via this link:
+<a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a></p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="entries">
 <h2 id="back-to-announcement-of-winners">Back to announcement of winners</h2>
 </div>
-<p class="leftbar">
-It is pointless to ask the <a href="../judges.html">IOCCC judges</a> how many
+<p>It is pointless to ask the <a href="../judges.html">IOCCC judges</a> how many
 submissions we receive. See <a href="../faq.html#how_many">How many submissions do the judges receive for a
-given IOCCC?</a>.
-</p>
-<p class="leftbar">
-Often, winning entries are published in selected magazines from around the
+given IOCCC?</a>.</p>
+<p>Often, winning entries are published in selected magazines from around the
 world. Winners have appeared in books (‘<code>The New Hacker's Dictionary</code>’,
 ‘<code>Obfuscated C and Other Mysteries</code>’, ‘<code>Pointers On C</code>’, others) and on t-shirts
 (sometimes by the author(s) themselves). There have been multiple classes
 that have focused in part, on IOCCC winning entries. And more than one winner has been turned
-into a tattoo!
-</p>
+into a tattoo!</p>
 <p>Last, but not least, <a href="../authors.html">winners</a> receive international fame and flames! :-)</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="more-information">
@@ -2482,43 +2072,29 @@ into a tattoo!
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 </div>
 </div>
-<p class="leftbar">
-For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.
-</p>
-<p class="leftbar">
-<strong>Be SURE</strong> to review the <a href="index.html">IOCCC Rules and Guidelines</a> as they
-may (and <strong>often do</strong>) change from year to year.
-</p>
-<p class="leftbar">
-<strong>PLEASE</strong> be sure you have the current <a href="rules.html">IOCCC rules</a> and
-<a href="guidelines.html">IOCCC guidelines</a> prior to submitting to the contest.
-</p>
+<p>For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.</p>
+<p><strong>Be SURE</strong> to review the <a href="index.html">IOCCC Rules and Guidelines</a> as they
+may (and <strong>often do</strong>) change from year to year.</p>
+<p><strong>PLEASE</strong> be sure you have the current <a href="rules.html">IOCCC rules</a> and
+<a href="guidelines.html">IOCCC guidelines</a> prior to submitting to the contest.</p>
 <p>See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
-<p class="leftbar">
-For the updates and breaking IOCCC news, you are encouraged to follow
+<p>For the updates and breaking IOCCC news, you are encouraged to follow
 the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a>. See our
 FAQ on “<a href="../faq.html#try_mastodon">Mastodon</a>”
 for more information. Please do note that unless
 you are mentioned by us you will <strong>NOT</strong> get a notification from the app <em>so you
-should refresh the page <strong>even if you do follow us</strong></em>.
-</p>
-<p class="leftbar">
-Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.
-</p>
-<p class="leftbar">
-Consider joining the IOCCC discord community via this link:
-<a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a>
-</p>
-<p class="leftbar">
-See the
+should refresh the page <strong>even if you do follow us</strong></em>.</p>
+<p>Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
+<p>Consider joining the IOCCC discord community via this link:
+<a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a></p>
+<p>See the
 FAQs on “<a href="../faq.html#mkiocccentry">obtaining, compiling, installing and using the mkiocccentry tools</a>”
 and the
 FAQ on “<a href="../quick-start.html#enter">how to enter the IOCCC</a>”
 as that FAQ has important details on
 <a href="../next/register.html">how to register</a>
 as well as
-<a href="../next/submit.html">how to upload your submission</a> for the IOCCC.
-</p>
+<a href="../next/submit.html">how to upload your submission</a> for the IOCCC.</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <p>Jump to: <a href="#">top</a>
 <!-- AFTER: last line of markdown file: next/guidelines.md --></p>

--- a/next/guidelines.md
+++ b/next/guidelines.md
@@ -48,13 +48,11 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-These [IOCCC guidelines](guidelines.html) are version **28.48 2025-09-28**.
+These [IOCCC guidelines](guidelines.html) are version **28.49 2025-11-17**.
 </p>
 
-<p class="leftbar">
 The markdown form of these guidelines <a href="guidelines.md"
 download="guidelines.md">is available for download</a>.
-</p>
 
 **IMPORTANT**: Be **SURE** to read the [IOCCC rules](rules.html).
 
@@ -93,11 +91,9 @@ about them.  The [IOCCC guidelines](guidelines.html) should be viewed as
 allowed_.  Even so, you are safer if you remain within the [IOCCC
 guidelines](guidelines.html).
 
-<p class="leftbar">
 Of course if a guideline is talking about a rule and you break that guideline,
 you stand a good chance of having your submission rejected for breaking the
 rule, not the guideline.
-</p>
 
 You **SHOULD read the CURRENT [IOCCC rules](rules.html)**, _prior_ to submitting
 code to the contest.
@@ -131,68 +127,51 @@ This contest will enter the **[judging](../faq.html#judging)** state on **2025-0
 When this happens, you may no longer upload your submissions to the IOCCC.
 </p>
 
-<p class="leftbar">
 **IMPORTANT NOTE**: Until the contest enters the **[open](../faq.html#open)** state, any or all
 of the above **dates and times may change _AT ANY TIME_**!
-</p>
 
 <p class="leftbar">
 The reason for the times of day are so that key IOCCC events are **calculated**
 to be a **fun**ctional UTC time.  :-)
 </p>
 
-<p class="leftbar">
 Until the contest status becomes **[open](../faq.html#open)**,
 the [IOCCC rules](rules.html),
 [IOCCC guidelines](guidelines.html) and the tools in the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry) **SHOULD be
 considered** provisional **BETA** versions and **may be adjusted _AT ANY TIME_**
 before the contest status becomes **[open](../faq.html#open)**.
-</p>
 
-<p class="leftbar">
 See the
 FAQ on "[how to register and submit to the IOCCC](../quick-start.html#enter)"
 for instructions on registering and participating in the IOCCC, as the process
 may change from contest to contest.
-</p>
 
-<p class="leftbar">
 To assist in the formation of the xz compressed tarball for submission, use the
 `mkiocccentry(1)` tool as found in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
-</p>
 
-<p class="leftbar">
 See FAQs regarding:
-</p>
 
 - [obtaining the latest mkiocccentry tools](../faq.html#obtaining_mkiocccentry)
 - [compiling the mkiocccentry tools](../faq.html#compiling_mkiocccentry)
 - [installing the mkiocccentry tools](../faq.html#install)
 - [using the mkiocccentry tools](../faq.html#using_mkiocccentry)
 
-<p class="leftbar">
 Uploading a tarball not formed by `mkiocccentry(1)` puts you at a very big risk of
 violating [Rule 17](rules.html#rule17), especially as `mkiocccentry(1)` does a
 great number of things that are required, and it also runs many checks, and if
 any of those checks fail, you are at a very great risk of having your submission
 rejected for violating [Rule 17](rules.html#rule17).
-</p>
 
-<p class="leftbar">
 We **STRONGLY** recommend you **do** install the
 [mkiocccentry toolkit](https://github.com/ioccc-src/mkiocccentry).
-</p>
 
-<p class="leftbar">
 **IMPORTANT NOTE**: the tools that require other tools, `mkiocccentry(1)` and
 `txzchk(1)`, will, as of version `2.0.2 2025-03-11`, search under `$PATH`. If
 you have an earlier version and you have not installed the tools and run the
 tools from outside the repo directory, you will have to use the options to the
 tools to set the path to the required tools.
-</p>
 
-<p class="leftbar">
 See the
 FAQ on "[obtaining and compiling the most recent mkiocccentry tools](../faq.html#mkiocccentry)"
 and the
@@ -201,79 +180,65 @@ as that FAQ has important details on
 [how to register](../next/register.html)
 as well as
 [how to upload your submission](../next/submit.html) to the IOCCC.
-</p>
 
-<p class="leftbar">
-See also the
-FAQ on "[what the minimum required versions are for this
-contest](../faq.html#minimum_versions)"
-for more details on how to verify you have the correct versions for this
-contest.
-</p>
-
-<p class="leftbar">
 While the contest is **[open](../faq.html#open)**, you may modify your
 previously uploaded submission by rebuilding your submission with the
 `mkiocccentry(1)` tool and then re-uploading it to **the same slot number** on the
 [submit server](https://submit.ioccc.org).
-</p>
 
-<p class="leftbar">
 **HINT:** so that you do not have to repeatedly answer all the
 questions, the `mkiocccentry(1)` tool has the options `-a answers`, `-A answers`
 and `-i answers`, where `-a` will write to an answers file (if it does not
 already exist), `-A` **WILL OVERWRITE THE FILE** and `-i` will read the answers from
 the file. If you use `-A`, **BE SURE** you don't overwrite another file by accident!
-</p>
 
-<p class="leftbar">
 Be aware that even with the `-i answers` you will still be required to confirm
 most if not all `y/n` questions - you just don't have to input the name of the
 submission, the abstract, the author details etc. If you really wish to
 circumvent this you can use the `-Y` option but we do not recommend this because
 if your update breaks a rule or there is some problem, you might not see it.
-</p>
 
-<p class="leftbar">
 To help with not having to repeatedly enter a UUID, whether for the same
 submission or multiple submissions, you can use the `-u uuidfile` or `-U UUID`
 option. See the
 FAQ on "[how to avoid re-entering your UUID](../faq.html#uuid)"
 for more details. Note that the `-i answers` option cannot be used with the UUID
 options as the answers file includes the UUID.
-</p>
 
-<p class="leftbar">
 The overall size limit (see [Rule 2a](rules.html#rule2a)) on `prog.c` has been
 **increased from 4096 to 4993** bytes.
 The [Rule 2a](rules.html#rule2a) size was changed from
 **4096** to **4993** to keep the "2b to 2a" size ratio to a
 value similar to the [2001-2012](../faq.html#size_rule2001-2012) and
 [2013-2020](../faq.html#size_rule2013-2020) IOCCC eras.
-</p>
 
-<p class="leftbar">
 The [Rule 2b](rules.html#rule2b) size has **increased from 2053 to 2503**
 bytes.
+
+<p class="leftbar">
+However, you should pay especial attention to our remarks in the [IOCCC28
+index.html](../2024/index.html):
 </p>
 
 <p class="leftbar">
+> **IMPORTANT HINT**: Only 3 of the 23 **IOCCC28 winners** came close to the
+[Rule 2 size limit](../next/rules.html#rule2).  Large code size isn't
+everything.  :-) Those submitting to future contents should **take a careful
+note** of that fact.
+</p>
+
+
 Your submission must satisfy **BOTH** the maximum size
 [Rule 2a](rules.html#rule2a) **AND** the IOCCC size [Rule 2b](rules.html#rule2b).
-</p>
 
-<p class="leftbar">
 To check your code against [Rule 2](rules.html#rule2), use the `iocccentry(1)` tool.
 For example:
-</p>
 
 ``` <!---sh-->
     iocccsize prog.c
 ```
 
-<p class="leftbar">
 The IOCCC size tool algorithm can be summarized as follows:
-</p>
 
 > The size tool counts most C reserved words (keyword, secondary, and selected
 preprocessor keywords) as 1.  The size tool counts all other bytes as 1
@@ -284,29 +249,21 @@ before the end of file.
 ASCII whitespace includes ASCII tab, ASCII space, ASCII newline,
 ASCII formfeed, and ASCII carriage return.
 
-<p class="leftbar">
 When '`;`', '`{`' or '`}`' are within a C string, they may still not be
 counted by the IOCCC size tool.  This is a **feature**, not a bug!
-</p>
 
-<p class="leftbar">
 In cases where the above summary and the algorithm implemented by
 the IOCCC size tool `iocccsize(1)` conflict, the algorithm implemented
 by the current version of `iocccsize(1)` is preferred by the [IOCCC judges](../judges.html).
-</p>
 
-<p class="leftbar">
 In other words, make sure `iocccsize` does not flag any issues with your
 `prog.c`.
-</p>
 
-<p class="leftbar">
 There are at least 2 other reasons for selecting 2503 as the 2nd limit besides
 the fact that 2503 is a prime. These reasons may be searched for and discovered
 if you are ["Curios!" about 2503](https://t5k.org/curios/page.php/2503.html).
 :-) Moreover, 2053 was the number of the kernel disk pack of one of the judge's
 BESM-6, and 2503 is a decimal anagram of 2053.
-</p>
 
 Take note that this secondary limit imposed by the IOCCC size tool
 obviates some of the need to `#define` C reserved words in an effort
@@ -314,11 +271,12 @@ to get around the size limits of [Rule 2](rules.html#rule2).
 
 Yes Virginia, **that is a hint**!
 
-<p class="leftbar">
 The **official locale** of the **IOCCC** is **C**.
-</p>
 
 <p class="leftbar">
+Did you really think anything else? :-)
+</p>
+
 The [mkiocccentry toolkit](https://github.com/ioccc-src/mkiocccentry),
 as of [Release version 2.4.4 2025-03-15](https://github.com/ioccc-src/mkiocccentry/releases/tag/2.4.4),
 will run with a locale set to **C**.
@@ -370,7 +328,6 @@ often award '**Best abuse of the [rules](rules.html)**' or '**Worst abuse of the
 [rules](rules.html)**' or some variation to a submission that illustrates this
 point in an ironic way.
 
-<p class="leftbar">
 The IOCCC has a rich history of remarkable winning entries created by
 authors who skillfully employed various techniques to develop their code.
 While it is **NOT** required, you are allowed to use tools to develop
@@ -380,76 +337,57 @@ runtime analysis tools, machine learning tools, natural language models,
 code copilot tools, so-called AI services, large language models (LLMS), etc.
 If you do make use of such tools or services, then we **ENCOURAGE you to describe
 how you used such tools** in your `remarks.md` file.
-</p>
 
-<p class="leftbar">
 You may use git, or services such as [GitHub](https://www.github.com)
 to develop and maintain your submission.  However, we **DISLIKE**
 submissions that **require** them in order to build/compile your submission.
-</p>
 
-<p class="leftbar">
 Submissions will be judged in an environment that has no **IDE**.
 Any submission that fails to compile/build because it requires
 an **IDE** will be rejected.
-</p>
 
-<p class="leftbar">
 We will use the `make(1)` tool, your `Makefile`, and other tools found in
 [Single UNIX Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 environments and systems that conform to the [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 in the building and compiling of your submission.
-</p>
 
 We do realize that there are holes in the [rules](rules.html), and invite
 submitters to attempt to exploit them.  We may award '**Worst abuse of the
 [rules](rules.html)**' or '**Best abuse of the [rules](rules.html)**' or some
 variation and then plug the hole next year.
 
-<p class="leftbar">
 When we do need to plug a hole in the [IOCCC rules](rules.html) or [IOCCC
 guidelines](guidelines.html), we will attempt to use a very small plug, if not
 smaller.  Or, maybe not.  :-)
-</p>
 
-<p class="leftbar">
 There may be fewer than 2^7+1 reasons why these [IOCCC
 guidelines](guidelines.html) seem obfuscated.
-</p>
 
-<p class="leftbar">
 **IMPORTANT:** Be sure that **your submission works** as documented in your
 `remarks.md` file.  We sometimes make an effort to debug a submission
 that has a slight problem, particularly in or near the final round.
 On the other hand, we have seen some otherwise excellent submissions
 fall down because they didn't work as documented.
-</p>
 
-<p class="leftbar">
 If you submission has bugs and/or mis-features, you are **MUCH BETTER** off
 documenting such bugs and/or mis-features in your `remarks.md` file.
-</p>
 
-<p class="leftbar">
 Consider an example of a [prime number](https://en.wikipedia.org/wiki/Prime_number)
 printing program that claims that 16 is a prime number.
 Noting such a bug in your `remarks.md` file could save your submission:
-</p>
 
 > "_this submission sometimes prints the 4th power of a prime by mistake_"
 
 Sometimes a strange bug or (mis-)feature can even help the submission!  Of course, a correctly
 working submission might be better.
 
-<p class="leftbar">
 We tend to look down on a [prime
 number](https://en.wikipedia.org/wiki/Prime_number) printer that claims that
 16 is a prime number.
 Clever people will note that 16 might be prime
 under certain conditions.  ;-)  Wise people, when submitting something clever
 will fully explain such cleverness in their submission's `remarks.md` file.
-</p>
 
 People who are considering to just use some complex mathematical
 function or state machine to spell out something such as "_hello,
@@ -470,29 +408,20 @@ Jump to: [top](#)
 # `mkiocccentry`
 </div>
 
-<p class="leftbar">
 [Rule 17](rules.html#rule17) (the `mkiocccentry(1)` rule) states that
 you **REALLY SHOULD** use the `mkiocccentry(1)` tool to package your submission tarball.
-</p>
 
-<p class="leftbar">
 See the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 for the `mkiocccentry(1)` tool and below for more details.
-</p>
 
-<p class="leftbar">
 **IMPORTANT NOTE**: make **CERTAIN** you have the most recent version of the
 `mkiocccentry` toolkit! See the
 FAQ on "[obtaining the mkiocccentry toolkit](../faq.html#obtaining_mkiocccentry)".
-</p>
 
-<p class="leftbar">
 `mkiocccentry` runs a number of checks, by the tool itself and by executing
 other tools, _before_ packaging your xz compressed tarball, including running
 `chksubmit(1)` on the submission directory.
-</p>
 
-<p class="leftbar">
 If `mkiocccentry` encounters an **error**, the program will exit and the xz
 compressed tarball **will not be formed**. For instance, if
 [chksubmit](#chksubmit) fails to validate the submission directory, either because
@@ -504,60 +433,45 @@ mkiocccentry bug report
 page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
 **PLEASE run the `bug_report.sh` script to help us out here!**  See the
 FAQ on "[reporting mkiocccentry bugs](../faq.html#mkiocccentry_bugs)".
-</p>
 
-<p class="leftbar">
 Once the tarball is packaged it will
 run `txzchk(1)`, which will also run `fnamchk(1)`, as part of its algorithm.
-</p>
 
-<p class="leftbar">
 However, even if `mkiocccentry` or one of the tools it invokes reports an error,
 it **does not** necessarily mean it is a bug in the code. It might be an issue with
 your submission. Thus if you report an error as a bug it might not be something
 that will be fixed as there might not be anything wrong with the tools.
-</p>
 
-<p class="leftbar">
 On the other hand, some conditions flagged by `mkiocccentry(1)` are **warnings**
 and it allows you to override these, if you wish. If you're brave enough you can
 use the `-W` option to ignore all warnings but this is a big risk; the `-y`
 option will assume '_yes_' to most questions but this is also a big risk. Using
 `-Y` will say '_yes_' to even more prompts. Needless to say, we do **NOT**
 recommend these options.
-</p>
 
-<p class="leftbar">
 In many places it will prompt you to verify what you input, allowing you to
 correct details as you go along. Be advised that there is a default answer and
 if you press enter it will proceed with that default, so make sure you have
 provided the correct answer.
-</p>
 
-<p class="leftbar">
 If you wish to **test** that your submission passes the `mkiocccentry(1)` tests
 without having to type in in answers each time, you can use the `-d` or `-s seed`
 option to `mkiocccentry` for the tool to pseudo-randomly create answers for you.
 For example:
-</p>
 
 ``` <!---sh-->
     mkiocccentry -d workdir topdir
 ```
 
-<p class="leftbar">
 **IMPORTANT NOTE**: if you run an IOCCC related tool outside the repo directory
 (specifying the absolute or relative path to the tool) and you have not
 installed the tools (and we **STRONGLY** recommend you **do** install them),
 then you will have to specify the options (such as paths) for the tools that are required like
 `chksubmit(1)`, `txzchk(1)` and `fnamchk(1)`.
-</p>
 
-<p class="leftbar">
 Make sure you have
 the latest version of of the [mkiocccentry toolkit](https://github.com/ioccc-src/mkiocccentry)
 so that you do not violate [Rule 17](rules.html#rule17) by mistake.
-</p>
 
 
 Jump to: [top](#)
@@ -567,24 +481,19 @@ Jump to: [top](#)
 ## `mkiocccentry(1)` synopsis
 </div>
 
-<p class="leftbar">
 The synopsis of the `mkiocccentry(1)` tool is:
-</p>
 
 ``` <!---sh-->
     mkiocccentry [options] workdir topdir
 ```
 
-<p class="leftbar">
 To help you with editing a submission, the `mkiocccentry(1)` tool has
 some options to write _OR_ read from an answers file so you do not have to input
 the information about the author(s) and the submission more than once, unless of
 course you need to make some changes, in which case you can use the option that
 overwrites the file. If you do use the overwrite option, **MAKE SURE** you do
 not overwrite another file!
-</p>
 
-<p class="leftbar">
 See the
 FAQ on the
 "[mkiocccentry tool](../faq.html#mkiocccentry)"
@@ -592,107 +501,88 @@ for how to use this tool and the
 FAQ on the
 "[finer details of mkiocccentry](../faq.html#mkiocccentry_details)"
 for even more information.
-</p>
 
 
 <div id="tools">
 # Other mkiocccentry tools
 </div>
 
-<p class="leftbar">
 The `mkiocccentry(1)` tool will execute a number of tools, some of which will
 execute one or more additional tools.
-</p>
 
 <div id="iocccsize">
 ## `iocccsize`
 </div>
 
-<p class="leftbar">
 `mkiocccentry(1)` will use code from `iocccsize(1)` which detects a number of
 issues (such as [Rule 2](rules.html#rule2)) that you may ignore, if you wish, as
 noted above.
-</p>
 
-<p class="leftbar">
 In other words, you no longer need to run `iocccsize` manually. However, the
 checks described above are still made but through the `mkiocccentry(1)` tool itself.
-</p>
-
 
 Jump to: [top](#)
 
 
-<div id="chkentry">
-## `chkentry`
+<div id="chksubmit">
+## `chksubmit`
 </div>
 
-<p class="leftbar">`mkiocccentry(1)` will write two JSON files: `.auth.json` and
+`mkiocccentry(1)` will write two JSON files: `.auth.json` and
 `.info.json`. These files contain information about the author(s) and about the
-submission. After these files are formed, the `chkentry(1)` tool will be run on
+submission. After these files are formed, the `chksubmit(1)` tool will be run on
 the submission directory; this tool not only validates the two JSON files
 (and runs specific checks on them after validating the JSON), but it also
 verifies that what is in the manifest in `.info.json` matches the contents of
-the directory, in addition to other checks. If `chkentry(1)` fails to validate
+the directory, in addition to other checks. If `chksubmit(1)` fails to validate
 anything at all, your submission **WILL BE** rejected!
-</p>
 
-<p class="leftbar">
-**IMPORTANT**: although `chkentry(1)` validates the files in the directory, it
+**IMPORTANT**: although `chksubmit(1)` validates the files in the directory, it
 only inspects the contents of the two JSON files; it performs other kinds of
 checks on the other files, and those checks are run on the two JSON files as
 well.
-</p>
 
-<p class="leftbar">
 If you submit your own JSON files (other than `.auth.json` and
 `.info.json`) then they do **NOT** have to be valid JSON.
 However, if you do provide such invalid JSON files, **PLEASE**
 document and explain this in your `remarks.md` file.
-</p>
 
 <p class="leftbar">
-If `chkentry` does not pass and you used `mkiocccentry(1)` it is **very likely** a
+On the other hand, some people might question what actually constitutes a valid
+JSON file. :-)
+</p>
+
+If `chksubmit` does not pass and you used `mkiocccentry(1)` it is **very likely** a
 bug and you should [report it as a bug at the mkiocccentry issues
 page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
 **PLEASE** run the command:
-</p>
 
 ``` <!---sh-->
     make bug_report
 ```
 
-<p class="leftbar">
 from the top level repo directory itself and attach the bug report file (it will
 tell you the name of the file). See also the
 FAQ on "[reporting mkiocccentry bugs](../faq.html#mkiocccentry_bugs)".
-</p>
 
-<p class="leftbar">
-Assuming that `chkentry(1)` successfully validates your submission directory,
+Assuming that `chksubmit(1)` successfully validates your submission directory,
 the tarball will be formed and then `txzchk(1)` will be executed on it. In this
 case, there should be no problems, as `mkiocccentry(1)` should **NOT** form a
 tarball if there are any issues.
-</p>
 
-<p class="leftbar">
-If `mkiocccentry(1)` is used and `chkentry(1)` fails to validate your submission
+If `mkiocccentry(1)` is used and `chksubmit(1)` fails to validate your submission
 directory, then unless it is a system specific problem, it could be a bug in
-`mkiocccentry(1)`, `chkentry(1)` or possibly `jparse`, although this is unlikely.
+`mkiocccentry(1)`, `chksubmit(1)` or possibly `jparse`, although this is unlikely.
 Nonetheless, if you believe there is a bug, you may report it as explained above.
-</p>
 
-<p class="leftbar">
 If you want to know what `.auth.json` is, see the
 FAQ on "[.auth.json](../faq.html#auth_json)".
 If you want to know what the `.info.json` file is, see the
 FAQ on "[.info.json](../faq.html#info_json)".
-On the other hand, if you want to know a bit more details about `chkentry(1)`, see the
-FAQ about "[chkentry](../faq.html#chkentry)".
-</p>
+On the other hand, if you want to know a bit more details about `chksubmit(1)`, see the
+FAQ about "[chksubmit](../faq.html#chksubmit)".
 
-<p class="leftbar">
-`chkentry` uses the `jparse` library. See the
+`chksubmit` uses the `jparse` library. See the
 [jparse
 README.md](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/README.md)
 in the [mkiocccentry GitHub repo subdirectory
@@ -702,9 +592,7 @@ file](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse/jparse_librar
 in the [mkiocccentry GitHub repo subdirectory
 jparse](https://github.com/ioccc-src/mkiocccentry/tree/master/jparse), for more
 details.
-</p>
 
-<p class="leftbar">
 The `jparse` parser, library and tools were co-developed by [Cody Boone
 Ferguson](../authors.html#Cody_Boone_Ferguson) and [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html) in 2022-2025 and come from the
@@ -712,15 +600,11 @@ Noll](http://www.isthe.com/chongo/index.html) in 2022-2025 and come from the
 tools use a _clone_** of the [jparse repo](https://github.com/xexyl/jparse) **at
 a _specific_ release**.  Thus the `mkiocccentry` will at times be behind the
 [jparse repo](https://github.com/xexyl/jparse)!
-</p>
 
-<p class="leftbar">
 You do **NOT need to install** `jparse` from the [jparse
 repo](https://github.com/xexyl/jparse)! The `mkiocccentry` tools link in the
 static library from `mkiocccentry`'s _clone_.
-</p>
 
-<p class="leftbar">
 The `mkiocccentry` toolkit _also_ has a clone of _both_ the [dbg
 library](https://github.com/lcn2/dbg) and the
 [dyn_array library](https://github.com/lcn2/dyn_array); the [dyn_array
@@ -729,30 +613,27 @@ library](https://github.com/lcn2/dbg) and the [jparse
 library](https://github.com/xexyl/jparse) uses both libraries but unlike in the
 [jparse repo](https://github.com/xexyl/jparse), the libraries do not need to be
 installed separately, in order to use the tools in `mkiocccentry`.
-</p>
 
-<p class="leftbar">
 In other words, `mkiocccentry` **contains everything** you need, and _even if you
 do install_ the libraries from their respective repos, it/they will **not be
 used** when compiling the `mkiocccentry` tools. This is important to
 make sure that you're using the correct versions, which is also verified by
-`chkentry` (in the JSON files created by `mkiocccentry(1)`). See [Rule
+`chksubmit` (in the JSON files created by `mkiocccentry(1)`). See [Rule
 17](rules.html#rule17)!
-</p>
 
 <p class="leftbar">
+We **HIGHLY** recommend you install the `mkiocccentry` toolkit, however.
+</p>
+
 Please see the
-FAQ on "[validating your submission directory](../faq.html#chkentry)
-for more details on `chkentry(1)`.
-</p>
+FAQ on "[validating your submission directory](../faq.html#chksubmit)
+for more details on `chksubmit(1)`.
 
-<p class="leftbar">
 You might also wish to see the
 FAQ on "[.auth.json](../faq.html#auth_json)"
 and the
 FAQ on "[.info.json](../faq.html#info_json)"
 for much more information on these files.
-</p>
 
 
 Jump to: [top](#)
@@ -762,7 +643,6 @@ Jump to: [top](#)
 ## `txzchk`
 </div>
 
-<p class="leftbar">
 `txzchk(1)` performs a wide number of sanity checks on the xz compressed
 tarball; if any issues are found ('`feathers are stuck in the tarball`' :-) )
 **AND if and _ONLY IF_ you used `mkiocccentry(1)`**, then it is **possibly** a
@@ -772,109 +652,93 @@ page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug
 **PLEASE run the `bug_report.sh` script to help us out here!** You may do this
 by running from the top level directory of the repo `make bug_report`. See the
 FAQ on "[reporting mkiocccentry bugs](../faq.html#mkiocccentry_bugs)".
-</p>
 
-<p class="leftbar">
 As part of its algorithm, `txzchk(1)` will run `fnamchk(1)` on the
 _tarball_ to verify that the _filename_ is valid. See the
 FAQ on "[fnamchk](../faq.html#fnamchk)"
 and the [fnamchk section](#fnamchk) below for more details on this tool.
-</p>
 
-<p class="leftbar">
 It is beyond the scope of this document to discuss the many tests that
 `txzchk(1)` performs; if you wish to know, we refer you to the [source
 code](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c) or the man
 page. You might just find a fun option if you do either of these!
-</p>
 
-<p class="leftbar">
 Of course, as `txzchk` does not extract the tarball, it is possible that if you
 manually package your submission tarball and/or find and exploit a missing
 check, you could still be violating [Rule 17](rules.html#rule17).
-</p>
 
 <div id="extra-files">
 ## Including optional and extra files
 </div>
 
 <p class="leftbar">
-The maximum total number of files that may be submitted has changed to **39** files.
-However, of those files, **5** are mandatory (`prog.c`, `Makefile`, `remarks.md` and
-the two JSON files generated by `mkiocccentry(1)`, `.info.json` and
-`.auth.json`).
+The maximum total number of _extra files_ that may be submitted is 31.
 </p>
 
 <p class="leftbar">
-Additionally, three of the files, if included, **MUST** be
-specific file(name)s **AND** in the top level directory, or they will be counted as
-an extra file, not an optional file.
+An _extra file_ is defined as a file that is not `prog.c`, `prog.alt.c`,
+`try.sh`, `try.alt.sh`, `remarks.md`, `Makefile`, `.auth.json` and `.info.json`:
+unless it's not in the top level directory, in which case it **IS** an _extra
+file_. The non-extra files are considered _free files_.
 </p>
 
 <p class="leftbar">
-In particular, any file that is not `prog.c`, `Makefile`, `remarks.md`,
-`try.sh`, `prog.alt.c` or `try.alt.sh` will be counted as an extra file, and if
-`try.sh`, `prog.alt.c` or `try.alt.sh` are not in the top level submission
-directory they will also be counted as an extra file. The `.info.json` and
-`.auth.json` files are not counted as extra files but are required.
+Of course any dot file that is not `.auth.json` and `.info.json` will result in
+a violation of [Rule 17](rules.html#rule17), regardless of its depth.
 </p>
 
-<p class="leftbar">
-In other words, the actual amount of **EXTRA** files is **31**.
-</p>
-
-<p class="leftbar">
 If you use an optional filename for something other than their intended use
 in order to get past the file limit, we will consider that an
-abuse of rules.  For more details on the optional files, see the
+abuse of rules.
+
+<p class="leftbar">
+For information on the `try` script files see the
 FAQ on the "[try.sh script system](../faq.html#try_script)"
-and the
+and for more details on alt code (including the `try.alt.sh` script) see the
 FAQ on "[alt code](../faq.html#alt_code)".
 </p>
 
 <p class="leftbar">
-If you **REALLY MUST** include more files than the limit allows, then you may do so by including as an extra
-file, a tarball. This does **NOT** have to pass `txzchk(1)` tests; only the
-submission tarball must pass the `txzchk(1)` tests.
+If you really **MUST** include more files than the limit allows, then you may do
+so by including as an extra file, a tarball. This does **NOT** have to pass
+`txzchk(1)` tests; only the submission tarball must pass the `txzchk(1)` tests.
 </p>
 
 <p class="leftbar">
+You **MUST** justify including extra files beyond the limit, should you do so.
+Even so this does not mean it will be considered valid.
+</p>
+
+<p class="leftbar">
+If you use a tarball for a depth beyond the maximum, you **MUST** justify this
+as well. Even so this does not mean it will be considered valid.
+</p>
+
 If you **DO** include a tarball, and the build process or the program extracts
-said tarball(s), the make `clobber` rule **MUST** remove the extracted files. Even so, if you
-include a tarball to get past the limit on the number of files, you **MUST**
-justify this in your `remarks.md` file.
-</p>
+said tarball(s), the make `clobber` rule **MUST** remove the extracted files.
 
-<p class="leftbar">
 **IMPORTANT REMINDER**: make **SURE** your tarball does **NOT** reveal who you are!
 The `mkiocccentry(1)` tool creates a v7 format tarball to prevent this. You can
 do the same like:
-</p>
 
 ``` <!---sh-->
     tar --format=v7 -cJf foo.txz directory
 ```
 
-<p class="leftbar">
-See [Rule 17](rules.html#rule17) and in particular the part about the [maximum
-number of files](../faq.html#max-files). If you do not follow these points, you
-are at a great risk of violating [Rule 17](rules.html#rule17)!
-</p>
+See [Rule 17](rules.html#rule17) and also the
+FAQ on "[maximum number of files](../faq.html#max-files)".
 
-<p class="leftbar">
+If you do not follow these points, you
+are at a great risk of violating [Rule 17](rules.html#rule17)!
+
 **NOTE**: if you want to include a test-suite that requires a lot of files,
 please suggest this in your `remarks.md` and if your submission wins it can
-be done. In other words you should not use a tarball for a test-suite unless you
+be done. In other words you should NOT use a tarball for a test-suite unless you
 have a very good reason for this (and if you do, make **SURE** you specify why
 in your `remarks.md` file).
-</p>
 
-
-<p class="leftbar">
 See also the
 FAQ on "[txzchk](../faq.html#txzchk)".
-</p>
-
 
 Jump to: [top](#)
 
@@ -883,21 +747,16 @@ Jump to: [top](#)
 ## `fnamchk(1)`
 </div>
 
-<p class="leftbar">
 As an important part of its algorithm, [txzchk&lpar;1&rpar;](#txzchk) directly executes
 `fnamchk(1)`.  If the filename is invalid (or the filename does not match the
 directory name of the tarball) then it is an **error** and you risk violating
 [Rule 17](rules.html#rule17). Nevertheless, you can run the tool manually,
 should you wish to.
-</p>
 
-<p class="leftbar">
 For more information on `fnamchk` and how to manually validate your submission
 tarball filename, see the
 FAQ on "[fnamchk](../faq.html#fnamchk)".
-</p>
 
-<p class="leftbar">
 It is extremely unlikely that `fnamchk(1)` reporting an invalid filename is a
 bug in `fnamchk(1)` and as such, ignoring such an issue risks violating [Rule
 17](rules.html#rule17) which is a big risk. Of course, using `mkiocccentry(1)`
@@ -907,38 +766,30 @@ you should [report it as a bug at the mkiocccentry issues
 page](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
 See the
 FAQ on "[reporting mkiocccentry bugs](../faq.html#mkiocccentry_bugs)".
-</p>
 
-<p class="leftbar">
 As you can see, the use of `mkiocccentry(1)` is **HIGHLY RECOMMENDED**, and at
 the risk of stating the obvious, you run **A VERY BIG RISK** of having
 your submission rejected if you package your own tarball, and there are **ANY
-problems**. For instance, if `chkentry(1)` found a problem in your `.info.json`
+problems**. For instance, if `chksubmit(1)` found a problem in your `.info.json`
 file, the `mkiocccentry(1)` tool would not package it. But if you were to package
 it manually, you would be violating [Rule 17](rules.html#rule17). But even if
 everything checks out OK you should **NOT** assume that everything **IS** OK.
-</p>
-
 
 <div id="bugs">
-# Problems and/or bugs in tools
+# Problems and/or bugs in the mkiocccentry toolkit
 </div>
 
-<p class="leftbar">
 Although the tools have been tested extensively, it is nonetheless possible for bugs to
 exist in the code, as all programmers know. In this case, **please** ask for help or report what
 you think is a bug via the [bug report issues page in the mkiocccentry
 repo](https://github.com/ioccc-src/mkiocccentry/issues/new?assignees=&labels=bug&projects=&template=bug_report.yml&title=%5BBug%5D+%3Ctitle%3E).
-</p>
 
-<p class="leftbar">
 Of course, it is also possible for `mkiocccentry(1)`, or one or more of the
 tools it executes (or another tool executes), to fail, but **NOT** because of a
 bug. An example problem is if there is not enough memory available or if some
 other library or syscall fails. Nonetheless it might be worth reporting as a
 bug; it is a judgement call: if it's a bug it'll be addressed and if it's not
 that's OK too!
-</p>
 
 
 <div id="make">
@@ -947,35 +798,29 @@ that's OK too!
 </div>
 </div>
 
-<p class="leftbar">
 We **recommend** AND **encourage** you to use the example Makefile,
 as the starting point for your submission's required `Makefile`:
-</p>
 
 - [view example Makefile](%%REPO_URL%%/next/Makefile.example)
 - <a href="Makefile.example" download="Makefile">download example Makefile</a>
 
-<p class="leftbar">
 Feel free to modify the `Makefile` to suit your obfuscation
 needs.
-</p>
 
-<p class="leftbar">
 **Please** add a space between the `=` and the value of variables, in the
 `Makefile`, making sure that the `=` comes immediately after the name. See the
 example `Makefile` for examples.
-</p>
 
 <p class="leftbar">
+This helps us fit the Makefile into a winning entry, should your submission win.
+</p>
+
 The rest of this section and its subsections will assume that you are using some
 variant of the example `Makefile`, again renamed as `Makefile`.
-</p>
 
-<p class="leftbar">
 We suggest that you compile your submission with a commonly available
 `-std=gnu17` (ISO C 2017 with GNU extensions) C compiler, via `clang(1)`
 and/or `gcc(1)`.
-</p>
 
 <div id="cflags">
 <div id="flags">
@@ -983,45 +828,37 @@ and/or `gcc(1)`.
 </div>
 </div>
 
-<p class="leftbar">
 Unless you **clearly state** otherwise in your `remarks.md` file, **AND** put in
 your submission's `Makefile`, we **will** compile using `-std=gnu17 -O3`!
-</p>
 
-<p class="leftbar">
 It **is OK** if you need to require your submission to **NOT be** compiled
 using the default `-std=gnu17 -O3` settings.  Simply **explain why**
 your submission should NOT be compiled using `-std=gnu17 -O3` in
 your `remarks.md` file, **AND** adjust your `Makefile` accordingly.
-</p>
 
 <p class="leftbar">
+You really should **NOT** redefine `CC` because doing so makes it less portable. <-- **Hint!**
+</p>
+
 One reason that you might have to change the flags, is that the optimiser is
 known to break some programs, but there are certainly other possible valid
 reasons. Again, just update the `Makefile` and explain it in your `remarks.md`.
 See the [optimiser section](#optimiser) for details for changing optimiser
 flags.
-</p>
 
-<p class="leftbar">
 For more fun when it comes to optimisers breaking code, see
 [1986/marshall/compilers.html](../1986/marshall/compilers.html).
-</p>
 
 
 <div id="compilers">
 ## Default compiler
 </div>
 
-<p class="leftbar">
 **IMPORTANT NOTE**: The use of `-std=gnu17` does **NOT** imply the use of the `gcc`
 compiler!  We often start by compiling using the **clang** C compiler instead.
-</p>
 
-<p class="leftbar">
 **PLEASE NOTE**: in macOS, the compiler `gcc` found at `/usr/bin/gcc` is
 in truth the `clang` compiler, as `/usr/bin/gcc --version` will show!
-</p>
 
 
 <div id="cstd">
@@ -1030,11 +867,8 @@ in truth the `clang` compiler, as `/usr/bin/gcc --version` will show!
 </div>
 </div>
 
-<p class="leftbar">
 You may change the standard under which your submission is compiled
 by modifying the `CSTD` Makefile variable.  For example, to use `c99` instead:
-</p>
-
 
 ``` <!---make-->
     CSTD= -std=c99
@@ -1052,11 +886,9 @@ by modifying the `CSTD` Makefile variable.  For example, to use `c99` instead:
 </div>
 </div>
 
-<p class="leftbar">
 You may change the level of optimization and compiler debug level
 that your submission is compiled with, by modifying the `OPT` Makefile variable.
 For example, to compile without optimization, and to include debug symbols:
-</p>
 
 ``` <!---make-->
     OPT= -O0 -g3
@@ -1068,27 +900,22 @@ For example, to compile without optimization, and to include debug symbols:
 </div>
 </div>
 
-<p class="leftbar">
 The default warning flags are set via the `CWARN` variable, as shown in the
 example `Makefile`:
-</p>
 
-``` <!---sh-->
+``` <!---make-->
     # Common C compiler warning flags
     #
     CWARN= -Wall -Wextra ${CSILENCE} ${CUNKNOWN}
 ```
 
-<p class="leftbar">
 For details on `CSILENCE` and `CUNKNOWN`, see the [section on disabling
 warnings](#disabling-warnings).
-</p>
 
 <div id="weverything">
 ### The `-Weverything` option
 </div>
 
-<p class="leftbar">
 For compilers, such as `clang`, that have the `-Weverything` option,
 while you may wish to try it, you should read our
 FAQ on "[clang -Weverything](../faq.html#weverything)".
@@ -1096,61 +923,45 @@ We do **NOT** recommend that you put
 the use of `-Weverything` into your submission's `Makefile` for the reasons
 cited there. This goes even if your version does not trigger a warning as some
 other version might!
-</p>
 
-<p class="leftbar">
 On the other hand, if `${CC}` has "`clang`" in the name, the example `Makefile` will
 automatically enable `-Weverything`, so you might have to use `-Wno-foo`
 options anyway, as detailed below. See the
 FAQ on "[-Weverything](../faq.html#weverything)"
 for more details.
-</p>
 
-<p class="leftbar">
 If "`clang`" is NOT in `${CC}`, the `CWARN` variable will not be further
 modified.
-</p>
 
-<p class="leftbar">
 There is no real penalty for compiler warnings.  Sometimes
 compiler warnings cannot be helped: especially in the case of
 obfuscated C.  :-)  So if you cannot easily get rid of a compiler
 warning, try not to fret too much.
-</p>
 
-<p class="leftbar">
 We **LIKE** code that has a minimum of warnings, especially under the
 more strict ` -Wall -Wextra -pedantic` mode:
-</p>
 
 ``` <!---make-->
     CWARN= -Wall -Wextra -pedantic
 ```
 
-<p class="leftbar">
 The two previous guidelines might be thought by some as being somewhat
 contradictory.  Isn't life, and isn't trying to satisfy "contradictory customer
 requirements" all too often like that?  :-)  Try to minimize warnings if you
 can.
-</p>
 
-<p class="leftbar">
 If you manage to produce very few warnings, or perhaps no warnings at
 all under the `-Wall -Wextra -pedantic` mode, then by all means brag about it in
 your `remarks.md` file **AND BE SURE TO TELL US** the OS, OS version, compiler
 and compiler version in which you observed this occurring (in case our OS and
 compiler produces a different result: so your submission won't be penalized for
 not meeting your claims).
-</p>
 
-<p class="leftbar">
 On the other hand, some warnings cannot be disabled and are enabled by compilers
 without any warning option specified. These are sometimes inevitable in
 obfuscated code and even in some non-obfuscated code, and you should not worry
 about this, though it might be worth pointing out.
-</p>
 
-<p class="leftbar">
 For instance, some compilers like to warn about use of pointers as arrays, which seems to
 be dubious, as it obviously can't (always) be avoided, being a big part of C, so
 you should not worry about this either; this is the warning
@@ -1159,7 +970,6 @@ See also the
 FAQ on "[forced warnings](../faq.html#forced_warnings)"
 and the
 FAQ on "[-Weverything](../faq.html#weverything)".
-</p>
 
 <div id="disabling-warnings">
 ## Disabling warnings
@@ -1171,7 +981,6 @@ included, you might wish to state this fact in your `remarks.md` file.
 And even without `-Weverything` there can be warnings, as noted above.
 </p>
 
-<p class="leftbar">
 If your submission issues lots of warnings but is otherwise
 marvelously obfuscated in multiple levels, don't worry about it.  Nevertheless,
 be sure that the warnings do not constitute a potential "**show stopper**"
@@ -1179,15 +988,12 @@ compiler problem.  Be sure that compilers such as both `gcc` and `clang` won't
 produce a compiler **error** and refuse to compile your code: unless for some
 reason that is what you intend to happen in which case document that too in your
 `remarks.md` file.  :-)
-</p>
 
 All other things being equal, a program that must turn off fewer
 warnings will be considered better, for certain values of better.
 
-<p class="leftbar">
 To turn off a compiler warning, in your submission's `Makefile`,
 try something such as:
-</p>
 
 ``` <!---make-->
     CSILENCE= -Wno-some-thing -Wno-another-thing
@@ -1201,56 +1007,27 @@ For instance:
     CSILENCE= -Wno-parentheses -Wno-binding-in-condition -Wno-misleading-indentation
 ```
 
-<p class="leftbar">
-If you do add "`-Wno-foo`" to your Makefile, consider changing:
-</p>
-
-``` <!---make-->
-    CUNKNOWN=
-```
-
-<p class="leftbar">
-to:
-</p>
-
-``` <!---make-->
-    CUNKNOWN= -Wno-unknown-warning-option
-```
-
-<p class="leftbar">
-Some compilers have reported this as an error, however, and if you have
-such a compiler you might want to not add it, or at least note in your
-`remarks.md` file, which OS, OS version, compiler and compiler version
-that has such a problem.
-</p>
-
 <div id="macros">
 ## Defining macros in the Makefile
 </div>
 
-<p class="leftbar">
 If you need to define something on the compile line, use
 the `CDEFINE` Makefile variable.  For example:
-</p>
 
 ``` <!---make-->
     CDEFINE= -Dfoo -Dbar=baz
 ```
 
-<p class="leftbar">
 **NOTE**: just because we offer a default way to use the `-D` option, we still
 do not like excess use of `-D` to get past size limits, especially since you
 could use `#define` in your code instead.
-</p>
 
 <div id="include">
 ## Include files in the Makefile
 </div>
 
-<p class="leftbar">
 If you need to include a file (as in `#include`) on the command line, use the
 `CINCLUDE` Makefile variable.  For example:
-</p>
 
 ``` <!---make-->
     CINCLUDE= -include stdio.h
@@ -1261,73 +1038,59 @@ If you need to include a file (as in `#include`) on the command line, use the
 ## Magic in the Makefile
 </div>
 
-<p class="leftbar">
 If you need to add other "**magic**" flags to your compile line,
 use the `COTHER` Makefile variable.  For example:
-</p>
 
 ``` <!---make-->
     COTHER= -fno-math-errno
 ```
 
-<p class="leftbar">
 **NOTE**: **We only recommend using "_magic_" flags if _BOTH_ `gcc`
 _and_ `clang`** support it.
-</p>
 
-<p class="leftbar">
 Again, please note that in macOS, `/usr/bin/gcc` is actually `clang`!
-</p>
 
 
 <div id="clobber">
 ## The clobber rule
 </div>
 
-<p class="leftbar">
 When `make clobber` is invoked, we request that submissions be restored
 to their original submission state.  For example, any temporary files
 (**including** the compiled program(s)) created during the build process, or
 during execution should be removed by the `clobber` rule. In other words, the
 only things that should be in the directory after running `make clobber` is what
 is in your submission tarball itself.
-</p>
 
-<p class="leftbar">
 While people are free to manage their submission under `git(1)` or even use a
 GitHub repo, dot-files and dot-directories such as `.git` are not allowed in a
 submission.
-</p>
 
-<p class="leftbar">
 The `mkiocccentry(1)` tool will ignore dot-files and dot-directories (such as
 `.vimrc`, `.bashrc`, `.git` and `.github`) and not put them in the submission's
 compressed tarball. So while you may use such files and
 directories to help develop your submission, they won't be included when you run
 the `mkiocccentry(1)` tool.
-</p>
 
-<p class="leftbar">
 Even if you did manage to get dot files or dot directories in the tarball
 somehow, `txzchk(1)` will flag it as an error. When the judges run `txzchk(1)`
 on the uploaded submission compressed tarball, if anything is wrong, for
 instance if you "sneak in" any dot files or dot directories, the submission
 **WILL BE REJECTED** for violating [Rule 17](rules.html#rule17)!
-</p>
 
-<p class="leftbar">
 You may use whatever tools you need to develop your submission, including the
 use of `git(1)` or `gh(1)`, just be sure that your submission code and your
 submission Makefile don't depend on such tools.
-</p>
 
-<p class="leftbar">
 Of course if you do use GitHub to work on your submission, you might want to
 make the repo private so you don't reveal who you are. :-)
+
+<p class="leftbar">
+In other words, make **SURE** you keep anonymous who submitted the code!
 </p>
 
 <p class="leftbar">
-If this is not clear, please do **NOT** use these tools to help with the
+Please do **NOT** use these tools to help with the
 `clobber` rule! For instance, do **NOT** use `git clean`! Not only does this
 depend on the user having `git(1)` but it also does not account for the
 submission tarballs. Even worse is when someone does have it in a `git(1)` repo
@@ -1335,9 +1098,7 @@ it will remove files that are not under `git(1)` control! Instead, see the
 `clobber` rule in the example Makefile to see how to manage this.
 </p>
 
-<p class="leftbar">
 In other words, for `make clobber`, do something like:
-</p>
 
 
 ``` <!---makefile-->
@@ -1353,17 +1114,13 @@ and **NOT** something like this:
             -git clean -f   # WRONG !!!
 ```
 
-<p class="leftbar">
 And do **NOT** use `git` for any other `Makefile` rule either.
-</p>
 
 
-<p class="leftbar">
 **NOTE**: `mkiocccentry(1)` will directly run `make clobber` in the submission
 directory. And although it is not an error if this fails, if it fails because the
 Makefile does not have a clobber rule, it will be flagged by `mkiocccentry(1)`
 (you may ignore this but it does put you at a risk of violating the rules).
-</p>
 
 
 Jump to: [top](#)
@@ -1375,32 +1132,24 @@ Jump to: [top](#)
 </div>
 </div>
 
-<p class="leftbar">
 We **VERY MUCH LIKE** submissions that use an edited variant of the
 example Makefile, as described and linked to in the [Makefile section](#makefile),
 renamed as `Makefile` of course.  This makes it easier for the [IOCCC judges](../judges.html)
 to test your submission. And if your submissions wins, it makes it easier to integrate it into
 the [Official IOCCC winner website](https://www.ioccc.org/index.html).
-</p>
 
-<p class="leftbar">
 We **VERY MUCH LIKE** submissions that have some educational value. This does **NOT** mean
 that your submission should not be obfuscated but rather that the IOCCC has moved away from
 the idea of "spoilers". You should not encrypt or rot13 content in your `remarks.md` file.
-</p>
 
-<p class="leftbar">
 It is **VERY MUCH** appreciated if your remarks have some educational
 value. And although educational value is not required, it is an
 **EXCELLENT** bonus.
-</p>
 
 
-<p class="leftbar">
 We **LIKE** submissions that use an edited version of the
 `try.sh` example script (and if you have alternate code,
 the same applies with the `try.alt.sh` script):
-</p>
 
 - [view example try.sh](%%REPO_URL%%/next/try.sh)
 - <a href="try.sh">download example try.sh</a>
@@ -1408,17 +1157,29 @@ the same applies with the `try.alt.sh` script):
 - [view example try.alt.sh](%%REPO_URL%%/next/try.alt.sh)
 - <a href="try.alt.sh">download example try.alt.sh</a>
 
-<p class="leftbar">
 Of course, it is quite possible that only one invocation is
 possible, so it is not necessarily detrimental to your submission if you do not
 include one, though we do like interesting and creative uses of submissions. See
 also the
 FAQ on "[submitting try.sh and try.alt.sh scripts](../faq.html#try_scripts)".
+
+<p class="leftbar">
+Even if it only has one invocation we still **LIKE** the try scripts.
 </p>
 
 <p class="leftbar">
-You might wish to add `./try.sh` to the `try` rule in the Makefile you submit.
-If you have alternate code, then you can use the `try.alt` rule as well.
+If you do include a `try.sh` then **PLEASE** remove the `try` rule in the
+Makefile.
+</p>
+
+<p class="leftbar">
+If you do include a `try.alt.sh` then **PLEASE** remove the `try.alt` rule in
+the Makefile.
+</p>
+
+<p class="leftbar">
+If you don't have a prog.alt.c, then **PLEASE** remove the `try.alt` rule as
+well.
 </p>
 
 Doing masses of `#define`s to obscure the source has become 'old'.  We
@@ -1433,10 +1194,8 @@ as a program that is more well rounded in confusion.
     #d foo             /* <-- don't expect this to turn into #define foo */
 ```
 
-<p class="leftbar">
 In other words, it is a compilation error, and in order to get older
 IOCCC winning entries that did this to compile, we had to update them to not do this.
-</p>
 
 When declaring local or global variables, you should declare the type:
 
@@ -1445,22 +1204,16 @@ When declaring local or global variables, you should declare the type:
     this_is_not;       /* <-- Try to avoid implicit type declarations */
 ```
 
-<p class="leftbar">
 We tend to **like _less_** a submission that requires either
 `gcc` **OR** `clang`.  **We _prefer_ submissions** that can compile
-under **BOTH** `gcc` **AND** `clang`.
-</p>
+under **BOTH** `gcc` **AND** `clang`. **Hint!**
 
-<p class="leftbar">
 We **RECOMMEND** that the compiler flags you use in your
 submission's `Makefile` are supported by **BOTH** `gcc` **AND** `clang`.
-</p>
 
-<p class="leftbar">
 We **DISLIKE** the use of obscure compiler flags, especially
 if `gcc` and/or `clang` do not support it.  We **suggest**
 that you not use any really obscure compiler flags if you can help it.
-</p>
 
 One side effect of the above is that you cannot assume the use
 of nested functions such as:
@@ -1479,9 +1232,7 @@ nested functions.  Such constructions, while interesting and sometimes
 amusing, will have to wait until they are required by a C standard that are
 actually implemented in **BOTH** `gcc` **AND** `clang`.
 
-<p class="leftbar">
 We **DISLIKE** submissions that require the use of `-fnested-functions`.
-</p>
 
 We prefer programs that do not require a fish license: crayons and
 cat detector vans not withstanding.
@@ -1500,19 +1251,18 @@ not portable and _must not_ be used**:
 
 In particular, do not treat `va_list` variables as if they were a `char **`.
 
-<p class="leftbar">
 We **DISLIKE** the use of `varargs.h`.  Use `stdarg.h` instead.
-</p>
 
-<p class="leftbar">
 We **DISLIKE** the use of `gets(3)`.  Use `fgets(3)` instead.
-</p>
 
-<p class="leftbar">
 We tend to **DISLIKE** the blatant use of tarballs in an attempt to simply get
 around the extra file number limit. We realize there may be cases where a
 tarball containing a number of extra files may be needed. Such a need for a
 tarball **MUST** be explained in the `remarks.md` file.
+
+<p class="leftbar">
+Using a mass of `goto`s to obfuscate your code has become 'old' and is unlikely
+to make it through the final rounds, if it even gets that far.
 </p>
 
 On 28 January 2007, the Judges rescinded the requirement that the
@@ -1531,20 +1281,16 @@ serve a useful purpose: they are often the only program that people
 attempt to completely understand.  For this reason, we look for
 programs that are compact, and are instructional.
 
-<p class="leftbar">
 While those who are used to temperatures found on [dwarf
 planets](https://science.nasa.gov/dwarf-planets/)
 (**yes Virginia, dwarf planets _ARE_ planets!**), such as
 [Pluto](https://science.nasa.gov/dwarf-planets/pluto/), might be able to
 explain to the Walrus why our seas are boiling hot, the question of
 whether pigs have wings is likely to remain a debatable point to most.
-</p>
 
-<p class="leftbar">
 One line programs should be short one line programs: say around **80** to **132**
 bytes long.  Going well beyond **132** bytes is a bit too long to be called
 a one-liner in our vague opinion.
-</p>
 
 We tend to **DISLIKE** programs that:
 
@@ -1553,23 +1299,20 @@ We tend to **DISLIKE** programs that:
 sockets/streams specific code is likely not to be)
 * dump core or have compiler warnings (it is OK only if
 you warn us in your `remarks.md` file)
-* <p class="leftbar">won't compile or run in a [Single UNIX
+* won't compile or run in a [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
-environment</p>
-* <p class="leftbar">depend on a utility or application not normally found
+environment
+* depend on a utility or application not normally found
 in systems that conform to the [Single UNIX
-Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)</p>
-* abuse the build file to get around the size limit<br>
-* <p class="leftbar">obfuscate by use of ANSI trigraphs</p>
-* <p class="leftbar">obfuscate by use of digraphs</p>
-* <p class="leftbar">are larger than they need to be</p>
-* <p class="leftbar">have more lines than they need to have</p>
-* <p class="leftbar">are "blob-ier" (just a pile of unformatted C code)
-than they need to be</p>
-* <p class="leftbar">are rather similar to **[previous
-winners](../years.html)** :-(</p>
-* <p class="leftbar">are **identical** to **[previous
-losers](https://en.wikipedia.org/wiki/Null_device)** :-)</p>
+Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
+* abuse the build file to get around the size limit
+* obfuscate by use of ANSI trigraphs
+* obfuscate by use of digraphs
+* are larger than they need to be
+* have more lines than they need to have
+* are "blob-ier" (just a pile of unformatted C code) than they need to be
+* are rather similar to **[previous winners](../years.html)** :-(
+* are **identical** to **[previous losers](https://en.wikipedia.org/wiki/Null_device)** :-)
 * that mandate the exclusive use of a specific Integrated Development Environment (IDE)
 
 In order to encourage submission portability, we **DISLIKE** submissions that
@@ -1577,12 +1320,10 @@ fail to build unless one is using an IDE. For example, do not
 mandate that one must use Microsoft Visual Studio to compile
 your submission.
 
-<p class="leftbar">
 The program must compile and link cleanly in a [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 environment. Therefore do not assume the system has a
 [windows.h](https://en.wikipedia.org/wiki/Windows.h) include file:
-</p>
 
 
 ``` <!---c-->
@@ -1608,32 +1349,24 @@ source under the size limit.
 Your source code, post-pre-processing, should not exceed the size of
 [Microsoft Windows](https://en.wikipedia.org/wiki/Microsoft_Windows). :-)
 
-<p class="leftbar">
 Other windows, on the other hand, might be OK: especially where "**X
 marks the spot**".  Yet on the third hand, windows are best when they are
 "unseen" (i.e., not dirty).  :-)
-</p>
 
-<p class="leftbar">
 The [IOCCC judges](../judges.html), as a group, have a history giving wide degree of latitude
 to reasonable submissions.  And recently they have had as much longitudinal
 variation as it is possible to have on [Earth](https://science.nasa.gov/earth/).  :-)
-</p>
 
-<p class="leftbar">
 You should try to restrict commands used in the build file to commands found in
 [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 environments and systems that conform to the [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification).
-</p>
 
-<p class="leftbar">
 You may compile and use your own programs.  If you do, try to build and execute
 from the current directory.  This restriction is not a hard and
 absolute one.  The intent is to ensure that the building of your
 program is reasonably portable.
-</p>
 
 We prefer programs that are portable across a wide variety of UNIX-like
 operating systems (e.g., Linux, GNU Hurd, BSD, UNIX, etc.).
@@ -1677,10 +1410,12 @@ Please try to be much more creative.
 We really **DISLIKE** submissions that make blatant use of including
 large data files to get around the source code size limit.
 
+<p class="leftbar">
 We do not recommend submitting [systemd](https://systemd.io) source code to the IOCCC,
 if nothing else because that code is likely to exceed [the source code
 size limit](rules.html#rule2).  This isn't to say that another highly compact and obfuscated
-replacement of `init` would not be an interesting submission.
+replacement of `init(8)` would not be an interesting submission.
+</p>
 
 Did we remember to indicate that programs that blatantly use
 some complex state machine to do something simple, are boring?
@@ -1688,7 +1423,6 @@ We think we did.  :-)
 
 > All generalizations are false, including this one. -- **Mark Twain**
 
-<p class="leftbar">
 Given two versions of the same program, one that is a compact blob
 of code, and the other that is formatted more like a typical C
 program, we tend to favor the second version.  Of course, a third
@@ -1696,7 +1430,6 @@ version of the same program that is formatted in an interesting
 and/or obfuscated way, would definitely win over the first two!
 Remember, you can submit more than one submission.  See the [IOCCC
 rules](rules.html) for details (in particular, [Rule 9](rules.html#rule9)).
-</p>
 
 We suggest that you avoid trying for the '**smallest self-replicating**'
 source.  The smallest, a [zero byte entry](../1994/smr/index.html), won in
@@ -1713,11 +1446,9 @@ is **NOT** the smallest C source file that when compiled and run, dumps core:
     main;
 ```
 
-<p class="leftbar">
 Unless you specify `-fwritable-strings` (see `COTHER` in the example
 Makefile, described in the [Makefile section](#makefile)), do not assume this
 sort of code will work:
-</p>
 
 ``` <!---c-->
     char *T = "So many primes, so little time!";
@@ -1725,22 +1456,16 @@ sort of code will work:
     T[14] = ';';    /* modifying a string requires: -fwritable-strings */
 ```
 
-<p class="leftbar">
 Even so, one should probably not assume that this is universally accepted.
-</p>
 
-<p class="leftbar">
 Initialized char arrays are OK to write over.  For instance, this is OK:
-</p>
 
 ``` <!---c-->
     char b[] = "Is this OK";
     b[9] = 'k';     /* modifying an initialized char array is OK */
 ```
 
-<p class="leftbar">
 There are more than 1 typos in this very sentence.
-</p>
 
 X client submissions should be as portable as possible.  Submissions that
 adapt to a wide collection of environments will be favored.  For
@@ -1755,27 +1480,21 @@ source program (one that actually works) to display audio/visual data.
 X client submissions should avoid using X related libraries and
 software that are not in wide spread use.
 
-<p class="leftbar">
 As of Red Hat RHEL9.0, the X.org server is deprecated. See the
 FAQ on "[Xorg deprecation"](../faq.html#Xorg_deprecated)"
 for more details. This does not mean that a submission using this will
 necessarily be rejected, but it would be better if it can support Wayland in
 some way or another.
-</p>
 
 This could be the only _guideline_ that contains the word
 [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin).
 
-<p class="leftbar">
 However, do you know how to play [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin)?
 You do?!?  (Except on Tuesday?)
-</p>
 
-<p class="leftbar">
 OK, there are actually 2 _guidelines_ that contain the word
 [fizzbin](https://en.wikipedia.org/wiki/List_of_games_in_Star_Trek#Fizzbin),
 unless you count this one, in which case there are 3. :-)
-</p>
 
 We **DISLIKE** submissions that use proprietary toolkits such as the `M*tif`,
 `Xv*ew`, or `OpenL*ok` toolkits, since not everyone has them.  Use an
@@ -1783,33 +1502,23 @@ open source toolkit that is widely and freely available instead.
 
 **NOTE**: The previous _guideline_ in this spot has been replaced by this _guideline_:
 
-<p class="leftbar">
 X client submissions should try to not to depend on particular items in
 `.Xdefaults`.  If you must do so, be sure to note the required lines
 in the your `remarks.md` file.  They should also not depend on any
 particular window manager.
-</p>
 
-<p class="leftbar">
 Try to avoid submissions that play music that some people believe is copyrighted
 music.
-</p>
 
-<p class="leftbar">
 While we recognize that UNIX is not a universal operating system, the contest
 does have a bias towards such systems.  In an effort to expand the scope of the
 contest, we phrase our bias to favor the [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification).
-</p>
 
-<p class="leftbar">
 You are **well advised** to submit code that conforms to the [Single UNIX
 Specification Version 4](https://unix.org/version4/overview.html).
-</p>
 
-<p class="leftbar">
 To quote the [IOCCC judges](../judges.html):
-</p>
 
 > You very well might not be completely prohibited from failing to not partly
 misunderstand this particular _guideline_, but of course, we could not possibly
@@ -1836,25 +1545,19 @@ Some types of programs can't excel (anti-tm) in some areas.  Your
 program doesn't have to excel in all areas, but doing well in several
 areas really does help.
 
-<p class="leftbar">
 You are better off explaining what your submission does in your
 `remarks.md` file section rather than leaving it obscure for the
 [IOCCC judges](../judges.html) as we might miss something and/or be too tired to
 notice.
-</p>
 
-<p class="leftbar">
 Please avoid this specific individual _guideline_, if it at all possible.
-</p>
 
-<p class="leftbar">
 We freely admit that interesting, creative or humorous comments in
 your `remarks.md` file help your chances of winning.  If you had to
 read so many twisted submissions, you too would enjoy a good laugh or two.
 We think the readers of the contest winners do as well.  We do read
 your `remarks.md` content during the judging process, so it is worth your
 while to write a remarkable `remarks.md` file.
-</p>
 
 We **DISLIKE** C code with trailing control-M's (`\r` or `\015`) that results
 in compilation failures.  Some non-UNIX/non-Linux tools such as
@@ -1867,16 +1570,17 @@ One should restrict libcurses to portable features found on BSD
 or Linux curses.
 
 <p class="leftbar">
-[Rule 13](rules.html#rule13) no longer discourages the use of UTF-8
-characters in C code.
+If you do `#include <curses.h>` make **CERTAIN** you link in curses (i.e.
+`-lcurses`) and not ncurses (i.e. `-lncurses`).
 </p>
 
-<p class="leftbar">
+[Rule 13](rules.html#rule13) no longer discourages the use of UTF-8
+characters in C code.
+
 It is a very good idea to, in your `remarks.md` file, tell us why you
 think your submission is obfuscated.  This is particularly true if
 your submission has some very subtle obfuscations that we might
 otherwise overlook.  **<<-- Hint!**
-</p>
 
 Anyone can format their code into a dense blob.  A really clever
 author will try format their submission using a "normal" formatting style
@@ -1891,11 +1595,9 @@ about why you think your submission is obfuscated.  On the other hand,
 if you are pushing up against the size limits, you may be forced
 into creating a dense blob. Such are the trade-offs that obfuscators face!
 
-<p class="leftbar">
 We prefer code that can run on either a 64-bit or 32-bit
 processor.  However, it is **UNWISE **to assume it will run on an
 some Intel-like x86 architecture**.
-</p>
 
 We believe that Mark Twain's quote:
 
@@ -1903,30 +1605,25 @@ We believe that Mark Twain's quote:
 
 ... is a good motto for those writing code for the IOCCC.
 
-<p class="leftbar">
 The IOCCC size tool source is not an original work, unless you are [Anthony C
 Howe](../authors.html#Anthony_C_Howe), in which case it is original!  :-)
 Submitting source code that uses the contents of
 [iocccsize.c](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c),
 _unless_ you are [Anthony C Howe](../authors.html#Anthony_C_Howe), might run the
 risk of violating [Rule 7](rules.html#rule7).
-</p>
 
-<p class="leftbar">
 The IOCCC submission tarball validator source is not an original work,
 unless you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), in
 which case it is original!  :-) Submitting source code that uses the contents of
 [txzchk.c](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c),
 _unless_ you are [Cody Boone Ferguson](../authors.html#Cody_Boone_Ferguson), might
 run the risk of violating [Rule 7](rules.html#rule7).
-</p>
 
-<p class="leftbar">
 In addition to the above tools, none of the [mkiocccentry
 tools](https://github.com/ioccc-src/mkiocccentry), _including, **but not
 limited**_ to
 [mkiocccentry](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c),
-[chkentry](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c),
+[chksubmit](https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c),
 [chksubmit](https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c),
 [fnamchk](https://github.com/ioccc-src/mkiocccentry/blob/master/test_ioccc/fnamchk.c)
 and
@@ -1945,9 +1642,7 @@ library, _unless_ you are [Cody Boone
 Ferguson](../authors.html#Cody_Boone_Ferguson) or [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), might run the risk of violating
 [Rule 7](rules.html#rule7).
-</p>
 
-<p class="leftbar">
 And unless you are [Landon Curt Noll](https://en.wikipedia.org/wiki/Landon_Curt_Noll),
 the code in
 [dbg](https://github.com/ioccc-src/mkiocccentry/tree/master/dbg) and
@@ -1955,9 +1650,7 @@ the code in
 not original works. Submitting source code that uses the contents of those
 libraries, _unless_ you [Landon Curt Noll](https://en.wikipedia.org/wiki/Landon_Curt_Noll),
 might run the risk of violating [Rule 7](rules.html#rule7).
-</p>
 
-<p class="leftbar">
 [Rule 7](rules.html#rule7) does not prohibit you from writing your own
 obfuscated versions of these tools, unless of course you are [Landon Curt
 Noll](http://www.isthe.com/chongo/index.html), in which case you _probably_
@@ -1965,9 +1658,7 @@ won't win since [IOCCC judges](../judges.html) should not enter the IOCCC! :-)
 However, **_if_** you do write your own version, you **_might_** wish to make it do something
 **_more_ interesting** than simply implementing the [IOCCC](../index.html)
 tools' algorithms.
-</p>
 
-<p class="leftbar">
 Even so, we do not recommend you try and submit a JSON parser due to
 the fact it will likely exceed [the source code size limit](rules.html#rule2)
 and because you likely can't beat [flex](https://github.com/westes/flex) and
@@ -1980,41 +1671,32 @@ because of the [source code size limit](rules.html#rule2) or because it is not
 as obfuscated as the [flex](https://github.com/westes/flex) and [bison](https://www.gnu.org/software/bison/)
 generated code of
 [jparse](https://github.com/ioccc-src/mkiocccentry/blob/master/jparse).
-</p>
 
 While programs that only run in a specific word size are OK, if you have
 to pick, choose a 64-bit word size.
 
-<p class="leftbar">
 If the [IOCCC judges](../judges.html) are feeling ornery we
 might choose to compile your program for running on an Arduino or
 a PDP-11.  Heck, should we ever find an emulator of 60-bit CDC Cyber
 CPU, we might just try your submission on that emulator as well :-)
-</p>
 
-<p class="leftbar">
 If your submission **MUST** run only on a 64-bit or 32-bit architecture,
 then you **MUST** specify the `-arch` on your command line
 (see `ARCH` in the example
 Makefile, described in [Makefile section](#makefile)).  Do not assume a
 processor word size without specifying `-arch`.  For example:
-</p>
 
 ``` <!---make-->
     ARCH= -m64
 ```
 
-<p class="leftbar">
 Note, however, that some platforms will not necessarily support some
 architectures. For instance, more recent versions of `macOS` do **NOT** support
 32-bit!
-</p>
 
-<p class="leftbar">
 If there are limitations in your submission, you are highly encouraged
 to note such limitations in your `remarks.md` file.  For example if your
 submission factors values up to a certain size, you might want to state:
-</p>
 
 >   This submission factors values up `2305567963945518424753102147331756070`.
 Attempting to factor larger values will produce unpredictable results.
@@ -2031,9 +1713,7 @@ However the [IOCCC judges](../judges.html) might try to also factor 0, so you wa
 `2305567963945518424753102147331756070`.  Attempting to factor values outside
 that range will produce unpredictable results.
 
-<p class="leftbar">
 Moreover they might try to also factor 3.5 or 0x7, or Fred, so you want to might state:
-</p>
 
 >   This submission factors integers between 1 and
 `2305567963945518424753102147331756070`.  Attempting to factor anything else
@@ -2060,48 +1740,34 @@ and state:
 program is given enough time and memory.  If the value is not a proper integer,
 the program might insult a fish named Eric.
 
-<p class="leftbar">
 Do not fear if you're not 100% sure of the significance of
 `2305567963945518424753102147331756070` as it is not of prime importance: or is
 it?  :-)
-</p>
 
-<p class="leftbar">
 We **DISLIKE** the use of ASCII tab characters in markdown files, such as in the required `remarks.md` file.
-</p>
 
-<p class="leftbar">
 We don't mind the use of ASCII tab characters in your C code.  Feel free
 to use ASCII tab characters if that suits your obfuscation needs.  If is
 perfectly **OK** to use tab characters elsewhere in your submission, just not in
 markdown files as this tends annoy us when it comes time to
 rendering your markdown content as it complicates the process.
-</p>
 
-<p class="leftbar">
 If you do use ASCII tab characters in your non-markdown files, be
 aware that some people may use a tab stop that is different than the common 8
 character tab stop.
-</p>
 
-<p class="leftbar">
 **PLEASE** observe our [IOCCC markdown guidelines](../markdown.html)
 when forming your submission's `remarks.md` file.  And if your submission
 contains additional markdown files, please follow those same guidelines for
 those files. See also [Rule 19](rules.html#rule19) and our
 FAQ on "[markdown](../faq.html#markdown)".
-</p>
 
-<p class="leftbar">
 We **LIKE** reading `remarks.md` files, especially if they contain
 useful, informative, and even humorous content about your submission.  Yes, this
 is a **hint**.  :-)
-</p>
 
-<p class="leftbar">
 We **RECOMMEND** you put a reasonable amount effort into the content of the
 `remarks.md` file: it is a required file for a reason.  :-)
-</p>
 
 Try to be even more creative!
 
@@ -2132,7 +1798,6 @@ have a submission that might otherwise be interesting, you might want to
 submit two versions; one that does not abuse the [IOCCC rules](rules.html) and one that
 does.
 
-<p class="leftbar">
 If you intend to abuse the [IOCCC rules](rules.html),
 indicate so in your `remarks.md` file.  You **MUST** try to justify
 why you consider your rule abuse to be allowed under the
@@ -2141,24 +1806,18 @@ your submission is valid.  Humor and/or creativity help plead a case.
 As there is no guarantee that you will succeed, you might consider
 submitting an alternate version that conforms to the
 [IOCCC rules](rules.html).
-</p>
 
-<p class="leftbar">
 If you do bypass the `mkiocccentry(1)` warnings about [Rule
 2a](rules.html#rule2a) and/or about [Rule 2b](rules.html#rule2b) or any other
 rule and submit a submission anyway, you **MUST** try to justify why the IOCCC
 [IOCCC judges](../judges.html) should not reject your submission due to a rule
 violation, and you would be wise to do this towards the top of your `remarks.md`
 file.
-</p>
 
-<p class="leftbar">
 Abusing the web submission procedure tends to annoy us more
 than amuse us.  Spend your creative energy on content of your
 submission rather than on the submission process itself.
-</p>
 
-<p class="leftbar">
 We are often asked why the contest [IOCCC rules](rules.html) and [IOCCC
 guidelines](guidelines.html) seem strange or contain mistakes, flaws or
 grammatical errors.  One reason is that we sometimes make genuine mistakes.  But
@@ -2169,9 +1828,7 @@ deliberately leave behind holes (or introduce new ones) so that future rule
 abuse can continue.  A clever author should be able to read them and "drive a
 truck through the holes" in the [IOCCC rules](rules.html) and [IOCCC
 guidelines](guidelines.html).
-</p>
 
-<p class="leftbar">
 At the risk of stating the obvious, this contest is a parody of the software
 development process.  The [IOCCC rules](rules.html) and [IOCCC guidelines](guidelines.html)
 are only part of the overall contest.  Even so, one might think the
@@ -2182,7 +1839,6 @@ sometimes conflicting specifications and requirements from marketing, sales,
 product management and even from customers themselves on an all too regular basis.
 This is one of the reasons why the [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) are written in obfuscated form.
-</p>
 
 
 Jump to: [top](#)
@@ -2194,13 +1850,11 @@ Jump to: [top](#)
 
 Submissions are judged by Leonid A. Broukhis and Landon Curt Noll.
 
-<p class="leftbar">
 Each submission submitted is given a random string and subdirectory.  The
 submission files including, but not limited to `prog.c`, `Makefile`,
 `remarks.md`, `.info.json`, `.auth.json` as well as any data files that you
 submit, are all placed under their own directory and stored and judged from this
 directory.
-</p>
 
 Any information about the authors is not read by the [IOCCC judges](../judges.html) until
 the judging process is complete, and then only from entries that have
@@ -2211,11 +1865,9 @@ The above process helps keep us biased for/against any one particular
 individual.  Therefore you **MUST** refrain from putting any information
 that reveals your identity in your submission.
 
-<p class="leftbar">
 Now some people point out that coding and/or writing style might reveal the
 information about the authors.  However we consider this to be simply
 circumstantial and outside the scope of the above paragraph.
-</p>
 
 Some people, in the past, have attempted to obfuscate their identity by
 including comments of famous Internet personalities such as [Peter
@@ -2250,16 +1902,12 @@ attempts to send non-winners into oblivion.  We remove all non-winning
 files, and shred all related printouts.  By tradition, we do not even
 reveal the number of submissions that we receive.
 
-<p class="leftbar">
 During the judging process, a process that spans multiple sessions over
 a few weeks, we post general updates from our [Mastodon
 account](https://fosstodon.org/@ioccc).
-</p>
 
-<p class="leftbar">
 **Make sure you reload the feed** every so often **because unless you
 are mentioned you will NOT get a push notification!**
-</p>
 
 
 Jump to: [top](#)
@@ -2286,8 +1934,8 @@ Jump to: [top](#)
 
 A reading consists of a number of actions:
 
-* <p class="leftbar">Reading `prog.c`, the C source and reviewing the `remarks.md` information</p>
-* <p class="leftbar">Briefly looking at any supplied data files</p>
+* Reading `prog.c`, the C source and reviewing the `remarks.md` information
+* Briefly looking at any supplied data files
 * Passing the source thru the C pre-processor skipping over any `#include`d files
 * Performing a number of C beautify/cleanup edits on the source
 * Passing the beautified source thru the C pre-processor skipping over any `#include`d files
@@ -2298,14 +1946,10 @@ A reading consists of a number of actions:
 In later rounds, other actions are performed including performing
 miscellaneous tests on the source and binary.
 
-<p class="leftbar">
 This is the very **guideline** that goes, **BING!**
-</p>
 
-<p class="leftbar">
 Okay, technically that was the _second_ **guideline** that goes **BING**, and this
 is the third. :-)
-</p>
 
 Until we reduce the stack of submissions down to about 25 submissions,
 submissions are judged on an individual basis.  A submission is set aside because it
@@ -2324,9 +1968,8 @@ we receive.  A typical category list might be:
 * **best game that is obfuscated**
 * **most creatively obfuscated program**
 * **most deceptive C code** (code with deceptive comments and source code)
-* <p class="leftbar">**best X program** (see [OUR LIKES AND DISLIKES](#likes)
-and the
-FAQ on "[Xorg being deprecated](../faq.html#Xorg_deprecated)")</p>
+* **best X program** (see [OUR LIKES AND DISLIKES](#likes) and the FAQ on "[Xorg
+being deprecated](../faq.html#Xorg_deprecated)")
 * **best abuse of ISO C or ANSI C standard** (see above about compilers)
 * **best abuse of the C preprocessor**
 * **worst/best abuse of the rules** (or some variation)
@@ -2351,14 +1994,16 @@ worthwhile to resubmit an improved version of a submission that failed to win in
 a previous year, the next year.  This assumes, of course, that the submission is
 worth improving in the first place!
 
-<p class="leftbar">
 Over the years, more than one [IOCCC judge](../judges.html)
 has been known to **bribe** another [IOCCC judge](../judges.html) into voting for a
 winning submissions by offering a bit of high quality chocolate, or
 other fun item.
-</p>
 
 <p class="leftbar">
+Over the years some judges have submitted code that had to be rejected once it
+was discovered to be a judge.
+</p>
+
 One **should NOT** attempt to **bribe** an [IOCCC
 judge](../judges.html), **unless you are an [IOCCC judge](../judges.html)**,
 because **bribing** an [IOCCC judge](../judges.html) by a non-judge
@@ -2366,9 +2011,7 @@ has been shown to **NOT** be effective when the **person _attempting_
 the _bribe_ is made known** to the [IOCCC judges](../judges.html)
 (i.e., they are not anonymous) AND/OR the **bribe** is otherwise
 associated with a submission to the [IOCCC](../index.html).
-</p>
 
-<p class="leftbar">
 With the previous guideline in mind: **anonymous** gifts
 for the [IOCCC judges](../judges.html) that are **NOT ASSOCIATED
 WITH** a submission to the [IOCCC](../index.html) may be sent to the
@@ -2378,12 +2021,9 @@ It has been shown that receiving  **anonymous** gifts provides the
 [IOCCC judges](../judges.html) with a nice
 [dopamine](https://en.wikipedia.org/wiki/Dopamine) boost, and happy
 [IOCCC judges](../judges.html) help make the [IOCCC](../index.html) better for everyone. :-)
-</p>
 
-<p class="leftbar">
 See the
 FAQ on "[supporting the IOCCC](../faq.html#support)".
-</p>
 
 More often than not, we select a small submission (usually one line) and a
 strange/creative layout submission.  We sometimes also select a
@@ -2391,9 +2031,7 @@ submission that abuses the [IOCCC guidelines](guidelines.html) in an interesting
 or that stretches the contest [rules](rules.html) that while legal, it
 nevertheless goes against the **intent** of the [rules](rules.html).
 
-<p class="leftbar">
 Nevertheless, see [Rule 12](rules.html#rule12).
-</p>
 
 In the end, we traditionally pick one submission as '**best**'.  Sometimes such
 a submission simply far exceeds any of the other submissions.  More often, the
@@ -2411,17 +2049,13 @@ Jump to: [top](#)
 # ANNOUNCEMENT OF WINNERS:
 </div>
 
-<p class="leftbar">
 The [IOCCC judges](../judges.html) will toot initial announcement of who won, the name
 of their award, and a very brief description (award title) of the winning entry
 from the [@IOCCC Mastodon account](https://fosstodon.org/@ioccc).
-</p>
 
-<p class="leftbar">
 We recommend that you follow us on mastodon but **please make sure to
 refresh the feed** every so often (if not more often) because unless you are
 mentioned or someone boosts your post you will not get a push notification.
-</p>
 
 
 Jump to: [top](#)
@@ -2431,35 +2065,23 @@ Jump to: [top](#)
 ## How the new IOCCC winners will be announced
 </div>
 
-<p class="leftbar">
 The [current status of the IOCCC](../status.html) will change from
 **[judging](../faq.html#judging)** to **[closed](../faq.html#closed)** .
-</p>
 
-<p class="leftbar">
 The **contest_status** in the [status.json](../status.json) file will change
 from **judging** to **closed** as well.
-</p>
 
-<p class="leftbar">
 When the above happens, the winning entries have been selected by the [IOCCC
 judges](../judges.html).
-</p>
 
-<p class="leftbar">
 The [IOCCC judges](../judges.html) will begin to prepare to release the source
 code of the new IOCCC winners.
-</p>
 
-<p class="leftbar">
 The [IOCCC judges](../judges.html) will commit the winning source to the
 [IOCCC winner repo](https://github.com/ioccc-src/winner) which will update the
 [Official IOCCC website](https://www.ioccc.org/index.html).
-</p>
 
-<p class="leftbar">
 The [IOCCC news](../news.html) will also contain an announcement of the winners.
-</p>
 
 
 Jump to: [top](#)
@@ -2484,10 +2106,8 @@ In addition a note is posted to the [IOCCC Mastodon account](https://fosstodon.o
 We will also post a notice to the IOCCC discord server.
 </p>
 
-<p class="leftbar">
 Consider joining the IOCCC discord community via this link:
 [https://discord.gg/Wa42Qujwnw](https://discord.gg/Wa42Qujwnw)
-</p>
 
 
 Jump to: [top](#)
@@ -2497,20 +2117,16 @@ Jump to: [top](#)
 ## Back to announcement of winners
 </div>
 
-<p class="leftbar">
 It is pointless to ask the [IOCCC judges](../judges.html) how many
 submissions we receive.  See [How many submissions do the judges receive for a
 given IOCCC?](../faq.html#how_many).
-</p>
 
-<p class="leftbar">
 Often, winning entries are published in selected magazines from around the
 world.  Winners have appeared in books ('`The New Hacker's Dictionary`',
 '`Obfuscated C and Other Mysteries`', '`Pointers On C`', others) and on t-shirts
 (sometimes by the author(s) themselves).  There have been multiple classes
 that have focused in part, on IOCCC winning entries.  And more than one winner has been turned
 into a tattoo!
-</p>
 
 Last, but not least, [winners](../authors.html) receive international fame and flames!  :-)
 
@@ -2524,41 +2140,28 @@ Jump to: [top](#)
 </div>
 </div>
 
-<p class="leftbar">
 For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
-</p>
 
-<p class="leftbar">
 **Be SURE** to review the [IOCCC Rules and Guidelines](index.html) as they
 may (and **often do**) change from year to year.
-</p>
 
-<p class="leftbar">
 **PLEASE** be sure you have the current [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) prior to submitting to the contest.
-</p>
 
 See the [Official IOCCC website news](../news.html) for additional information.
 
-<p class="leftbar">
 For the updates and breaking IOCCC news, you are encouraged to follow
 the [IOCCC on Mastodon](https://fosstodon.org/@ioccc).  See our
 FAQ on "[Mastodon](../faq.html#try_mastodon)"
 for more information. Please do note that unless
 you are mentioned by us you will **NOT** get a notification from the app _so you
 should refresh the page **even if you do follow us**_.
-</p>
 
-<p class="leftbar">
 Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
-</p>
 
-<p class="leftbar">
 Consider joining the IOCCC discord community via this link:
 [https://discord.gg/Wa42Qujwnw](https://discord.gg/Wa42Qujwnw)
-</p>
 
-<p class="leftbar">
 See the
 FAQs on "[obtaining, compiling, installing and using the mkiocccentry tools](../faq.html#mkiocccentry)"
 and the
@@ -2567,7 +2170,6 @@ as that FAQ has important details on
 [how to register](../next/register.html)
 as well as
 [how to upload your submission](../next/submit.html) for the IOCCC.
-</p>
 
 
 <hr style="width:10%;text-align:left;margin-left:0">

--- a/next/rules.html
+++ b/next/rules.html
@@ -488,12 +488,10 @@ writing by <a href="../contact.html">contacting the judges</a>.</p>
 </div>
 </div>
 <p class="leftbar">
-These <a href="rules.html">IOCCC rules</a> are version <strong>28.30 2025-03-03</strong>.
+These <a href="rules.html">IOCCC rules</a> are version <strong>28.31 2025-11-17</strong>.
 </p>
-<p class="leftbar">
-The markdown form of these rules <a href="rules.md" download="rules.md">is
-available for download</a>.
-</p>
+<p>The markdown form of these rules <a href="rules.md" download="rules.md">is
+available for download</a>.</p>
 <p><strong>IMPORTANT</strong>: Be sure to read the <a href="guidelines.html">IOCCC guidelines</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="change_marks">
@@ -545,16 +543,14 @@ This contest will enter the <strong><a href="../faq.html#judging">judging</a></s
 <strong>IMPORTANT NOTE</strong>: Until the contest enters the <strong><a href="../faq.html#open">open</a></strong> state, any or all
 of the above <strong>dates and times may change</strong>!
 </p>
-<p class="leftbar">
-See the
+<p>See the
 FAQ on “<a href="../faq.html#mkiocccentry">obtaining and compiling the mkiocccentry tools</a>”
 and the
 FAQ on “<a href="../quick-start.html#enter">how to enter the IOCCC</a>”
 as that FAQ has important details on
 <a href="../next/register.html">how to register</a>
 as well as
-<a href="../next/submit.html">how to upload your submission</a> to the IOCCC.
-</p>
+<a href="../next/submit.html">how to upload your submission</a> to the IOCCC.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rules">
 <h1 id="ioccc-rules">IOCCC RULES</h1>
@@ -563,192 +559,132 @@ as well as
 <div id="rule_abuse">
 <h4 id="a-warning-about-rule-abuse">A warning about rule abuse</h4>
 </div>
-<p class="leftbar">
-<strong>WARNING:</strong> Abusing these rules comes with a <strong>fair amount of risk</strong>
+<p><strong>WARNING:</strong> Abusing these rules comes with a <strong>fair amount of risk</strong>
 that your submission will be rejected. If you do plan to abuse the
 rules, then you <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong> in your <code>remarks.md</code> file,
 as to why you think your rule abuse should be allowed, and as to why you think
 your submission should not be rejected for a rule violation.
 <strong>Nevertheless, <em>even if you do</em> explain this in your <code>remarks.md</code> file
-you submission may still be rejected</strong>.
-</p>
-<p class="leftbar">
-If you use the most recently released official IOCCC submission packaging tool
+you submission may still be rejected</strong>.</p>
+<p>If you use the most recently released official IOCCC submission packaging tool
 (hereby referred to as <code>mkiocccentry(1)</code>), which we <strong>STRONGLY recommend you
 do</strong>, then the <code>mkiocccentry(1)</code> tool will warn you if there appears to be a
 violation in certain rules (not all can be detected). The <code>mkiocccentry(1)</code>
-tool also runs <code>chkentry(1)</code> and <code>txzchk(1)</code>, the latter of which runs
+tool also runs <code>chksubmit(1)</code> and <code>txzchk(1)</code>, the latter of which runs
 <code>fnamchk(1)</code>. Overriding problems detected by any of these tools comes with a
-<strong>fair amount of risk</strong> that your submission will be rejected.
-</p>
-<p class="leftbar">
-If you do override a rule violation warning from the <code>mkiocccentry(1)</code> or
+<strong>fair amount of risk</strong> that your submission will be rejected.</p>
+<p>If you do override a rule violation warning from the <code>mkiocccentry(1)</code> or
 another related IOCCC tool, or otherwise plan to abuse the rules, then you
 <strong>MUST CLEARLY EXPLAIN THE RATIONALE</strong> of why you are attempting to abuse the
 rules in your <code>remarks.md</code> file. <strong><em>Even if you do</em> explain this in your
-<code>remarks.md</code> file your submission may still be rejected</strong>.
-</p>
-<p class="leftbar">
-<strong>HINT:</strong> If you do submit such a rule abusing / rule violating
+<code>remarks.md</code> file your submission may still be rejected</strong>.</p>
+<p><strong>HINT:</strong> If you do submit such a rule abusing / rule violating
 submission, then consider also submitting an alternate version in a
 <strong>different submission</strong> server slot that does <strong>NOT</strong> violate the rules
-in case your rule abuse excuse is rejected.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT</strong>: if you do submit such an alternate non-rule abusing version,
+in case your rule abuse excuse is rejected.</p>
+<p><strong>IMPORTANT</strong>: if you do submit such an alternate non-rule abusing version,
 <strong>PLEASE</strong> indicate that in your <code>remarks.md</code> file of your non-rule abusing
 version so that the <a href="../judges.html">IOCCC judges</a> do not think you uploaded a
-duplicate into a wrong slot by mistake.
-</p>
-<p class="leftbar">
-Uploading a tarball not formed by <code>mkiocccentry(1)</code> puts you at a very big risk of
+duplicate into a wrong slot by mistake.</p>
+<p>Uploading a tarball not formed by <code>mkiocccentry(1)</code> puts you at a very big risk of
 violating <a href="rules.html#rule17">Rule 17</a>, especially as <code>mkiocccentry(1)</code> does a
 great number of things that are required, and it also runs many checks, and if
 any of those checks fail, you are at a very great risk of having your submission
-rejected for violating <a href="rules.html#rule17">Rule 17</a>.
-</p>
-<p class="leftbar">
-See also <a href="#rule13">Rule 12</a>.
-</p>
+rejected for violating <a href="rules.html#rule17">Rule 17</a>.</p>
+<p>See also <a href="#rule13">Rule 12</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule0">
 <h2 id="rule-0">Rule 0</h2>
 </div>
-<p class="leftbar">
-Just as C starts at 0, so the IOCCC starts at <a href="#rule0">Rule 0</a>. :-)
-</p>
-<p class="leftbar">
-The “<a href="#dates">Important IOCCC dates</a>” section above is part of this rule.
-</p>
+<p>Just as C starts at 0, so the IOCCC starts at <a href="#rule0">Rule 0</a>. :-)</p>
+<p>The “<a href="#dates">Important IOCCC dates</a>” section above is part of this rule.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule1">
 <h2 id="rule-1">Rule 1</h2>
 </div>
-<p class="leftbar">
-Your submission must be a C program.
-</p>
-<p class="leftbar">
-You see, the contest is not called the <strong>International Obfuscated JSON Contest</strong>
+<p>Your submission must be a C program.</p>
+<p>You see, the contest is not called the <strong>International Obfuscated JSON Contest</strong>
 (<strong>IOJSONC</strong>), even if the <a href="https://github.com/xexyl/jparse/blob/master/json_README.md#so-called-json-spec">so-called JSON
 spec</a> might be called obfuscated
-by some people. :-)
-</p>
+by some people. :-)</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule2">
 <h2 id="rule-2">Rule 2</h2>
 </div>
 <p><a href="#rule2">Rule 2</a> requires that your submission satisfy <strong>BOTH</strong> <a href="#rule2a">Rule
 2a</a> <strong>AND</strong> <a href="#rule2b">Rule 2b</a>.</p>
-<p class="leftbar">
-You may check your code with respect to <a href="#rule2a">Rule 2a</a> and <a href="#rule2b">Rule
+<p>You may check your code with respect to <a href="#rule2a">Rule 2a</a> and <a href="#rule2b">Rule
 2b</a> prior to submitting your code by giving the filename
-as a command like argument to the <code>iocccsize(1)</code> tool. For example:
-</p>
+as a command like argument to the <code>iocccsize(1)</code> tool. For example:</p>
 <pre><code>    iocccsize prog.c</code></pre>
-<p class="leftbar">
-The source to <code>iocccsize(1)</code> may be found in the
-<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.
-</p>
-<p class="leftbar">
-See also the
+<p>The source to <code>iocccsize(1)</code> may be found in the
+<a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>.</p>
+<p>See also the
 FAQ on “<a href="../faq.html#mkiocccentry_test">how to further test your submission</a>”
-for more more thorough testing, including <a href="#rule2">Rule 2</a>.
-</p>
-<p class="leftbar">
-See also <a href="#rule2a">Rule 2a</a>, <a href="#rule2b">Rule 2b</a>, and <a href="#rule17">Rule 17</a>.
-</p>
+for more more thorough testing, including <a href="#rule2">Rule 2</a>.</p>
+<p>See also <a href="#rule2a">Rule 2a</a>, <a href="#rule2b">Rule 2b</a>, and <a href="#rule17">Rule 17</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule2a">
 <h2 id="rule-2a">Rule 2a</h2>
 </div>
 <p class="leftbar">
-The size of your program source <strong>should NOT exceed 4993 bytes</strong>.
+The size of your program source <strong>MUST NOT exceed 4993 bytes</strong>.
 </p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule2b">
 <h2 id="rule-2b">Rule 2b</h2>
 </div>
-<p class="leftbar">
-When the filename of your program source is given as a command line argument to
+<p>When the filename of your program source is given as a command line argument to
 the latest version of the official IOCCC size tool (hereby referred to as
-<code>iocccsize(1)</code>), the value printed <strong>should NOT exceed <em>2503</em></strong>.
-</p>
-<p class="leftbar">
-See also <a href="#rule17">Rule 17</a>.
-</p>
+<code>iocccsize(1)</code>), the value printed <strong>MUST NOT exceed <em>2503</em></strong>.</p>
+<p>See also <a href="#rule17">Rule 17</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule3">
 <h2 id="rule-3">Rule 3</h2>
 </div>
-<p class="leftbar">
-You must <a href="../next/register.html">register</a> in order to submit your entry to the IOCCC.
+<p>You must <a href="../next/register.html">register</a> in order to submit your entry to the IOCCC.
 You may <a href="../next/register.html">register</a> while the contest is either
-<strong><a href="../faq.html#pending">pending</a></strong> or <strong><a href="../faq.html#open">open</a></strong>.
-</p>
-<p class="leftbar">
-When the contest is <strong><a href="../faq.html#open">open</a></strong>, the <a href="https://submit.ioccc.org">submit server</a>
+<strong><a href="../faq.html#pending">pending</a></strong> or <strong><a href="../faq.html#open">open</a></strong>.</p>
+<p>When the contest is <strong><a href="../faq.html#open">open</a></strong>, the <a href="https://submit.ioccc.org">submit server</a>
 will email you your <a href="https://submit.ioccc.org">submit server</a>
 <strong>Username</strong> and <strong>Initial password</strong>. <strong>Please be patient</strong> as it may take some time,
-perhaps as much as a few days, for your registration to be processed and for that email to be sent.
-</p>
-<p class="leftbar">
-Those who <a href="../next/register.html">register</a> while the contest status is <strong><a href="../faq.html#pending">pending</a></strong>
+perhaps as much as a few days, for your registration to be processed and for that email to be sent.</p>
+<p>Those who <a href="../next/register.html">register</a> while the contest status is <strong><a href="../faq.html#pending">pending</a></strong>
 will receive their email (containing their <a href="https://submit.ioccc.org">submit server</a> <strong>Username</strong>
 and <strong>Initial password</strong>), later: usually a few days around the time when the contest status
-becomes <strong><a href="../faq.html#open">open</a></strong>.
-</p>
-<p class="leftbar">
-Once that email with your <strong>Username</strong> and <strong>Initial password</strong> is sent, you
-will have fortnight (<strong>14 days</strong>) to <a href="../next/pw-change.html">change your submit server initial password</a>.
-</p>
-<p class="leftbar">
-If you do not change your <strong>Initial password</strong> in time, you will have to
+becomes <strong><a href="../faq.html#open">open</a></strong>.</p>
+<p>Once that email with your <strong>Username</strong> and <strong>Initial password</strong> is sent, you
+will have fortnight (<strong>14 days</strong>) to <a href="../next/pw-change.html">change your submit server initial password</a>.</p>
+<p>If you do not change your <strong>Initial password</strong> in time, you will have to
 <a href="../contact.md#if-you-really-need-to-send-email-the-ioccc-judges">send email to the IOCCC judges</a>
-to ask for your password to be reset.
-</p>
-<p class="leftbar">
-Because it takes time (maybe even a few days) to process your registration
+to ask for your password to be reset.</p>
+<p>Because it takes time (maybe even a few days) to process your registration
 and for the server to email you your initial login and password, you
 should <strong>MAKE SURE</strong> you give yourself enough time to register well
 before the contest closes. In other words, <strong>DO NOT WAIT UNTIL THE FINAL DAYS</strong>
 of the contest to register! The <a href="../judges.html">IOCCC judges</a>
 are <strong>NOT</strong> responsible for delayed or lost email, or for those who wait
-until the last minute to try to register!
-</p>
-<p class="leftbar">
-See the
+until the last minute to try to register!</p>
+<p>See the
 FAQ on “<a href="../quick-start.html#enter">how to register and submit to the IOCCC</a>”
 for instructions on registering and participating in the IOCCC, as the process
-may change from contest to contest.
-</p>
-<p class="leftbar">
-See also <a href="#rule8">Rule 8</a>.
-</p>
+may change from contest to contest.</p>
+<p>See also <a href="#rule8">Rule 8</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule4">
 <h2 id="rule-4">Rule 4</h2>
 </div>
-<p class="leftbar">
-If your submission is selected as a winning entry, then your submission may be modified in order
-to fit into the structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.
-</p>
-<p class="leftbar">
-For example, your submission’s <code>Makefile</code> will be modified and your <code>remarks.md</code>
-will become a <code>README.md</code> which will be used to generate an <code>index.html</code> file.
-</p>
-<p class="leftbar">
-Your source code will be the file <code>prog.c</code>. The compiled binary
+<p>If your submission is selected as a winning entry, then your submission may be modified in order
+to fit into the structure of the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a>.</p>
+<p>For example, your submission’s <code>Makefile</code> will be modified and your <code>remarks.md</code>
+will become a <code>README.md</code> which will be used to generate an <code>index.html</code> file.</p>
+<p>Your source code will be the file <code>prog.c</code>. The compiled binary
 will be called <code>prog</code>. If you submission requires different filenames,
 then modify your submission’s <code>Makefile</code> to <strong>COPY</strong> (<strong>NOT</strong> move!) the files
-accordingly.
-</p>
-<p class="leftbar">
-Of course your program may also do this, as long as it works, but you’re welcome
-to use your <code>Makefile</code> as well.
-</p>
-<p class="leftbar">
-See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.
-</p>
+accordingly.</p>
+<p>Of course your program may also do this, as long as it works, but you’re welcome
+to use your <code>Makefile</code> as well.</p>
+<p>See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule5">
 <h2 id="rule-5">Rule 5</h2>
@@ -758,64 +694,45 @@ part of your original submission including, but not limited to <code>prog.c</cod
 <code>Makefile</code> or any data files you submit.</p>
 <p>If you submission needs (or wishes :-) ) to modify such content, it <strong>MUST</strong>
 first copy the file to a new filename and then modify that copy.</p>
-<p class="leftbar">
-You may use your submission (program) to form a copy, or you can make use of
-your <code>Makefile</code> to form that copy.
-</p>
-<p class="leftbar">
-If you do make a copy of a submission file, <strong>PLEASE</strong> be sure that
+<p>You may use your submission (program) to form a copy, or you can make use of
+your <code>Makefile</code> to form that copy.</p>
+<p>If you do make a copy of a submission file, <strong>PLEASE</strong> be sure that
 the <code>clobber</code> rule of your <code>Makefile</code> removes that copy in order to
-restore your submission to its original submission state.
-</p>
+restore your submission to its original submission state.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule6">
 <h2 id="rule-6">Rule 6</h2>
 </div>
-<p class="leftbar">
-I am not a rule, I am a <code>free(void *human);</code> ‼️
-</p>
-<p class="leftbar">
-        <code>while (!(ioccc(rule(you(are(number(6)))))) {</code><br>
+<p>I am not a rule, I am a <code>free(void *human);</code> ‼️</p>
+<p>        <code>while (!(ioccc(rule(you(are(number(6)))))) {</code><br>
                 <code>ha_ha_ha();</code><br>
-        <code>}</code>
-</p>
+        <code>}</code></p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule7">
 <h2 id="rule-7">Rule 7</h2>
 </div>
-<p class="leftbar">
-The obfuscated C program must be your own original work.
-</p>
-<p class="leftbar">
-You (the author(s)) <strong>MUST</strong> own the contents of your submission <strong>OR</strong>
-you <strong>MUST</strong> have permission from the owner(s) to submit their content.
-</p>
-<p class="leftbar">
-If you submit any content that is owned by others, you <strong>MUST
+<p>The obfuscated C program must be your own original work.</p>
+<p>You (the author(s)) <strong>MUST</strong> own the contents of your submission <strong>OR</strong>
+you <strong>MUST</strong> have permission from the owner(s) to submit their content.</p>
+<p>If you submit any content that is owned by others, you <strong>MUST
 detail that ownership</strong> (i.e., who owns what) <strong><em>AND</em> document the
-permission you obtained from them</strong>, in your <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-Please note that the tools in <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
+permission you obtained from them</strong>, in your <code>remarks.md</code> file.</p>
+<p>Please note that the tools in <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry
 repo</a> are <strong>NOT</strong> original works,
-unless of course you’re the original authors, in which case they are original. :-)
-</p>
-<p class="leftbar">
-Nevertheless tools such as those listed are <strong>NOT</strong> obfuscated. If submitted, they
-would probably violate a number of rules. :-)
-</p>
+unless of course you’re the original authors, in which case they are original. :-)</p>
+<p>Nevertheless tools such as those listed are <strong>NOT</strong> obfuscated. If submitted, they
+would probably violate a number of rules. :-)</p>
 <ul>
 <li><a href="https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c">mkiocccentry(1)</a></li>
 <li><a href="https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c">iocccsize(1)</a></li>
-<li><a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c">chkentry(1)</a></li>
+<li><a href="https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c">chksubmit(1)</a></li>
 <li><a href="https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c">txzchk(1)</a></li>
 <li><a href="https://github.com/ioccc-src/mkiocccentry/blob/master/soup/location_main.c">location(1)</a></li>
 <li><a href="https://github.com/xexyl/jparse">jparse repo as cloned by the mkiocccentry repo</a></li>
 <li><a href="https://github.com/lcn2/dbg">dbg repo as cloned by the mkiocccentry repo</a></li>
 <li><a href="https://github.com/lcn2/dyn_array">dyn_array repo as cloned by the mkiocccentry repo</a></li>
 </ul>
-<p class="leftbar">
-The IOCCC has a rich history of remarkable winning entries created by
+<p>The IOCCC has a rich history of remarkable winning entries created by
 authors who skillfully employed various techniques to develop their code.
 While it is <strong>NOT</strong> required, you are <em>allowed</em> to use tools to develop
 and test your submission. These tools may include, but are not limited
@@ -823,77 +740,50 @@ to code generators, code analysis tools, static code analysis tools,
 runtime analysis tools, machine learning tools, natural language models,
 code copilot tools, so-called AI services, large language models (LLMs), etc.
 If you do make use of such tools or services, then we <strong>ENCOURAGE you to describe
-what tools and how you used those tools</strong>, in your <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.
-</p>
+what tools and how you used those tools</strong>, in your <code>remarks.md</code> file.</p>
+<p>See also <a href="#rule5">Rule 5</a>, <a href="#rule18">Rule 18</a> and <a href="#rule21">Rule 21</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule8">
 <h2 id="rule-8">Rule 8</h2>
 </div>
-<p class="leftbar">
-Submissions may only be uploaded to the <a href="https://submit.ioccc.org">IOCCC submit server</a>
-while the contest is <strong><a href="../faq.html#open">open</a></strong>.
-</p>
-<p class="leftbar">
-If you have <a href="../next/register.html">registered</a> and received by email your <a href="https://submit.ioccc.org">submit
+<p>Submissions may only be uploaded to the <a href="https://submit.ioccc.org">IOCCC submit server</a>
+while the contest is <strong><a href="../faq.html#open">open</a></strong>.</p>
+<p>If you have <a href="../next/register.html">registered</a> and received by email your <a href="https://submit.ioccc.org">submit
 server</a> <strong>Username</strong> and <strong>Initial password</strong> you may
 upload your submission to the <a href="https://submit.ioccc.org">submit server</a> but
-<strong>ONLY</strong> while the contest is <strong><a href="../faq.html#open">open</a></strong>.
-</p>
-<p class="leftbar">
-The <a href="https://submit.ioccc.org">submit server</a>, in accordance with <a href="rules.html#rule17">Rule
+<strong>ONLY</strong> while the contest is <strong><a href="../faq.html#open">open</a></strong>.</p>
+<p>The <a href="https://submit.ioccc.org">submit server</a>, in accordance with <a href="rules.html#rule17">Rule
 17</a>, places a limit of <strong>3999971</strong> bytes on the size of your
-upload.
-</p>
-<p class="leftbar">
-Once the contest is in the <strong><a href="../faq.html#judging">judging</a></strong> state (or
-<strong><a href="../faq.html#closed">closed</a></strong> state), you may <strong>NOT</strong> upload submissions.
-</p>
-<p class="leftbar">
-While the contest is <strong><a href="../faq.html#open">open</a></strong> or in the
+upload.</p>
+<p>Once the contest is in the <strong><a href="../faq.html#judging">judging</a></strong> state (or
+<strong><a href="../faq.html#closed">closed</a></strong> state), you may <strong>NOT</strong> upload submissions.</p>
+<p>While the contest is <strong><a href="../faq.html#open">open</a></strong> or in the
 <strong><a href="../faq.html#judging">judging</a></strong> state, the <a href="../judges.html">IOCCC judges</a>
 <strong>MAY</strong> (but are not required to) modify the slot comment of your submission to
 indicate that they have received it. If uploaded submission is malformed, the
 <a href="../judges.html">IOCCC judges</a> <strong>MAY</strong> (but are not required to) modify the slot
-comment accordingly.
-</p>
-<p class="leftbar">
-You are <strong>STRONGLY</strong> advised to use the <code>mkiocccentry(1)</code> tool
+comment accordingly.</p>
+<p>You are <strong>STRONGLY</strong> advised to use the <code>mkiocccentry(1)</code> tool
 as found in the <a href="https://github.com/ioccc-src/mkiocccentry">mkiocccentry repo</a>
-to form the file to upload to the <a href="https://submit.ioccc.org">submit server</a>.
-</p>
-<p class="leftbar">
-The <a href="https://submit.ioccc.org">submit server</a> will become active when the
+to form the file to upload to the <a href="https://submit.ioccc.org">submit server</a>.</p>
+<p>The <a href="https://submit.ioccc.org">submit server</a> will become active when the
 contest is <strong><a href="../faq.html#open">open</a></strong>. Until the contest status becomes
 <strong><a href="../faq.html#open">open</a></strong>, the <a href="https://submit.ioccc.org">submit server</a> may
-be offline and/or unresponsive.
-</p>
-<p class="leftbar">
-See the
+be offline and/or unresponsive.</p>
+<p>See the
 FAQs on “<a href="../faq.html#mkiocccentry">obtaining, compiling, installing and using the latest release of the mkiocccentry tools</a>”
-for more information about the <code>mkiocccentry(1)</code> tool.
-</p>
-<p class="leftbar">
-See the “<a href="#dates">Important IOCCC dates</a>” section above for when these contest states are scheduled.
-</p>
-<p class="leftbar">
-See also <a href="#rule3">Rule 3</a> and <a href="#rule17">Rule 17</a>.
-</p>
+for more information about the <code>mkiocccentry(1)</code> tool.</p>
+<p>See the “<a href="#dates">Important IOCCC dates</a>” section above for when these contest states are scheduled.</p>
+<p>See also <a href="#rule3">Rule 3</a> and <a href="#rule17">Rule 17</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule9">
 <h2 id="rule-9">Rule 9</h2>
 </div>
-<p class="leftbar">
-Each <strong>PERSON</strong> may register <strong>ONLY ONE</strong> account and each account may submit up to
-and including <strong>10.000000</strong> (ten in base 10) submissions <strong>PER</strong> contest.
-</p>
+<p>Each <strong>PERSON</strong> may register <strong>ONLY ONE</strong> account and each account may submit up to
+and including <strong>10.000000</strong> (ten in base 10) submissions <strong>PER</strong> contest.</p>
 <p><strong>Each submission <em>must be submitted separately</em></strong>.</p>
-<p class="leftbar">
-If this seems unreasonable we suggest you wait until the next contest and in
-the interim ponder this (modified or not) quote said by Bill Gates:
-</p>
+<p>If this seems unreasonable we suggest you wait until the next contest and in
+the interim ponder this (modified or not) quote said by Bill Gates:</p>
 <blockquote>
 <p>640K submissions ought to be enough for anybody.</p>
 <p>– Bill Gates s/640K/10/ (allegedly :-) )</p>
@@ -914,14 +804,10 @@ DISCOURAGED</strong>. We do not guarantee these functions will behave as
 you expect on our test platforms. If your program needs special
 permissions you <strong>MUST</strong> document this fact, and explain why
 it is needed in your submission’s <code>remarks.md</code> file.</p>
-<p class="leftbar">
-Furthermore, if you need a supplementary program that you include, to have these
+<p>Furthermore, if you need a supplementary program that you include, to have these
 permissions, you will also have to explain this, because these bits are not
-allowed in submissions and those bits will not be copied by <code>mkiocccentry(1)</code>.
-</p>
-<p class="leftbar">
-See also <a href="#rule17">Rule 17</a>.
-</p>
+allowed in submissions and those bits will not be copied by <code>mkiocccentry(1)</code>.</p>
+<p>See also <a href="#rule17">Rule 17</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule12">
 <h2 id="rule-12">Rule 12</h2>
@@ -930,163 +816,118 @@ See also <a href="#rule17">Rule 17</a>.
 the opinion of the <a href="../judges.html">judges</a>, violates the rules WILL BE DISQUALIFIED</strong>.
 Submissions that attempt to abuse the rules <strong>MUST</strong> try to justify why
 their rule abuse is legal, in the <code>remarks.md</code> file.</p>
-<p class="leftbar">
-See also <a href="#rule_abuse">the warning about rule abuse</a>.
-</p>
+<p>See also <a href="#rule_abuse">the warning about rule abuse</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule13">
 <h2 id="rule-13">Rule 13</h2>
 </div>
-<p class="leftbar">
-7 out of 13 UTF-8 characters in C code agree that this rule number is lucky
-enough to be a prime number.
-</p>
-<p class="leftbar">
-Fun fact: the fear of the number 13 is called <em>triskaidekaphobia</em>.
-</p>
+<p>7 out of 13 UTF-8 characters in C code agree that this rule number is lucky
+enough to be a prime number.</p>
+<p>Fun fact: the fear of the number 13 is called <em>triskaidekaphobia</em>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule14">
 <h2 id="rule-14">Rule 14</h2>
 </div>
-<p class="leftbar">
-Any C source that fails to compile because of lines with trailing
-control-M’s (i.e., lines with a trailing byte <code>015</code>) <strong>might</strong> be rejected.
-</p>
-<p class="leftbar">
-Please do <strong>NOT</strong> put trailing control-M’s on <code>prog.c</code>, <code>Makefile</code>, or
+<p>Any C source that fails to compile because of lines with trailing
+control-M’s (i.e., lines with a trailing byte <code>015</code>) <strong>might</strong> be rejected.</p>
+<p>Please do <strong>NOT</strong> put trailing control-M’s on <code>prog.c</code>, <code>Makefile</code>, or
 <code>remarks.md</code> files but instead end lines with a trailing newline (i.e.,
-byte <code>012</code>) character.
-</p>
-<p class="leftbar">
-As we do <strong>NOT</strong> use DOS, please also be sure that the <code>Makefile</code> and
-<code>remarks.md</code> files end in final newline (i.e., byte <code>012</code>) character.
-</p>
-<p class="leftbar">
-You are permitted, in order to try and squeeze your <code>prog.c</code> under
+byte <code>012</code>) character.</p>
+<p>As we do <strong>NOT</strong> use DOS, please also be sure that the <code>Makefile</code> and
+<code>remarks.md</code> files end in final newline (i.e., byte <code>012</code>) character.</p>
+<p>You are permitted, in order to try and squeeze your <code>prog.c</code> under
 a <a href="#rule2a">Rule 2a</a> and/or <a href="#rule2b">Rule 2b</a> limit, to <strong>NOT</strong>
 end your <code>prog.c</code> with a newline (i.e., byte <code>012</code>) character.
 If you need to do this, <strong>PLEASE</strong> document that in your <code>remarks.md</code> file and
 if your compiler complains about this, document this too and update your
-<code>Makefile</code> to account for this.
-</p>
+<code>Makefile</code> to account for this.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule15">
 <h2 id="rule-15">Rule 15</h2>
 </div>
-<p class="leftbar">
-In order to register for the IOCCC, you <strong>MUST</strong> have a valid email address.
-</p>
-<p class="leftbar">
-The <a href="../judges.html">judges</a> <strong>are NOT responsible for delays in email</strong>, so please plan
-enough time accordingly.
-</p>
-<p class="leftbar">
-See the
+<p>In order to register for the IOCCC, you <strong>MUST</strong> have a valid email address.</p>
+<p>The <a href="../judges.html">judges</a> <strong>are NOT responsible for delays in email</strong>, so please plan
+enough time accordingly.</p>
+<p>See the
 FAQ on “<a href="../quick-start.html#register">how to register</a>”
-for details.
-</p>
+for details.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule16">
 <h2 id="rule-16">Rule 16</h2>
 </div>
 <p>Submissions that are similar to previous winning IOCCC entries are discouraged.</p>
-<p class="leftbar">
-You are allowed to resubmit to a later contest, a submission that
+<p>You are allowed to resubmit to a later contest, a submission that
 did not win the IOCCC. If you do so, then you would be well advised
 to try and enhance and improve your submission.
 If you do resubmit something that did not previously win, then
 you are <strong>encouraged</strong> to mention this in your <code>remarks.md</code> file
-as this <strong>sometimes</strong> helps.
-</p>
-<p class="leftbar">
-Resubmitting an improved submission that did not become an
+as this <strong>sometimes</strong> helps.</p>
+<p>Resubmitting an improved submission that did not become an
 IOCCC winning entry is a <strong>time honored</strong> tradition of the IOCCC.
 There are some IOCCC winning entries that were submitted to multiple contests
 before they were improved enough to “climb over” (as the expression
-goes) all the other submissions for a given contest.
-</p>
+goes) all the other submissions for a given contest.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule17">
 <h2 id="rule-17">Rule 17</h2>
 </div>
-<p class="leftbar">
-Your submission must be in the form of a <strong>xz compressed tarball</strong> that
+<p>Your submission must be in the form of a <strong>xz compressed tarball</strong> that
 the <strong>current released version</strong> of the <code>mkiocccentry(1)</code> tool would generate.
 The files, directories, and paths <strong>MUST</strong> conform to the limits imposed
 by <code>mkiocccentry(1)</code> including but <strong>NOT LIMITED</strong> to their names, count,
-path length, directory tree depth and permissions.
-</p>
-<p class="leftbar">
-Your <strong>xz compressed tarball</strong> must be larger than <strong>0</strong> bytes and no larger
-than <strong>3999971</strong> bytes.
-</p>
-<p class="leftbar">
-The sum of the byte lengths of all files, after the <strong>xz compressed tarball</strong> is untarred,
-must <strong>NOT</strong> exceed <code>27651*1024</code> bytes.
-</p>
-<p class="leftbar">
-Your <strong>xz compressed tarball</strong> submission <em>file</em> <strong>MUST</strong> pass the tests performed by
-the current version of <code>txzchk(1)</code>.
-</p>
-<p class="leftbar">
-Your <strong>xz compressed tarball</strong> submission <em>filename</em> <strong>MUST</strong> pass the tests
-performed by the current version of <code>fnamchk(1)</code>.
-</p>
-<p class="leftbar">
-When your <strong>xz compressed tarball</strong> submission file is untarred, the
+path length, directory tree depth and permissions.</p>
+<p>Your <strong>xz compressed tarball</strong> must be larger than <strong>0</strong> bytes and no larger
+than <strong>3999971</strong> bytes.</p>
+<p>The sum of the byte lengths of all files, after the <strong>xz compressed tarball</strong> is untarred,
+must <strong>NOT</strong> exceed <code>27651*1024</code> bytes.</p>
+<p>Your <strong>xz compressed tarball</strong> submission <em>file</em> <strong>MUST</strong> pass the tests performed by
+the current version of <code>txzchk(1)</code>.</p>
+<p>Your <strong>xz compressed tarball</strong> submission <em>filename</em> <strong>MUST</strong> pass the tests
+performed by the current version of <code>fnamchk(1)</code>.</p>
+<p>When your <strong>xz compressed tarball</strong> submission file is untarred, the
 resulting <em>directory</em> <strong>MUST</strong> pass the checks performed by the current version
-of <code>chkentry(1)</code>.
-</p>
-<p class="leftbar">
-The resulting <code>prog.c</code> file <strong>MUST</strong> pass the <a href="#rule2">Rule 2</a> size checks performed by the current
-version of <code>iocccsize(1)</code>.
-</p>
-<p class="leftbar">
-The <code>.auth.json</code> and <code>.info.json</code> <strong>MUST</strong> be compatible with what the
+of <code>chksubmit(1)</code>.</p>
+<p>The resulting <code>prog.c</code> file <strong>MUST</strong> pass the <a href="#rule2">Rule 2</a> size checks performed by the current
+version of <code>iocccsize(1)</code>.</p>
+<p>The <code>.auth.json</code> and <code>.info.json</code> <strong>MUST</strong> be compatible with what the
 current version of the <code>mkiocccentry(1)</code> tool would produce. They <strong>MUST
-ALSO</strong> pass the tests performed by the current version of <code>chkentry(1)</code>.
-</p>
-<p class="leftbar">
-The required <code>Makefile</code> must <strong>NOT</strong> be empty.
-</p>
-<p class="leftbar">
-The required <code>remarks.md</code> must <strong>NOT</strong> be empty.
-</p>
-<p class="leftbar">
-You may <strong>NOT</strong> submit a tarball created by the <code>-d</code> or <code>-s seed</code> option of
-<code>mkiocccentry(1)</code>.
-</p>
+ALSO</strong> pass the tests performed by the current version of <code>chksubmit(1)</code>.</p>
+<p>The required <code>Makefile</code> must <strong>NOT</strong> be empty.</p>
+<p>The required <code>remarks.md</code> must <strong>NOT</strong> be empty.</p>
+<p>You may <strong>NOT</strong> submit a tarball created by the <code>-d</code> or <code>-s seed</code> option of
+<code>mkiocccentry(1)</code>.</p>
 <p class="leftbar">
 The maximum number of files your submission tarball may contain, not counting
-the optional files (<code>prog.alt.c</code>, <code>try.sh</code>, <code>try.alt.sh</code>) and the mandatory
-files (<code>prog.c</code>, <code>Makefile</code>, <code>remarks.md</code>) is 31.
+the free files (<code>prog.c</code>, <code>remarks.md</code>, <code>Makefile</code>, <code>prog.alt.c</code>, <code>try.sh</code>,
+<code>try.alt.sh</code> and the two files generated by <code>mkiocccentry</code>, <code>.info.json</code> and
+<code>.auth.json</code>) is 31.
+</p>
+<p class="leftbar">
+The maximum number of directories your submission may have is 13 and the maximum
+depth a path may have is 4.
+</p>
+<p class="leftbar">
+The maximum filename length (a component of a path) is 38 which means the
+maximum length total of a path is 60 characters.
 </p>
 <p>See the
 FAQ on “<a href="../faq.html#extra-files">what extra files are and how to include more</a>”
 as well as the <a href="guidelines.html#extra-files">guidelines on extra files</a>
 for more details.</p>
 <h3 id="tldr-rule-17---use-mkiocccentry1-to-form-your-submission">TL;DR Rule 17 - Use <code>mkiocccentry(1)</code> to form your submission</h3>
-<p class="leftbar">
-Let the current version of the <code>mkiocccentry(1)</code> tool form your <strong>xz
-compressed tarball</strong> submission file.
-</p>
+<p>Let the current version of the <code>mkiocccentry(1)</code> tool form your <strong>xz
+compressed tarball</strong> submission file.</p>
 <h3 id="warning">Warning</h3>
-<p class="leftbar">
-Using command line flags or input prompts to override checks and
+<p>Using command line flags or input prompts to override checks and
 limits made by the above mentioned tools is <strong>NOT</strong> recommended
 and may result in your submission being rejected by the <a href="https://submit.ioccc.org">IOCCC
-submit server</a> and/or the <a href="../judges.html">IOCCC Judges</a>.
-</p>
-<p class="leftbar">
-See the
+submit server</a> and/or the <a href="../judges.html">IOCCC Judges</a>.</p>
+<p>See the
 FAQ on the “<a href="../faq.html#mkiocccentry">mkiocccentry toolkit</a>
-for how to obtain and use the above mentioned tools.
-</p>
-<p class="leftbar">
-<strong>IMPORTANT</strong>: See the
+for how to obtain and use the above mentioned tools.</p>
+<p><strong>IMPORTANT</strong>: See the
 FAQ on “<a href="../faq.html#rule17">Rule 17</a>”
-for very important details behind this rule.
-</p>
+for very important details behind this rule.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule18">
 <h2 id="rule-18">Rule 18</h2>
@@ -1095,53 +936,37 @@ for very important details behind this rule.
 <blockquote>
 <p><strong><a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International</a></strong></p>
 </blockquote>
-<p class="leftbar">
-See also <a href="#rule7">Rule 7</a>.
-</p>
+<p>See also <a href="#rule7">Rule 7</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule19">
 <h2 id="rule-19">Rule 19</h2>
 </div>
-<p class="leftbar">
-The <code>remarks.md</code> file, a required non-empty file, must be written in
-<a href="https://www.markdownguide.org/basic-syntax/">Markdown format</a>.
-</p>
-<p class="leftbar">
-We currently use <a href="https://pandoc.org">pandoc(1)</a> to automatically
+<p>The <code>remarks.md</code> file, a required non-empty file, must be written in
+<a href="https://www.markdownguide.org/basic-syntax/">Markdown format</a>.</p>
+<p>We currently use <a href="https://pandoc.org">pandoc(1)</a> to automatically
 convert markdown to HTML. Please try to avoid submitting an HTML file
 translation to any markdown file. If you <strong>MUST</strong> submit such an HTML
-translation, <strong>PLEASE</strong> mention this in your <code>remarks.md</code> file.
-</p>
-<p class="leftbar">
-For any submission that wins the contest, we modify your <code>remarks.md</code> file and
+translation, <strong>PLEASE</strong> mention this in your <code>remarks.md</code> file.</p>
+<p>For any submission that wins the contest, we modify your <code>remarks.md</code> file and
 rename it as <code>README.md</code> and then use <a href="https://pandoc.org">pandoc(1)</a>
 to generate the <code>index.html</code> file in the top level directory of your submission.
 For this reason, <code>mkiocccentry(1)</code> will <strong>NOT</strong> package such files (in the top
-level submission directory) and both <code>txzchk(1)</code> and <code>chkentry(1)</code> will flag
+level submission directory) and both <code>txzchk(1)</code> and <code>chksubmit(1)</code> will flag
 them as errors (in the top level submission directory) as well, so please do
 <strong>NOT</strong> try and slip these files in the top level directory where your
-<code>remarks.md</code> resides.
-</p>
-<p class="leftbar">
-See the <a href="https://www.markdownguide.org/cheat-sheet/">Markdown Cheat Sheet</a>
-for a handy quick reference to the Markdown syntax.
-</p>
-<p class="leftbar">
-See the <a href="https://www.markdownguide.org">Markdown guide</a>
+<code>remarks.md</code> resides.</p>
+<p>See the <a href="https://www.markdownguide.org/cheat-sheet/">Markdown Cheat Sheet</a>
+for a handy quick reference to the Markdown syntax.</p>
+<p>See the <a href="https://www.markdownguide.org">Markdown guide</a>
 for free and open-source reference guide that explains
-how to use markdown.
-</p>
-<p class="leftbar">
-See also the <a href="http://daringfireball.net/projects/markdown/basics">Daring Fireball Markdown:
+how to use markdown.</p>
+<p>See also the <a href="http://daringfireball.net/projects/markdown/basics">Daring Fireball Markdown:
 Basics</a> for
-information on the markdown format.
-</p>
-<p class="leftbar">
-<strong>PLEASE</strong> see our
+information on the markdown format.</p>
+<p><strong>PLEASE</strong> see our
 FAQ on “<a href="../faq.html#remarks_md">remarks.md</a>”
 <strong>AND</strong> the
-<a href="../markdown.html">IOCCC markdown guidelines</a> for additional markdown guidance.
-</p>
+<a href="../markdown.html">IOCCC markdown guidelines</a> for additional markdown guidance.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule20">
 <h2 id="rule-20">Rule 20</h2>
@@ -1149,54 +974,40 @@ FAQ on “<a href="../faq.html#remarks_md">remarks.md</a>”
 <p>The how to build instructions must be in GNU Makefile format. See the
 FAQ about “<a href="../faq.html#make_compatibility">make(1) compatibility the IOCCC supports</a>
 for more details.</p>
-<p class="leftbar">
-You are <strong>ENCOURAGED</strong> to use the
+<p>You are <strong>ENCOURAGED</strong> to use the
 Makefile example, renamed as <code>Makefile</code> of course, for help in constructing your
 <code>Makefile</code>. See the <a href="guidelines.html#makefile">Makefile section</a> in the
-guidelines for more details.
-</p>
+guidelines for more details.</p>
 <p>The target of the <code>Makefile</code> must be called <code>prog</code>. The original
 C source file must be called <code>prog.c</code>.</p>
 <p>To invoke the C compiler, use <code>${CC}</code>. To invoke the C preprocessor use
 <code>${CPP}</code>.</p>
 <p>Do <strong>NOT</strong> assume that <code>.</code> (the current directory) is in the <code>$PATH</code>.</p>
-<p class="leftbar">
-When <code>make clobber</code> is invoked, we request that your submission directory be restored
+<p>When <code>make clobber</code> is invoked, we request that your submission directory be restored
 to its original submission state. For example, any temporary files
 created during the build process, or during execution should be
-removed by the <code>clobber</code> rule.
-</p>
-<p class="leftbar">
-Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with <code>bash(1)</code>
+removed by the <code>clobber</code> rule.</p>
+<p>Your <code>Makefile</code> <strong>MUST</strong> use a syntax that is compatible with <code>bash(1)</code>
 <strong>AND</strong> GNU <code>make(1)</code>. You are <strong>ENCOURAGED</strong> to use <code>SHELL= bash</code> in
-your <code>Makefile</code>. Please add a space between the <code>=</code> and the value.
-</p>
-<p class="leftbar">
-Assume that commands commonly found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
+your <code>Makefile</code>. Please add a space between the <code>=</code> and the value.</p>
+<p>Assume that commands commonly found in <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a>
 environments and systems that conform to the <a href="https://en.wikipedia.org/wiki/Single_UNIX_Specification">Single UNIX
 Specification</a> are
-available in the <code>$PATH</code> search path.
-</p>
+available in the <code>$PATH</code> search path.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule21">
 <h2 id="rule-21">Rule 21</h2>
 </div>
-<p class="leftbar">
-Your submission <strong>MUST NOT</strong> create or modify files <strong>ABOVE</strong> the current directory
+<p>Your submission <strong>MUST NOT</strong> create or modify files <strong>ABOVE</strong> the current directory
 <em>with the exception of</em> the <code>/tmp</code> and the <code>/var/tmp</code> directories. Your submission
 <strong>MAY</strong> create subdirectories <strong>below</strong> the submission directory, or in <code>/tmp</code>,
 or in <code>/var/tmp</code> provided that <code>.</code> is <strong>NOT</strong> the first byte in any
-directory name or filename you create.
-</p>
-<p class="leftbar">
-If you do create files and directories, <strong>PLEASE</strong> be sure that
+directory name or filename you create.</p>
+<p>If you do create files and directories, <strong>PLEASE</strong> be sure that
 the <code>clobber</code> rule of your <code>Makefile</code> removes such created files
-in order to restore your submission to its original submission state.
-</p>
-<p class="leftbar">
-See also <a href="#rule5">Rule 5</a>.
-</p>
+in order to restore your submission to its original submission state.</p>
+<p>See also <a href="#rule5">Rule 5</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule22">
 <h2 id="rule-22">Rule 22</h2>
@@ -1210,11 +1021,9 @@ identify the authors of your code. The <a href="../judges.html">judges</a> <stro
 within your code, data, remarks or program output (unless you are
 <strong>Peter Honeyman</strong> or pretending to be <strong>Peter Honeyman</strong>) will be grounds
 for disqualification of your submission.</p>
-<p class="leftbar">
-And don’t assume that we won’t be able to determine your name even if it’s not
+<p>And don’t assume that we won’t be able to determine your name even if it’s not
 obvious, because you stand a significant chance of violating this rule if you
-do.
-</p>
+do.</p>
 <p>Yes, Virginia, <strong>WE REALLY MEAN IT!</strong></p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule23">
@@ -1250,60 +1059,42 @@ The <a href="rules.html">IOCCC rule set</a> needs more than <code>5^2</code> rul
 <div id="rule27">
 <h2 id="rule-27">Rule 27</h2>
 </div>
-<p class="leftbar">
-Unless otherwise needed, <a href="#rule27">Rule 27</a> is reserved for something cubic. :-)
-</p>
+<p>Unless otherwise needed, <a href="#rule27">Rule 27</a> is reserved for something cubic. :-)</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="rule28">
 <h2 id="rule-28">Rule 28</h2>
 </div>
-<p class="leftbar">
-<a href="#rule28">Rule 28</a> is a perfect way to end the list of <a href="rules.html">IOCCC rules</a>
-as we do <strong>NOT</strong> plan to have <strong>496</strong> rules. :-)
-</p>
+<p><a href="#rule28">Rule 28</a> is a perfect way to end the list of <a href="rules.html">IOCCC rules</a>
+as we do <strong>NOT</strong> plan to have <strong>496</strong> rules. :-)</p>
 <p>Jump to: <a href="#">top</a></p>
 <div id="more-information">
 <div id="information">
 <h1 id="for-more-information">FOR MORE INFORMATION:</h1>
 </div>
 </div>
-<p class="leftbar">
-For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.
-</p>
-<p class="leftbar">
-<strong>Be SURE</strong> to review the <a href="index.html">IOCCC Rules and Guidelines</a> as they
-may (and <strong>often do</strong>) change from year to year.
-</p>
-<p class="leftbar">
-<strong>PLEASE</strong> be <strong>SURE</strong> you have the <strong>current</strong> <a href="rules.html">IOCCC rules</a> and
-<a href="guidelines.html">IOCCC guidelines</a> prior to submitting to the contest.
-</p>
+<p>For questions or comments about the contest, see <a href="../contact.html">Contacting the IOCCC</a>.</p>
+<p><strong>Be SURE</strong> to review the <a href="index.html">IOCCC Rules and Guidelines</a> as they
+may (and <strong>often do</strong>) change from year to year.</p>
+<p><strong>PLEASE</strong> be <strong>SURE</strong> you have the <strong>current</strong> <a href="rules.html">IOCCC rules</a> and
+<a href="guidelines.html">IOCCC guidelines</a> prior to submitting to the contest.</p>
 <p>See the <a href="../news.html">Official IOCCC website news</a> for additional information.</p>
-<p class="leftbar">
-For the updates and breaking IOCCC news, you are encouraged to follow
+<p>For the updates and breaking IOCCC news, you are encouraged to follow
 the <a href="https://fosstodon.org/@ioccc">IOCCC on Mastodon</a> account. See our
 FAQ on “<a href="../faq.html#try_mastodon">Mastodon</a>”
 for more information. Please do note that unless
 you are mentioned by us you will <strong>NOT</strong> get a notification from the app <em>so you
-should refresh the page <strong>even if you do follow us</strong></em>.
-</p>
-<p class="leftbar">
-Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.
-</p>
-<p class="leftbar">
-Consider joining the IOCCC discord community via this link:
-<a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a>
-</p>
-<p class="leftbar">
-See the
+should refresh the page <strong>even if you do follow us</strong></em>.</p>
+<p>Check out the <a href="https://www.ioccc.org/index.html">Official IOCCC winner website</a> in general.</p>
+<p>Consider joining the IOCCC discord community via this link:
+<a href="https://discord.gg/Wa42Qujwnw">https://discord.gg/Wa42Qujwnw</a></p>
+<p>See the
 FAQ on “<a href="../faq.html#mkiocccentry">obtaining, compiling, installing and using the mkiocccentry tools</a>”
 and the
 FAQ on “<a href="../quick-start.html#enter">how to enter the IOCCC</a>”
 as that FAQ has important details on
 <a href="../next/register.html">how to register</a>
 as well as
-<a href="../next/submit.html">how to upload your submission</a> for the IOCCC.
-</p>
+<a href="../next/submit.html">how to upload your submission</a> for the IOCCC.</p>
 <p>Jump to: <a href="#">top</a></p>
 <p><strong>Leonid A. Broukhis</strong><br>
 <strong>chongo (Landon Curt Noll) <code>/\cc/\</code></strong></p>

--- a/next/rules.md
+++ b/next/rules.md
@@ -48,13 +48,11 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-These [IOCCC rules](rules.html) are version **28.30 2025-03-03**.
+These [IOCCC rules](rules.html) are version **28.31 2025-11-17**.
 </p>
 
-<p class="leftbar">
 The markdown form of these rules <a href="rules.md" download="rules.md">is
 available for download</a>.
-</p>
 
 **IMPORTANT**: Be sure to read the [IOCCC guidelines](guidelines.html).
 
@@ -131,7 +129,6 @@ This contest will enter the **[judging](../faq.html#judging)** state on **2025-0
 of the above **dates and times may change**!
 </p>
 
-<p class="leftbar">
 See the
 FAQ on "[obtaining and compiling the mkiocccentry tools](../faq.html#mkiocccentry)"
 and the
@@ -140,7 +137,6 @@ as that FAQ has important details on
 [how to register](../next/register.html)
 as well as
 [how to upload your submission](../next/submit.html) to the IOCCC.
-</p>
 
 
 Jump to: [top](#)
@@ -156,7 +152,6 @@ To help us with the volume of submissions, we ask that you follow the rules belo
 #### A warning about rule abuse
 </div>
 
-<p class="leftbar">
 **WARNING:** Abusing these rules comes with a **fair amount of risk**
 that your submission will be rejected.  If you do plan to abuse the
 rules, then you **MUST CLEARLY EXPLAIN THE RATIONALE** in your `remarks.md` file,
@@ -164,50 +159,38 @@ as to why you think your rule abuse should be allowed, and as to why you think
 your submission should not be rejected for a rule violation.
 **Nevertheless, _even if you do_ explain this in your `remarks.md` file
 you submission may still be rejected**.
-</p>
 
-<p class="leftbar">
 If you use the most recently released official IOCCC submission packaging tool
 (hereby referred to as `mkiocccentry(1)`), which we **STRONGLY recommend you
 do**, then the `mkiocccentry(1)` tool will warn you if there appears to be a
 violation in certain rules (not all can be detected).  The `mkiocccentry(1)`
-tool also runs `chkentry(1)` and `txzchk(1)`, the latter of which runs
+tool also runs `chksubmit(1)` and `txzchk(1)`, the latter of which runs
 `fnamchk(1)`.  Overriding problems detected by any of these tools comes with a
 **fair amount of risk** that your submission will be rejected.
-</p>
 
-<p class="leftbar">
 If you do override a rule violation warning from the `mkiocccentry(1)` or
 another related IOCCC tool, or otherwise plan to abuse the rules, then you
 **MUST CLEARLY EXPLAIN THE RATIONALE** of why you are attempting to abuse the
 rules in your `remarks.md` file.  **_Even if you do_ explain this in your
 `remarks.md` file your submission may still be rejected**.
-</p>
 
-<p class="leftbar">
 **HINT:** If you do submit such a rule abusing / rule violating
 submission, then consider also submitting an alternate version in a
 **different submission** server slot that does **NOT** violate the rules
 in case your rule abuse excuse is rejected.
-</p>
-<p class="leftbar">
+
 **IMPORTANT**: if you do submit such an alternate non-rule abusing version,
 **PLEASE** indicate that in your `remarks.md` file of your non-rule abusing
 version so that the [IOCCC judges](../judges.html) do not think you uploaded a
 duplicate into a wrong slot by mistake.
-</p>
 
-<p class="leftbar">
 Uploading a tarball not formed by `mkiocccentry(1)` puts you at a very big risk of
 violating [Rule 17](rules.html#rule17), especially as `mkiocccentry(1)` does a
 great number of things that are required, and it also runs many checks, and if
 any of those checks fail, you are at a very great risk of having your submission
 rejected for violating [Rule 17](rules.html#rule17).
-</p>
 
-<p class="leftbar">
 See also [Rule 12](#rule13).
-</p>
 
 
 Jump to: [top](#)
@@ -217,13 +200,9 @@ Jump to: [top](#)
 ## Rule 0
 </div>
 
-<p class="leftbar">
 Just as C starts at 0, so the IOCCC starts at [Rule 0](#rule0).  :-)
-</p>
 
-<p class="leftbar">
 The "[Important IOCCC dates](#dates)" section above is part of this rule.
-</p>
 
 
 Jump to: [top](#)
@@ -233,16 +212,12 @@ Jump to: [top](#)
 ## Rule 1
 </div>
 
-<p class="leftbar">
 Your submission must be a C program.
-</p>
 
-<p class="leftbar">
 You see, the contest is not called the **International Obfuscated JSON Contest**
 (**IOJSONC**), even if the [so-called JSON
 spec](https://github.com/xexyl/jparse/blob/master/json_README.md#so-called-json-spec) might be called obfuscated
 by some people. :-)
-</p>
 
 
 Jump to: [top](#)
@@ -255,31 +230,23 @@ Jump to: [top](#)
 [Rule 2](#rule2) requires that your submission satisfy **BOTH** [Rule
 2a](#rule2a) **AND** [Rule 2b](#rule2b).
 
-<p class="leftbar">
 You may check your code with respect to [Rule 2a](#rule2a) and [Rule
 2b](#rule2b) prior to submitting your code by giving the filename
 as a command like argument to the `iocccsize(1)` tool. For example:
-</p>
 
 ``` <!---sh-->
     iocccsize prog.c
 ```
 
-<p class="leftbar">
 The source to `iocccsize(1)` may be found in the
 [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry).
-</p>
 
-<p class="leftbar">
 See also the
 FAQ on "[how to further test your submission](../faq.html#mkiocccentry_test)"
 for more more thorough testing, including [Rule 2](#rule2).
-</p>
 
 
-<p class="leftbar">
 See also [Rule 2a](#rule2a), [Rule 2b](#rule2b), and [Rule 17](#rule17).
-</p>
 
 Jump to: [top](#)
 
@@ -289,7 +256,7 @@ Jump to: [top](#)
 </div>
 
 <p class="leftbar">
-The size of your program source **should NOT exceed 4993 bytes**.
+The size of your program source **MUST NOT exceed 4993 bytes**.
 </p>
 
 Jump to: [top](#)
@@ -299,15 +266,11 @@ Jump to: [top](#)
 ## Rule 2b
 </div>
 
-<p class="leftbar">
 When the filename of your program source is given as a command line argument to
 the latest version of the official IOCCC size tool (hereby referred to as
-`iocccsize(1)`), the value printed **should NOT exceed _2503_**.
-</p>
+`iocccsize(1)`), the value printed **MUST NOT exceed _2503_**.
 
-<p class="leftbar">
 See also [Rule 17](#rule17).
-</p>
 
 Jump to: [top](#)
 
@@ -316,38 +279,27 @@ Jump to: [top](#)
 ## Rule 3
 </div>
 
-<p class="leftbar">
 You must [register](../next/register.html) in order to submit your entry to the IOCCC.
 You may [register](../next/register.html) while the contest is either
 **[pending](../faq.html#pending)** or  **[open](../faq.html#open)**.
-</p>
 
-<p class="leftbar">
 When the contest is **[open](../faq.html#open)**, the [submit server](https://submit.ioccc.org)
 will email you your [submit server](https://submit.ioccc.org)
 **Username** and **Initial password**.  **Please be patient** as it may take some time,
 perhaps as much as a few days, for your registration to be processed and for that email to be sent.
-</p>
 
-<p class="leftbar">
 Those who [register](../next/register.html) while the contest status is **[pending](../faq.html#pending)**
 will receive their email (containing their [submit server](https://submit.ioccc.org) **Username**
 and **Initial password**), later: usually a few days around the time when the contest status
 becomes **[open](../faq.html#open)**.
-</p>
 
-<p class="leftbar">
 Once that email with your **Username** and **Initial password** is sent, you
 will have fortnight (**14 days**) to [change your submit server initial password](../next/pw-change.html).
-</p>
 
-<p class="leftbar">
 If you do not change your **Initial password** in time, you will have to
 [send email to the IOCCC judges](../contact.md#if-you-really-need-to-send-email-the-ioccc-judges)
 to ask for your password to be reset.
-</p>
 
-<p class="leftbar">
 Because it takes time (maybe even a few days) to process your registration
 and for the server to email you your initial login and password, you
 should **MAKE SURE** you give yourself enough time to register well
@@ -355,18 +307,13 @@ before the contest closes.  In other words, **DO NOT WAIT UNTIL THE FINAL DAYS**
 of the contest to register!  The [IOCCC judges](../judges.html)
 are **NOT** responsible for delayed or lost email, or for those who wait
 until the last minute to try to register!
-</p>
 
-<p class="leftbar">
 See the
 FAQ on "[how to register and submit to the IOCCC](../quick-start.html#enter)"
 for instructions on registering and participating in the IOCCC, as the process
 may change from contest to contest.
-</p>
 
-<p class="leftbar">
 See also [Rule 8](#rule8).
-</p>
 
 
 Jump to: [top](#)
@@ -376,31 +323,21 @@ Jump to: [top](#)
 ## Rule 4
 </div>
 
-<p class="leftbar">
 If your submission is selected as a winning entry, then your submission may be modified in order
 to fit into the structure of the [Official IOCCC winner website](https://www.ioccc.org/index.html).
-</p>
 
-<p class="leftbar">
 For example, your submission's `Makefile` will be modified and your `remarks.md`
 will become a `README.md` which will be used to generate an `index.html` file.
-</p>
 
-<p class="leftbar">
 Your source code will be the file `prog.c`.  The compiled binary
 will be called `prog`.  If you submission requires different filenames,
 then modify your submission's `Makefile` to **COPY** (**NOT** move!) the files
 accordingly.
-</p>
 
-<p class="leftbar">
 Of course your program may also do this, as long as it works, but you're welcome
 to use your `Makefile` as well.
-</p>
 
-<p class="leftbar">
 See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
-</p>
 
 
 Jump to: [top](#)
@@ -417,16 +354,12 @@ part of your original submission including, but not limited to `prog.c`, the
 If you submission needs (or wishes :-) ) to modify such content, it **MUST**
 first copy the file to a new filename and then modify that copy.
 
-<p class="leftbar">
 You may use your submission (program) to form a copy, or you can make use of
 your `Makefile` to form that copy.
-</p>
 
-<p class="leftbar">
 If you do make a copy of a submission file, **PLEASE** be sure that
 the `clobber` rule of your `Makefile` removes that copy in order to
 restore your submission to its original submission state.
-</p>
 
 
 Jump to: [top](#)
@@ -436,15 +369,11 @@ Jump to: [top](#)
 ## Rule 6
 </div>
 
-<p class="leftbar">
 I am not a rule, I am a `free(void *human);` ‼️
-</p>
 
-<p class="leftbar">
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`while (!(ioccc(rule(you(are(number(6)))))) {`<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ha_ha_ha();`<br>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`
-</p>
 
 
 Jump to: [top](#)
@@ -454,42 +383,31 @@ Jump to: [top](#)
 ## Rule 7
 </div>
 
-<p class="leftbar">
 The obfuscated C program must be your own original work.
-</p>
 
-<p class="leftbar">
 You (the author(s)) **MUST** own the contents of your submission **OR**
 you **MUST** have permission from the owner(s) to submit their content.
-</p>
 
-<p class="leftbar">
 If you submit any content that is owned by others, you **MUST
 detail that ownership** (i.e., who owns what) **_AND_ document the
 permission you obtained from them**, in your `remarks.md` file.
-</p>
 
-<p class="leftbar">
 Please note that the tools in [mkiocccentry
 repo](https://github.com/ioccc-src/mkiocccentry) are **NOT** original works,
 unless of course you're the original authors, in which case they are original. :-)
-</p>
 
-<p class="leftbar">
 Nevertheless tools such as those listed are **NOT** obfuscated.  If submitted, they
 would probably violate a number of rules.  :-)
-</p>
 
 - [mkiocccentry&lpar;1&rpar;](https://github.com/ioccc-src/mkiocccentry/blob/master/mkiocccentry.c)
 - [iocccsize&lpar;1&rpar;](https://github.com/ioccc-src/mkiocccentry/blob/master/iocccsize.c)
-- [chkentry&lpar;1&rpar;](https://github.com/ioccc-src/mkiocccentry/blob/master/chkentry.c)
+- [chksubmit&lpar;1&rpar;](https://github.com/ioccc-src/mkiocccentry/blob/master/chksubmit.c)
 - [txzchk&lpar;1&rpar;](https://github.com/ioccc-src/mkiocccentry/blob/master/txzchk.c)
 - [location&lpar;1&rpar;](https://github.com/ioccc-src/mkiocccentry/blob/master/soup/location_main.c)
 - [jparse repo as cloned by the mkiocccentry repo](https://github.com/xexyl/jparse)
 - [dbg repo as cloned by the mkiocccentry repo](https://github.com/lcn2/dbg)
 - [dyn_array repo as cloned by the mkiocccentry repo](https://github.com/lcn2/dyn_array)
 
-<p class="leftbar">
 The IOCCC has a rich history of remarkable winning entries created by
 authors who skillfully employed various techniques to develop their code.
 While it is **NOT** required, you are _allowed_ to use tools to develop
@@ -499,11 +417,8 @@ runtime analysis tools, machine learning tools, natural language models,
 code copilot tools, so-called AI services, large language models (LLMs), etc.
 If you do make use of such tools or services, then we **ENCOURAGE you to describe
 what tools and how you used those tools**, in your `remarks.md` file.
-</p>
 
-<p class="leftbar">
 See also [Rule 5](#rule5), [Rule 18](#rule18) and [Rule 21](#rule21).
-</p>
 
 
 Jump to: [top](#)
@@ -513,64 +428,44 @@ Jump to: [top](#)
 ## Rule 8
 </div>
 
-<p class="leftbar">
 Submissions may only be uploaded to the [IOCCC submit server](https://submit.ioccc.org)
 while the contest is **[open](../faq.html#open)**.
-</p>
 
-<p class="leftbar">
 If you have [registered](../next/register.html) and received by email your [submit
 server](https://submit.ioccc.org) **Username** and **Initial password** you may
 upload your submission to the [submit server](https://submit.ioccc.org) but
 **ONLY** while the contest is **[open](../faq.html#open)**.
-</p>
 
-<p class="leftbar">
 The [submit server](https://submit.ioccc.org), in accordance with [Rule
 17](rules.html#rule17), places a limit of **3999971** bytes on the size of your
 upload.
-</p>
 
-<p class="leftbar">
 Once the contest is in the **[judging](../faq.html#judging)** state (or
 **[closed](../faq.html#closed)** state), you may **NOT** upload submissions.
-</p>
 
-<p class="leftbar">
 While the contest is **[open](../faq.html#open)** or in the
 **[judging](../faq.html#judging)** state, the [IOCCC judges](../judges.html)
 **MAY** (but are not required to) modify the slot comment of your submission to
 indicate that they have received it.  If uploaded submission is malformed, the
 [IOCCC judges](../judges.html) **MAY** (but are not required to) modify the slot
 comment accordingly.
-</p>
 
-<p class="leftbar">
 You are **STRONGLY** advised to use the `mkiocccentry(1)` tool
 as found in the [mkiocccentry repo](https://github.com/ioccc-src/mkiocccentry)
 to form the file to upload to the [submit server](https://submit.ioccc.org).
-</p>
 
-<p class="leftbar">
 The [submit server](https://submit.ioccc.org) will become active when the
 contest is **[open](../faq.html#open)**.  Until the contest status becomes
 **[open](../faq.html#open)**, the [submit server](https://submit.ioccc.org) may
 be offline and/or unresponsive.
-</p>
 
-<p class="leftbar">
 See the
 FAQs on "[obtaining, compiling, installing and using the latest release of the mkiocccentry tools](../faq.html#mkiocccentry)"
 for more information about the `mkiocccentry(1)` tool.
-</p>
 
-<p class="leftbar">
 See the "[Important IOCCC dates](#dates)" section above for when these contest states are scheduled.
-</p>
 
-<p class="leftbar">
 See also [Rule 3](#rule3) and [Rule 17](#rule17).
-</p>
 
 
 Jump to: [top](#)
@@ -580,17 +475,13 @@ Jump to: [top](#)
 ## Rule 9
 </div>
 
-<p class="leftbar">
 Each **PERSON** may register **ONLY ONE** account and each account may submit up to
 and including **10.000000** (ten in base 10) submissions **PER** contest.
-</p>
 
 **Each submission _must be submitted separately_**.
 
-<p class="leftbar">
 If this seems unreasonable we suggest you wait until the next contest and in
 the interim ponder this (modified or not) quote said by Bill Gates:
-</p>
 
 > 640K submissions ought to be enough for anybody.
 >
@@ -622,15 +513,11 @@ you expect on our test platforms. If your program needs special
 permissions you **MUST** document this fact, and explain why
 it is needed in your submission's `remarks.md` file.
 
-<p class="leftbar">
 Furthermore, if you need a supplementary program that you include, to have these
 permissions, you will also have to explain this, because these bits are not
 allowed in submissions and those bits will not be copied by `mkiocccentry(1)`.
-</p>
 
-<p class="leftbar">
 See also [Rule 17](#rule17).
-</p>
 
 Jump to: [top](#)
 
@@ -644,9 +531,7 @@ the opinion of the [judges](../judges.html), violates the rules WILL BE DISQUALI
 Submissions that attempt to abuse the rules **MUST** try to justify why
 their rule abuse is legal, in the `remarks.md` file.
 
-<p class="leftbar">
 See also [the warning about rule abuse](#rule_abuse).
-</p>
 
 Jump to: [top](#)
 
@@ -655,14 +540,10 @@ Jump to: [top](#)
 ## Rule 13
 </div>
 
-<p class="leftbar">
 7 out of 13 UTF-8 characters in C code agree that this rule number is lucky
 enough to be a prime number.
-</p>
 
-<p class="leftbar">
 Fun fact: the fear of the number 13 is called _triskaidekaphobia_.
-</p>
 
 
 Jump to: [top](#)
@@ -672,30 +553,22 @@ Jump to: [top](#)
 ## Rule 14
 </div>
 
-<p class="leftbar">
 Any C source that fails to compile because of lines with trailing
 control-M's (i.e., lines with a trailing byte `015`) **might** be rejected.
-</p>
 
-<p class="leftbar">
 Please do **NOT** put trailing control-M's on `prog.c`, `Makefile`, or
 `remarks.md` files but instead end lines with a trailing newline (i.e.,
 byte `012`) character.
-</p>
 
-<p class="leftbar">
 As we do **NOT** use DOS, please also be sure that the `Makefile` and
 `remarks.md` files end in final newline (i.e., byte `012`) character.
-</p>
 
-<p class="leftbar">
 You are permitted, in order to try and squeeze your `prog.c` under
 a [Rule 2a](#rule2a) and/or [Rule 2b](#rule2b) limit, to **NOT**
 end your `prog.c` with a newline  (i.e., byte `012`) character.
 If you need to do this, **PLEASE** document that in your `remarks.md` file and
 if your compiler complains about this, document this too and update your
 `Makefile` to account for this.
-</p>
 
 
 Jump to: [top](#)
@@ -705,20 +578,14 @@ Jump to: [top](#)
 ## Rule 15
 </div>
 
-<p class="leftbar">
 In order to register for the IOCCC, you **MUST** have a valid email address.
-</p>
 
-<p class="leftbar">
 The [judges](../judges.html) **are NOT responsible for delays in email**, so please plan
 enough time accordingly.
-</p>
 
-<p class="leftbar">
 See the
 FAQ on "[how to register](../quick-start.html#register)"
 for details.
-</p>
 
 
 Jump to: [top](#)
@@ -730,22 +597,18 @@ Jump to: [top](#)
 
 Submissions that are similar to previous winning IOCCC entries are discouraged.
 
-<p class="leftbar">
 You are allowed to resubmit to a later contest, a submission that
 did not win the IOCCC.  If you do so, then you would be well advised
 to try and enhance and improve your submission.
 If you do resubmit something that did not previously win, then
 you are **encouraged** to mention this in your `remarks.md` file
 as this **sometimes** helps.
-</p>
 
-<p class="leftbar">
 Resubmitting an improved submission that did not become an
 IOCCC winning entry is a **time honored** tradition of the IOCCC.
 There are some IOCCC winning entries that were submitted to multiple contests
 before they were improved enough to "climb over" (as the expression
 goes) all the other submissions for a given contest.
-</p>
 
 Jump to: [top](#)
 
@@ -754,68 +617,57 @@ Jump to: [top](#)
 ## Rule 17
 </div>
 
-<p class="leftbar">
 Your submission must be in the form of a **xz compressed tarball** that
 the **current released version** of the `mkiocccentry(1)` tool would generate.
 The files, directories, and paths **MUST** conform to the limits imposed
 by `mkiocccentry(1)` including but **NOT LIMITED** to their names, count,
 path length, directory tree depth and permissions.
-</p>
 
-<p class="leftbar">
 Your **xz compressed tarball** must be larger than **0** bytes and no larger
 than **3999971** bytes.
-</p>
 
-<p class="leftbar">
 The sum of the byte lengths of all files, after the **xz compressed tarball** is untarred,
 must **NOT** exceed `27651*1024` bytes.
-</p>
 
-<p class="leftbar">
 Your **xz compressed tarball** submission _file_ **MUST** pass the tests performed by
 the current version of `txzchk(1)`.
-</p>
 
-<p class="leftbar">
 Your **xz compressed tarball** submission _filename_ **MUST** pass the tests
 performed by the current version of `fnamchk(1)`.
-</p>
 
-<p class="leftbar">
 When your **xz compressed tarball** submission file is untarred, the
 resulting _directory_ **MUST** pass the checks performed by the current version
-of `chkentry(1)`.
-</p>
+of `chksubmit(1)`.
 
-<p class="leftbar">
 The resulting `prog.c` file **MUST** pass the [Rule 2](#rule2) size checks performed by the current
 version of `iocccsize(1)`.
-</p>
 
-<p class="leftbar">
 The `.auth.json` and `.info.json` **MUST** be compatible with what the
 current version of the `mkiocccentry(1)` tool would produce.  They **MUST
-ALSO** pass the tests performed by the current version of `chkentry(1)`.
-</p>
+ALSO** pass the tests performed by the current version of `chksubmit(1)`.
 
-<p class="leftbar">
 The required `Makefile` must **NOT** be empty.
-</p>
 
-<p class="leftbar">
 The required `remarks.md` must **NOT** be empty.
-</p>
 
-<p class="leftbar">
 You may **NOT** submit a tarball created by the `-d` or `-s seed` option of
 `mkiocccentry(1)`.
-</p>
 
 <p class="leftbar">
 The maximum number of files your submission tarball may contain, not counting
-the optional files (`prog.alt.c`, `try.sh`, `try.alt.sh`) and the mandatory
-files (`prog.c`, `Makefile`, `remarks.md`) is 31.
+the free files (`prog.c`, `remarks.md`, `Makefile`, `prog.alt.c`, `try.sh`,
+`try.alt.sh` and the two files generated by `mkiocccentry`, `.info.json` and
+`.auth.json`) is 31.
+</p>
+
+<p class="leftbar">
+The maximum number of directories your submission may have is 13 and the maximum
+depth a path may have is 4.
+</p>
+
+<p class="leftbar">
+The maximum filename length (a component of a path) is 38 which means the
+maximum length total of a path is 60 characters.
 </p>
 
 See the
@@ -825,31 +677,23 @@ for more details.
 
 ### TL;DR Rule 17 - Use `mkiocccentry(1)` to form your submission
 
-<p class="leftbar">
 Let the current version of the `mkiocccentry(1)` tool form your **xz
 compressed tarball** submission file.
-</p>
 
 ### Warning
 
-<p class="leftbar">
 Using command line flags or input prompts to override checks and
 limits made by the above mentioned tools is **NOT** recommended
 and may result in your submission being rejected by the [IOCCC
 submit server](https://submit.ioccc.org) and/or the [IOCCC Judges](../judges.html).
-</p>
 
-<p class="leftbar">
 See the
 FAQ on the "[mkiocccentry toolkit](../faq.html#mkiocccentry)
 for how to obtain and use the above mentioned tools.
-</p>
 
-<p class="leftbar">
 **IMPORTANT**: See the
 FAQ on "[Rule 17](../faq.html#rule17)"
 for very important details behind this rule.
-</p>
 
 
 Jump to: [top](#)
@@ -863,9 +707,7 @@ The entirety of your submission must be submitted under the following license:
 
 > **[CC BY-SA 4.0 DEED Attribution-ShareAlike 4.0 International](https://creativecommons.org/licenses/by-sa/4.0/)**
 
-<p class="leftbar">
 See also [Rule 7](#rule7).
-</p>
 
 
 Jump to: [top](#)
@@ -875,52 +717,38 @@ Jump to: [top](#)
 ## Rule 19
 </div>
 
-<p class="leftbar">
 The `remarks.md` file, a required non-empty file, must be written in
 [Markdown format](https://www.markdownguide.org/basic-syntax/).
-</p>
 
-<p class="leftbar">
 We currently use [pandoc&lpar;1&rpar;](https://pandoc.org) to automatically
 convert markdown to HTML.  Please try to avoid submitting an HTML file
 translation to any markdown file.  If you **MUST** submit such an HTML
 translation, **PLEASE** mention this in your `remarks.md` file.
-</p>
 
-<p class="leftbar">
 For any submission that wins the contest, we modify your `remarks.md` file and
 rename it as `README.md` and then use [pandoc&lpar;1&rpar;](https://pandoc.org)
 to generate the `index.html` file in the top level directory of your submission.
 For this reason, `mkiocccentry(1)` will **NOT** package such files (in the top
-level submission directory) and both `txzchk(1)` and `chkentry(1)` will flag
+level submission directory) and both `txzchk(1)` and `chksubmit(1)` will flag
 them as errors (in the top level submission directory) as well, so please do
 **NOT** try and slip these files in the top level directory where your
 `remarks.md` resides.
-</p>
 
-<p class="leftbar">
 See the [Markdown Cheat Sheet](https://www.markdownguide.org/cheat-sheet/)
 for a handy quick reference to the Markdown syntax.
-</p>
 
-<p class="leftbar">
 See the [Markdown guide](https://www.markdownguide.org)
 for free and open-source reference guide that explains
 how to use markdown.
-</p>
 
-<p class="leftbar">
 See also the [Daring Fireball Markdown:
 Basics](http://daringfireball.net/projects/markdown/basics) for
 information on the markdown format.
-</p>
 
-<p class="leftbar">
 **PLEASE** see our
 FAQ on "[remarks.md](../faq.html#remarks_md)"
 **AND** the
 [IOCCC markdown guidelines](../markdown.html) for additional markdown guidance.
-</p>
 
 
 Jump to: [top](#)
@@ -934,12 +762,10 @@ The how to build instructions must be in GNU Makefile format. See the
 FAQ about "[make&lpar;1&rpar; compatibility the IOCCC supports](../faq.html#make_compatibility)
 for more details.
 
-<p class="leftbar">
 You are **ENCOURAGED** to use the
 Makefile example, renamed as `Makefile` of course, for help in constructing your
 `Makefile`. See the [Makefile section](guidelines.html#makefile) in the
 guidelines for more details.
-</p>
 
 The target of the `Makefile` must be called `prog`.  The original
 C source file must be called `prog.c`.
@@ -949,26 +775,20 @@ To invoke the C compiler, use `${CC}`. To invoke the C preprocessor use
 
 Do **NOT** assume that `.` (the current directory) is in the `$PATH`.
 
-<p class="leftbar">
 When `make clobber` is invoked, we request that your submission directory be restored
 to its original submission state.  For example, any temporary files
 created during the build process, or during execution should be
 removed by the `clobber` rule.
-</p>
 
-<p class="leftbar">
 Your `Makefile` **MUST** use a syntax that is compatible with `bash(1)`
 **AND** GNU `make(1)`.  You are **ENCOURAGED** to use `SHELL= bash` in
 your `Makefile`. Please add a space between the `=` and the value.
-</p>
 
-<p class="leftbar">
 Assume that commands commonly found in [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification)
 environments and systems that conform to the [Single UNIX
 Specification](https://en.wikipedia.org/wiki/Single_UNIX_Specification) are
 available in the `$PATH` search path.
-</p>
 
 
 Jump to: [top](#)
@@ -978,23 +798,17 @@ Jump to: [top](#)
 ## Rule 21
 </div>
 
-<p class="leftbar">
 Your submission **MUST NOT** create or modify files **ABOVE** the current directory
 _with the exception of_ the `/tmp` and the `/var/tmp` directories.  Your submission
 **MAY** create subdirectories **below** the submission directory, or in `/tmp`,
 or in `/var/tmp` provided that `.` is **NOT** the first byte in any
 directory name or filename you create.
-</p>
 
-<p class="leftbar">
 If you do create files and directories, **PLEASE** be sure that
 the `clobber` rule of your `Makefile` removes such created files
 in order to restore your submission to its original submission state.
-</p>
 
-<p class="leftbar">
 See also [Rule 5](#rule5).
-</p>
 
 
 Jump to: [top](#)
@@ -1017,11 +831,9 @@ within your code, data, remarks or program output (unless you are
 **Peter Honeyman** or pretending to be **Peter Honeyman**) will be grounds
 for disqualification of your submission.
 
-<p class="leftbar">
 And don't assume that we won't be able to determine your name even if it's not
 obvious, because you stand a significant chance of violating this rule if you
 do.
-</p>
 
 Yes, Virginia, **WE REALLY MEAN IT!**
 
@@ -1080,9 +892,7 @@ Jump to: [top](#)
 ## Rule 27
 </div>
 
-<p class="leftbar">
 Unless otherwise needed, [Rule 27](#rule27) is reserved for something cubic.  :-)
-</p>
 
 
 Jump to: [top](#)
@@ -1092,10 +902,8 @@ Jump to: [top](#)
 ## Rule 28
 </div>
 
-<p class="leftbar">
 [Rule 28](#rule28) is a perfect way to end the list of [IOCCC rules](rules.html)
 as we do **NOT** plan to have **496** rules. :-)
-</p>
 
 
 Jump to: [top](#)
@@ -1106,41 +914,28 @@ Jump to: [top](#)
 </div>
 </div>
 
-<p class="leftbar">
 For questions or comments about the contest, see [Contacting the IOCCC](../contact.html).
-</p>
 
-<p class="leftbar">
 **Be SURE** to review the [IOCCC Rules and Guidelines](index.html) as they
 may (and **often do**) change from year to year.
-</p>
 
-<p class="leftbar">
 **PLEASE** be **SURE** you have the **current** [IOCCC rules](rules.html) and
 [IOCCC guidelines](guidelines.html) prior to submitting to the contest.
-</p>
 
 See the [Official IOCCC website news](../news.html) for additional information.
 
-<p class="leftbar">
 For the updates and breaking IOCCC news, you are encouraged to follow
 the [IOCCC on Mastodon](https://fosstodon.org/@ioccc) account.  See our
 FAQ on "[Mastodon](../faq.html#try_mastodon)"
 for more information. Please do note that unless
 you are mentioned by us you will **NOT** get a notification from the app _so you
 should refresh the page **even if you do follow us**_.
-</p>
 
-<p class="leftbar">
 Check out the [Official IOCCC winner website](https://www.ioccc.org/index.html) in general.
-</p>
 
-<p class="leftbar">
 Consider joining the IOCCC discord community via this link:
 [https://discord.gg/Wa42Qujwnw](https://discord.gg/Wa42Qujwnw)
-</p>
 
-<p class="leftbar">
 See the
 FAQ on "[obtaining, compiling, installing and using the mkiocccentry tools](../faq.html#mkiocccentry)"
 and the
@@ -1149,7 +944,6 @@ as that FAQ has important details on
 [how to register](../next/register.html)
 as well as
 [how to upload your submission](../next/submit.html) for the IOCCC.
-</p>
 
 
 Jump to: [top](#)

--- a/next/submit.html
+++ b/next/submit.html
@@ -495,7 +495,7 @@ of:</p>
 timestamp</a>.</p>
 <p>We highly recommend that you use <code>mkiocccentry(1)</code> to create your submit file as
 it must pass the <code>txzchk(1)</code> sanity checks, and when the uncompressed tarball is
-untarred, the resulting directory must pass <code>chkentry(1)</code>.</p>
+untarred, the resulting directory must pass <code>chksubmit(1)</code>.</p>
 </blockquote>
 <p><strong>NOTE</strong>: the <code>00000000-0000-4000-0000-000000000000</code> is your UUID. <strong>MAKE SURE
 YOU CHANGE IT TO YOUR UUID</strong>!</p>
@@ -571,7 +571,7 @@ To see any status updates, you should logout and log back in later.</p>
 </blockquote>
 <p>Or:</p>
 <blockquote>
-<p><strong>Status: submit file failed the chkentry test! Use mkiocccentry to rebuild and resubmit to this slot.</strong></p>
+<p><strong>Status: submit file failed the chksubmit test! Use mkiocccentry to rebuild and resubmit to this slot.</strong></p>
 </blockquote>
 <p>… or <strong>ANY</strong> other error then you <strong>MUST FIX</strong> your submission, repackage your
 tarball with <code>mkiocccentry</code> and upload to the same slot again! If you do not fix
@@ -579,7 +579,7 @@ this your submission <strong>WILL BE REJECTED</strong> for violating <a href="ru
 17</a>!</p>
 <p>If the format test went well, then you will see:</p>
 <blockquote>
-<p><strong>Status: submit file received by the IOCCC judges. Passed both txzchk and chkentry tests.</strong></p>
+<p><strong>Status: submit file received by the IOCCC judges. Passed both txzchk and chksubmit tests.</strong></p>
 </blockquote>
 <p><strong>IMPORTANT</strong>: this does <strong>NOT</strong> mean that your submission does not violate the
 rules or that everything is OK once the tarball is extracted; it simply means
@@ -589,8 +589,8 @@ submission rejected for violating <a href="rules.html#rule17">Rule 17</a>, even 
 tests passed.</p>
 <p>For details on <code>txzchk</code>, see the
 FAQ on “<a href="../faq.html#txzchk">txzchk</a>”.</p>
-<p>For details on <code>chkentry</code>, see the
-FAQ on “<a href="../faq.html#chkentry">chkentry</a>”.</p>
+<p>For details on <code>chksubmit</code>, see the
+FAQ on “<a href="../faq.html#chksubmit">chksubmit</a>”.</p>
 <p>If you need more information on the two JSON files, see
 FAQ on the <a href="../faq.html#info_json">“.info.json file</a>”
 and the

--- a/next/submit.md
+++ b/next/submit.md
@@ -56,7 +56,7 @@ timestamp](https://unixtime.org/).
 >
 > We highly recommend that you use `mkiocccentry(1)` to create your submit file as
 it must pass the `txzchk(1)` sanity checks, and when the uncompressed tarball is
-untarred, the resulting directory must pass `chkentry(1)`.
+untarred, the resulting directory must pass `chksubmit(1)`.
 
 **NOTE**: the `00000000-0000-4000-0000-000000000000` is your UUID. **MAKE SURE
 YOU CHANGE IT TO YOUR UUID**!
@@ -153,7 +153,7 @@ After the format test is complete, if you see an error such as:
 
 Or:
 
-> **Status: submit file failed the chkentry test! Use mkiocccentry to rebuild and resubmit to this slot.**
+> **Status: submit file failed the chksubmit test! Use mkiocccentry to rebuild and resubmit to this slot.**
 
 ... or **ANY** other error then you **MUST FIX** your submission, repackage your
 tarball with `mkiocccentry` and upload to the same slot again! If you do not fix
@@ -162,7 +162,7 @@ this your submission **WILL BE REJECTED** for violating [Rule
 
 If the format test went well, then you will see:
 
-> **Status: submit file received by the IOCCC judges. Passed both txzchk and chkentry tests.**
+> **Status: submit file received by the IOCCC judges. Passed both txzchk and chksubmit tests.**
 
 **IMPORTANT**: this does **NOT** mean that your submission does not violate the
 rules or that everything is OK once the tarball is extracted; it simply means
@@ -174,8 +174,8 @@ tests passed.
 For details on `txzchk`, see the
 FAQ on "[txzchk](../faq.html#txzchk)".
 
-For details on `chkentry`, see the
-FAQ on "[chkentry](../faq.html#chkentry)".
+For details on `chksubmit`, see the
+FAQ on "[chksubmit](../faq.html#chksubmit)".
 
 If you need more information on the two JSON files, see
 FAQ on the [".info.json file](../faq.html#info_json)"

--- a/quick-start.html
+++ b/quick-start.html
@@ -577,7 +577,7 @@ you have an earlier version and you have not installed the tools and run the
 tools from outside the repo directory, you will have to use the options to the
 tools to set the path to the required tools.</p>
 <p>Do remember to make sure you have the latest vers
-<code>chkentry(1)</code>, <code>txzchk(1)</code> and <code>fnamchk(1)</code>. And remember to make sure you have
+<code>chksubmit(1)</code>, <code>txzchk(1)</code> and <code>fnamchk(1)</code>. And remember to make sure you have
 the latest version so you do not violate <a href="next/rules.html#rule17">Rule 17</a>.
 See the
 FAQ on “<a href="faq.html#obtaining_mkiocccentry">obtaining the latest mkiocccentry tools</a>”,

--- a/quick-start.md
+++ b/quick-start.md
@@ -177,7 +177,7 @@ tools from outside the repo directory, you will have to use the options to the
 tools to set the path to the required tools.
 
 Do remember to make sure you have the latest vers
-`chkentry(1)`, `txzchk(1)` and `fnamchk(1)`. And remember to make sure you have
+`chksubmit(1)`, `txzchk(1)` and `fnamchk(1)`. And remember to make sure you have
 the latest version so you do not violate [Rule 17](next/rules.html#rule17).
 See the
 FAQ on "[obtaining the latest mkiocccentry tools](faq.html#obtaining_mkiocccentry)",


### PR DESCRIPTION
This commit also removed some of the 'new marks' in the guidelines and rules (as they're no longer new) and some that were in the FAQ (which only happened when they were changed over to the FAQ).

Removed problematic FAQs (per discussion). This required renumbering.

Updated references of chkentry to chksubmit (only a few references to chkentry remain now - advising contestants to not use it but simply stating it is for the judges and it is what chksubmit uses).

Added note in guidelines about gotos becoming 'old' (as Landon told me it is something Leo wanted in the next guidelines thanks to me). Just so Landon does not forget my C sins. :-)

I have regenerated the html files but the guidelines.html and rules.html files have not been link-checked as these files will be modified by the judges a fair amount so there is no point yet. I believe I got references to nuked FAQs out but it's possible some were missed.

The quick-start.md and next/submit.md (and their html files) were updated as well to refer to chksubmit instead of chkentry.

It is quite possible some things were missed but this should help move things closer to getting ready for IOCCC29 in December.