### PR TITLE
Silence two pointless warnings in Makefile.example

### DIFF
--- a/2024/ferguson1/README.md
+++ b/2024/ferguson1/README.md
@@ -12,6 +12,15 @@ YouTube show for this entry:
     make all
 ```
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+> **STATUS: INABIAF - please DO NOT fix**
+
+For more detailed information see [2024/ferguson1 in bugs.html](../../bugs.html#2024_ferguson1).
+
+
 
 ## To use:
 

--- a/2024/ferguson1/index.html
+++ b/2024/ferguson1/index.html
@@ -481,6 +481,12 @@ YouTube show for this entry:</p>
 </blockquote>
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
+<p>For more detailed information see <a href="../../bugs.html#2024_ferguson1">2024/ferguson1 in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
 <pre><code>    ./prog</code></pre>
 <h2 id="try">Try:</h2>

--- a/bugs.html
+++ b/bugs.html
@@ -3615,11 +3615,42 @@ which lists some other conditions which should be considered features, not bugs.
 <h3 id="source-code-2024carliniprog.c">Source code: <a href="https://github.com/ioccc-src/winner/blob/master/2024/carlini/prog.c">2024/carlini/prog.c</a></h3>
 <h3 id="information-2024carliniindex.html">Information: <a href="2024/carlini/index.html">2024/carlini/index.html</a></h3>
 <p>When printing a 0 digit, the <code>fib.bin</code> 4004 program will print a space instead of a “0”.</p>
+<div id="2024_ferguson1">
+<h2 id="ferguson1-1">2024/ferguson1</h2>
+</div>
+<p>Jump to: <a href="#">top</a></p>
+<h3 id="status-inabiaf---please-do-not-fix-100">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-2024ferguson1prog.c">Source code: <a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson1/prog.c">2024/ferguson1/prog.c</a></h3>
+<h3 id="information-2024ferguson1index.html">Information: <a href="2024/ferguson1/index.html">2024/ferguson1/index.html</a></h3>
+<p>Upon starting this game you will immediately have a sinful night and playing it
+will lead you directly to a date with the Devil in HELL after things such as:</p>
+<ul>
+<li>having delusions and hallucinations</li>
+<li>engaging in robbery, accidental killings and cannibalism</li>
+<li>engaging in or thinking about illicit affairs</li>
+<li>encountering and trying to defend yourself against
+<a href="https://en.wikipedia.org/wiki/Blackbeard">Blackbeard</a> aka Edward Teach on his
+flagship <a href="https://en.wikipedia.org/wiki/Queen_Anne%27s_Revenge">Queen Anne’s
+Revenge</a></li>
+<li>dying of dysentery</li>
+<li>dying of starvation after all your oxen are consumed and nobody else is left</li>
+<li>being eaten by a dragon</li>
+<li>being eaten by Tyrannosauruses</li>
+<li>eating <a href="https://en.wikipedia.org/wiki/Goto">spaghetti</a> and <a href="https://en.wikipedia.org/wiki/Spaghetti_code">being strangled by
+it</a></li>
+<li>encountering the <a href="http://news.bbc.co.uk/onthisday/hi/dates/stories/april/1/newsid_2819000/2819261.stm">famous Spaghetti Tree</a></li>
+<li>and a whole host of other wild and exciting things!</li>
+</ul>
+<p>Whether or not you make it to Oregon Trail be prepared to meet the DEVIL in
+HELL!</p>
+<p>And MAKE SURE to say hi to
+<a href="https://www.ioccc.org/authors.html#Cody_Boone_Ferguson">him</a>! :-)
+He is waiting. 😈</p>
 <div id="2024_ferguson2">
 <h2 id="ferguson2">2024/ferguson2</h2>
 </div>
 <p>Jump to: <a href="#">top</a></p>
-<h3 id="status-inabiaf---please-do-not-fix-100">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-101">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2024ferguson2prog.c">Source code: <a href="https://github.com/ioccc-src/winner/blob/master/2024/ferguson2/prog.c">2024/ferguson2/prog.c</a></h3>
 <h3 id="information-2024ferguson2index.html">Information: <a href="2024/ferguson2/index.html">2024/ferguson2/index.html</a></h3>
 <p>As the language is a spoken language and as spaces are required to separate
@@ -3647,6 +3678,7 @@ solve this but the closest method broke output where it would otherwise work.
 The try.sh script demonstrates how you can often get the same output but because
 of words being multiple words (if it is not in the Navajo military dictionary)
 translation back to English is not perfect.</p>
+<p>Jump to: <a href="#">top</a></p>
 <div id="2024_howe">
 <h2 id="howe-1">2024/howe</h2>
 </div>
@@ -3691,7 +3723,7 @@ The <a href="http://www.isthe.com/cgi-bin/chongo/number.cgi">English name of tha
 <h2 id="kurdyukov4">2024/kurdyukov4</h2>
 </div>
 <p>Jump to: <a href="#">top</a></p>
-<h3 id="status-inabiaf---please-do-not-fix-101">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="status-inabiaf---please-do-not-fix-102">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
 <h3 id="source-code-2024kurdyukov4prog.c">Source code: <a href="https://github.com/ioccc-src/winner/blob/master/2024/kurdyukov4/prog.c">2024/kurdyukov4/prog.c</a></h3>
 <h3 id="information-2024kurdyukov4index.html">Information: <a href="2024/kurdyukov4/index.html">2024/kurdyukov4/index.html</a></h3>
 <p>The <a href="https://github.com/ioccc-src/winner/blob/master/2024/kurdyukov4/try.sh">2024/kurdyukov4/try.sh</a> script
@@ -3700,6 +3732,8 @@ compilers crashing and/or executables crashing when used with random
 input sizes larger than 64K bytes.</p>
 <p><strong>PLEASE NOTE</strong>: The above problems are <strong>NOT</strong> code bugs. They represent compiler mis-features,
 linker limitations, and/or architecture limitations.</p>
+<p>For more information see the “<strong>Large input size issues</strong>” section of
+<a href="2024/kurdyukov4/index.html#large-input-size-issues">2024/kurdyukov4/index.html</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="final_words">
@@ -3713,8 +3747,6 @@ fixes] via a <a href="https://github.com/ioccc-src/winner/pulls">GitHub pull
 request</a> or otherwise, we
 thank you as well for the help! We will happily add you to the
 <a href="thanks-for-help.html">thanks</a> file as well.</p>
-<p>For more information see the “<strong>Large input size issues</strong>” section of
-<a href="2024/kurdyukov4/index.html#large-input-size-issues">2024/kurdyukov4/index.html</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <!--
 

--- a/bugs.md
+++ b/bugs.md
@@ -4845,6 +4845,43 @@ Jump to: [top](#)
 
 When printing a 0 digit, the `fib.bin` 4004 program will print a space instead of a "0".
 
+<div id="2024_ferguson1">
+## 2024/ferguson1
+</div>
+
+Jump to: [top](#)
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2024/ferguson1/prog.c](%%REPO_URL%%/2024/ferguson1/prog.c)
+### Information: [2024/ferguson1/index.html](2024/ferguson1/index.html)
+
+Upon starting this game you will immediately have a sinful night and playing it
+will lead you directly to a date with the Devil in HELL after things such as:
+
+- having delusions and hallucinations
+- engaging in robbery, accidental killings and cannibalism
+- engaging in or thinking about illicit affairs
+- encountering and trying to defend yourself against
+[Blackbeard](https://en.wikipedia.org/wiki/Blackbeard) aka Edward Teach on his
+flagship [Queen Anne's
+Revenge](https://en.wikipedia.org/wiki/Queen_Anne%27s_Revenge)
+- dying of dysentery
+- dying of starvation after all your oxen are consumed and nobody else is left
+- being eaten by a dragon
+- being eaten by Tyrannosauruses
+- eating [spaghetti](https://en.wikipedia.org/wiki/Goto) and [being strangled by
+it](https://en.wikipedia.org/wiki/Spaghetti_code)
+- encountering the [famous Spaghetti Tree](http://news.bbc.co.uk/onthisday/hi/dates/stories/april/1/newsid_2819000/2819261.stm)
+- and a whole host of other wild and exciting things!
+
+Whether or not you make it to Oregon Trail be prepared to meet the DEVIL in
+HELL!
+
+And MAKE SURE to say hi to
+[him](https://www.ioccc.org/authors.html#Cody_Boone_Ferguson)! :-)
+He is waiting. 😈
+
+
 <div id="2024_ferguson2">
 ## 2024/ferguson2
 </div>
@@ -4893,6 +4930,7 @@ The try.sh script demonstrates how you can often get the same output but because
 of words being multiple words (if it is not in the Navajo military dictionary)
 translation back to English is not perfect.
 
+Jump to: [top](#)
 
 <div id="2024_howe">
 ## 2024/howe
@@ -4975,6 +5013,8 @@ input sizes larger than 64K bytes.
 **PLEASE NOTE**: The above problems are **NOT** code bugs.  They represent compiler mis-features,
 linker limitations, and/or architecture limitations.
 
+For more information see the "**Large input size issues**" section of
+[2024/kurdyukov4/index.html](2024/kurdyukov4/index.html#large-input-size-issues).
 
 Jump to: [top](#)
 
@@ -4993,8 +5033,6 @@ request](https://github.com/ioccc-src/winner/pulls) or otherwise, we
 thank you as well for the help! We will happily add you to the
 [thanks](thanks-for-help.html) file as well.
 
-For more information see the "**Large input size issues**" section of
-[2024/kurdyukov4/index.html](2024/kurdyukov4/index.html#large-input-size-issues).
 
 Jump to: [top](#)
 

--- a/next/Makefile.example
+++ b/next/Makefile.example
@@ -42,7 +42,8 @@ TRUE= true
 #
 # Example: CSILENCE= -Wno-int-conversion
 #
-CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage -Wno-overriding-deployment-version
+CSILENCE= -Wno-poison-system-directories -Wno-unsafe-buffer-usage -Wno-overriding-deployment-version \
+	  -Wno-missing-variable-declarations -Wno-missing-prototypes
 
 # Attempt to silence unknown warning options
 #


### PR DESCRIPTION

Not that there aren't many other pointless warnings but clang whines 
about '"missing" prototypes' and '"missing" variable declarations'. What
it really means is that it wants you to put in static (or extern I guess
but that's irrelevant in the IOCCC as you're not supposed to include
your own header files to save bytes and for functions that is useless)
despite the fact a variable can't be used before it's declared (hence
not missing) and a function can't be called unless it's prototyped or
the function comes first (hence not missing either). This is not only
wasteful it is very annoying having to update the Makefile for every
submission every year. These warnings are pointless outside the IOCCC in 
many cases but they're especially pointless in the IOCCC.