### PR TITLE
Rename Rule 5 and related links.

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -640,7 +640,7 @@ itself.
 
 Do remember that if your submission requires different filenames, then you
 **MUST** make a **COPY** of them in your `Makefile`. See also
-[Rule 5 - Purity](next/rules.html#rule-5---purity).
+[Rule 5 - Integrity](next/rules.html#rule-5---integrity).
 
 
 Jump to: [top](#)
@@ -1098,7 +1098,7 @@ modes, it also verifies them after the fact and if they are not correct it is an
 If you do need different permissions, then see the
 FAQ on "[file permissions](#file_perms)". Also keep in mind
 [Rule 4 - Files](next/rules.html#rule-4---files),
-[Rule 5 - Purity](next/rules.html#rule-5---purity),
+[Rule 5 - Integrity](next/rules.html#rule-5---integrity),
 and
 [Rule 16 - Anonymous](next/rules.html#rule-16---anonymous).
 

--- a/next/rules.md
+++ b/next/rules.md
@@ -37,7 +37,7 @@ and remains unaltered.  All other uses **MUST** receive prior permission in
 writing by [contacting the judges](../contact.html).
 
 
-## Rules version
+## Rules Version
 
 These IOCCC Rules are version **29.05 2025-11-21**.
 
@@ -179,7 +179,7 @@ See [Rule 17 - Packaging](rules.html#rule-17---packaging).
 
 
 <div id="rule5">
-## Rule 5 - Purity
+## Rule 5 - Integrity
 </div>
 
 Your submission **MUST NOT** modify the filenames or content of any of
@@ -294,7 +294,7 @@ bits are **NOT** allowed in submissions and those bits will **NOT** be copied by
 
 See [Rule 4 - Files](rules.html#rule-4---files),
 and
-[Rule 5 - Purity](rules.html#rule-5---purity).
+[Rule 5 - Integrity](rules.html#rule-5---integrity).
 
 
 <div id="rule11">


### PR DESCRIPTION
https://github.com/ioccc-src/winner/issues/208#issuecomment-3563523126

> > Was in the shower when I when the thought came to me `Rule 5 Purity` => `Rule 5 Integrity` ?
> 
> We like this, however ...
> 
> However, if someone is going to rename "Rules XX - Title", then the links will also change. So for example, "rules.html#rule-5---purity" would have to change to "rules.html#rule-5---integrity" throughout the repo.

