### PR TITLE
Various fixes in 2025/ferguson

### DIFF
--- a/2025/ferguson/.entry.json
+++ b/2025/ferguson/.entry.json
@@ -155,7 +155,7 @@
             "OK_to_edit" : true,
             "display_as" : "image",
             "display_via_github" : false,
-            "entry_text" : "flat Earth submerged under water"
+            "entry_text" : "Flat Earth submerged under water"
         },
         {
             "file_path" : "flat.jpg",

--- a/2025/ferguson/README.md
+++ b/2025/ferguson/README.md
@@ -6,11 +6,20 @@ Award: Opposite award
     make all
 ```
 
+### Bugs and (Mis)features:
+
+The current status of this entry is:
+
+> **STATUS: INABIAF - please DO NOT fix**
+
+For more detailed information see [2025/ferguson in bugs.html](../../bugs.html#2025_ferguson).
+
+
 
 ## To use:
 
 ``` <!---sh-->
-    ./prog lat lon in.ppm out.ppm
+    ./prog lat lon [in.ppm out.ppm]
 ```
 
 
@@ -41,7 +50,7 @@ Award: Opposite award
 ## Judges' remarks:
 
 Digging the proverbial hole through the Earth can land up in some
-different places.  In this projection of a globe of Earth (because flat
+different places.  In this projection of a globe of Earth (because Flat
 Earth is an archaic and scientifically disproved concept) onto the screen,
 it can start in one place and find its antipode.
 

--- a/2025/ferguson/comments.html
+++ b/2025/ferguson/comments.html
@@ -475,12 +475,17 @@ Even so with the IOCCC it all is fine in my view.</p>
 with you why <strong>I</strong> do not support comments and why I don’t think I should if I
 even could (but can’t, especially not with size constraints after what I have
 done).</p>
-<p>First of all though the spec (although this might be from the library but if
-that’s not an authoritative source I don’t know what is!) should tell you a lot:</p>
+<p>First of all: though the spec (yes this is from the library but if that’s not an
+authoritative source I don’t know what is!) should tell you a lot (emphasis
+added by me):</p>
 <blockquote>
-<p>Strings starting with <code>"#"</code> may be comments, the same as with PBM.</p>
+<p>Strings starting with <code>"#"</code> <strong>may</strong> be comments, the same as with PBM.</p>
 </blockquote>
-<p>MAY be comments? How exactly am I supposed to deal with THAT?</p>
+<p>MAY be comments? How exactly am I supposed to deal with THAT? That would imply
+that I have to deal with more than one mode and this is a parser without a
+library and with serious size constraints imposed. As I get to later and perhaps
+in <a href="index.html">index.html</a> images do not need comments because images are
+viewed in image editors and they show the actual image not the data.</p>
 <p>As I note elsewhere later on: in files sometimes <code>#</code> exist and
 are not part of comments but actually data. The fact the spec is so ambiguous
 should say everything about it but it also means you have to modify or strip
@@ -499,9 +504,10 @@ multiple lines like:</p>
 like trailing spaces in some cases so I have vim remove them in markdown files).</p>
 <p>That is even more ambiguity and the more ambiguous a design (and the fact
 DOCUMENTATION says ‘MAY be a comment’ is hard to fathom) the worse the design
-is.</p>
-<p>It’s not a terrible image format: obviously. But the idea of comments was not
-well thought out.</p>
+is (that does not mean it’s not a good design for the IOCCC though and this also
+is a nice excuse to not add even more code).</p>
+<p>It’s actually not a terrible image format: obviously. But the idea of comments
+was not well thought out.</p>
 <p>But honestly images are not meant to be viewed in a text editor/viewer BECAUSE
 THEY ARE NOT TEXT FILES; they are meant to be viewed in a GRAPHICS/IMAGE viewer
 (or editor). It’s in the name I believe? :-)</p>

--- a/2025/ferguson/comments.md
+++ b/2025/ferguson/comments.md
@@ -25,12 +25,17 @@ with you why **I** do not support comments and why I don't think I should if I
 even could (but can't, especially not with size constraints after what I have
 done).
 
-First of all though the spec (although this might be from the library but if
-that's not an authoritative source I don't know what is!) should tell you a lot:
+First of all: though the spec (yes this is from the library but if that's not an
+authoritative source I don't know what is!) should tell you a lot (emphasis
+added by me):
 
-> Strings starting with `"#"` may be comments, the same as with PBM.
+> Strings starting with `"#"` **may** be comments, the same as with PBM.
 
-MAY be comments? How exactly am I supposed to deal with THAT?
+MAY be comments? How exactly am I supposed to deal with THAT? That would imply
+that I have to deal with more than one mode and this is a parser without a
+library and with serious size constraints imposed. As I get to later and perhaps
+in [index.html](index.html) images do not need comments because images are
+viewed in image editors and they show the actual image not the data.
 
 As I note elsewhere later on: in files sometimes `#` exist and
 are not part of comments but actually data. The fact the spec is so ambiguous
@@ -60,10 +65,11 @@ like trailing spaces in some cases so I have vim remove them in markdown files).
 
 That is even more ambiguity and the more ambiguous a design (and the fact
 DOCUMENTATION says 'MAY be a comment' is hard to fathom) the worse the design
-is.
+is (that does not mean it's not a good design for the IOCCC though and this also
+is a nice excuse to not add even more code).
 
-It's not a terrible image format: obviously. But the idea of comments was not
-well thought out.
+It's actually not a terrible image format: obviously. But the idea of comments
+was not well thought out.
 
 But honestly images are not meant to be viewed in a text editor/viewer BECAUSE
 THEY ARE NOT TEXT FILES; they are meant to be viewed in a GRAPHICS/IMAGE viewer

--- a/2025/ferguson/index.html
+++ b/2025/ferguson/index.html
@@ -476,8 +476,14 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>Award: Opposite award</p>
 <h2 id="to-build">To build:</h2>
 <pre><code>    make all</code></pre>
+<h3 id="bugs-and-misfeatures">Bugs and (Mis)features:</h3>
+<p>The current status of this entry is:</p>
+<blockquote>
+<p><strong>STATUS: INABIAF - please DO NOT fix</strong></p>
+</blockquote>
+<p>For more detailed information see <a href="../../bugs.html#2025_ferguson">2025/ferguson in bugs.html</a>.</p>
 <h2 id="to-use">To use:</h2>
-<pre><code>    ./prog lat lon in.ppm out.ppm</code></pre>
+<pre><code>    ./prog lat lon [in.ppm out.ppm]</code></pre>
 <h2 id="try">Try:</h2>
 <pre><code>    ./try.sh</code></pre>
 <h2 id="alternate-code">Alternate code:</h2>
@@ -487,7 +493,7 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <pre><code>    ./try.alt.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>Digging the proverbial hole through the Earth can land up in some
-different places. In this projection of a globe of Earth (because flat
+different places. In this projection of a globe of Earth (because Flat
 Earth is an archaic and scientifically disproved concept) onto the screen,
 it can start in one place and find its antipode.</p>
 <p>We think you will have fun to see what is on the other side.</p>
@@ -3059,7 +3065,7 @@ triangular.<a href="#fnref10" class="footnote-back" role="doc-backlink">↩︎</
 <li><a href="china.ppm">china.ppm</a> - image locating China and its antipode</li>
 <li><a href="continents.png">continents.png</a> - image locating various continents and their antipodes</li>
 <li><a href="earth.ppm">earth.ppm</a> - Blue Marble equirectangular map of the Earth</li>
-<li><a href="flat-earth.ppm">flat-earth.ppm</a> - flat Earth submerged under water</li>
+<li><a href="flat-earth.ppm">flat-earth.ppm</a> - Flat Earth submerged under water</li>
 <li><a href="noclouds.ppm">noclouds.ppm</a> - Blue Marble Next Generation without clouds</li>
 <li><a href="sealand.ppm">sealand.ppm</a> - image locating Sealand and its antipode</li>
 <li><a href="snaefellsjokull.png">snaefellsjokull.png</a> - image locating Snæfellsjökull Iceland and its antipode</li>

--- a/2025/ferguson/prog.c
+++ b/2025/ferguson/prog.c
@@ -41,15 +41,15 @@
 		       while(U<-90)U=-R-U; C"%f %f\n",L=-U,lo=tr<0?R+tr:-(R -
 		      tr)); if ( g > 3) { if(!(q=fopen(f [g -2] , "r")))E(f[ 3
 		     ]); if (m (lo,tr, (J=u,H=d +4,I=J -H,D =* (S +u-1)+1,d  -=
-		    *(*(S+7)+ 6),L))||b^j*2)X; c=calloc(1,(F=9,H**Q*j)),x=- (tr
+		    *(*(S+7)+ 6),L))||b^j*2)X; c=calloc(1,(F=9,H**Q*j)),x=-  (tr
 		   +R) **Q/T,d=c==e!=d,Y=(lo+R)**Q/T,d=c!=e!=d!=d==2*d,d*=2, y =-
 		  (-U +90) *j /R,x =- x,Z =(-L+90) *j /R,d=!-!(c!=e)!=d-1!=d+1,  x
 		 =-x ,Y=-Y,Y=-Y,d=-!-!(c!=e)==d,Y=-Y,d=-d,x=-x,x=-x,d=c==e!=d==!( c
 		==e)!=d/2,d=d/2; /* CHANGE != 1 AND PROVE d IS 1 */ if  (d=(c!=e==!d
 	       !=d!=d==1&&e!=c)!=1||/* NOW YOU KNOW d IS 1! */fread(c, -*(S[F])-d*3 ,
-	      b*j,q)^j *j *2)X; m(Y=-Y,Z,B=4); m(-x,- y,(--u,t+=F,++B,7)); fclose ( q
+	      b*j,q)^j *j *2)X; m(Y=-Y,Z,B=4); m(-x,- y,(--u,t+=F,++B,7)) ; fclose ( q
 	     ); q=fopen(f[--g],"w"); if(!q)E(f[4]); m(Y,Z, (++ u,--t,0)); if (fprintf (
-	    q, "P6 %zu %zu %zu ",b,j,n) <0||fwrite(e,3,*Q*j,q) ^b * j) l "Hollow Earth"
+	    q, "P6 %zu %zu %zu ",b,j,n) <0||fwrite(e,3,*Q*j,q) ^ b * j) l "Hollow Earth"
 	   ); free(e); fclose(q) ; } } int m ( double a, double p, long s ){ if (a - 64 <
 	  0) a=31; if(p-64 <0)p=31; if(p +64 >=j)p=j-31; if(a+64 >=b)a=b-31; for ( V = &S[
          u][(z=(*(S+4))[*(*(S+3)+1)],S[t][B])]; !(*(S+d)[*V]&*V)&&z<2-*(*(S+5)+3); ++z) for

--- a/2025/ferguson/small.c
+++ b/2025/ferguson/small.c
@@ -4,7 +4,7 @@
  * without floating point you have the problem of truncation. I also believe I
  * had (did not really look) this program clamp out of range coordinates but
  * despite my jokes our Earth is not flat (it's actually tetrahedral! Roundish
- * yes but still a tetrahedron) so when one goes to the edge of the world they
+ * yes but still a tetrahedron[0]) so when one goes to the edge of the world they
  * do not fall off the edge.
  *
  * The point of including this file is so you can see how small the arrows were
@@ -14,7 +14,12 @@
  * A program calculating antipodes simply MUST use floating points.
  *
  * Nonetheless you do get to see how the arrows were 'rendered' in that the
- * arrays are simple with ones and zeros and not interleaved.
+ * arrays are simple with ones and zeros and not interleaved. Even so I needed
+ * to make it so the arrows were a lot bigger so that I myself (and many others)
+ * could actually see it!
+ *
+ * [0]: yes this is also a joke. Obviously it's triangular. Or spherical. I
+ * think :-)
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/bugs.html
+++ b/bugs.html
@@ -465,6 +465,7 @@ below and you wish to help with a year, you can use these links:</p>
 <li><a href="#2004">2004 entries</a> | <a href="#2005">2005 entries</a> | <a href="#2006">2006 entries</a> | <a href="#2011">2011 entries</a></li>
 <li><a href="#2012">2012 entries</a> | <a href="#2013">2013 entries</a> | <a href="#2014">2014 entries</a> | <a href="#2015">2015 entries</a></li>
 <li><a href="#2018">2018 entries</a> | <a href="#2019">2019 entries</a> | <a href="#2020">2020 entries</a> | <a href="#2024">2024 entries</a></li>
+<li><a href="#2025">2025 entries</a></li>
 </ul>
 <p>Jump to: <a href="#">top</a></p>
 <h2 id="please-read-the-next-sections-if-you-wish-to-help">PLEASE read the next sections if you wish to help</h2>
@@ -3704,6 +3705,21 @@ linker limitations, and/or architecture limitations.</p>
 <p>For more information see the “<strong>Large input size issues</strong>” section of
 <a href="2024/kurdyukov4/index.html#large-input-size-issues">2024/kurdyukov4/index.html</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
+<hr style="width:10%;text-align:left;margin-left:0">
+<div id="2025">
+<h1 id="section-41">2025</h1>
+</div>
+<hr style="width:10%;text-align:left;margin-left:0">
+<p>Jump to: <a href="#">top</a></p>
+<h3 id="status-inabiaf---please-do-not-fix-102">STATUS: INABIAF - please <strong>DO NOT</strong> fix</h3>
+<h3 id="source-code-2025fergusonprog.c">Source code: <a href="https://github.com/ioccc-src/winner/blob/master/2025/ferguson/prog.c">2025/ferguson/prog.c</a></h3>
+<h3 id="information-2025fergusonindex.html">Information: <a href="2025/ferguson/index.html">2025/ferguson/index.html</a></h3>
+<p>This program necessarily scales the arrows to a larger size for those who, like
+the author, cannot see them otherwise. This means that locations are a bit off
+<strong>on the rendered map</strong>, especially when coordinates are not on the edge of the
+map (even so it might or might not be that part of the arrow is in the ‘right’
+place and in all cases obviously only a part of the arrow can be in the correct
+place).</p>
 <hr style="width:10%;text-align:left;margin-left:0">
 <div id="final_words">
 <h1 id="final-words">Final words</h1>

--- a/bugs.md
+++ b/bugs.md
@@ -14,6 +14,7 @@ below and you wish to help with a year, you can use these links:
 - [2004 entries](#2004) |       [2005 entries](#2005)   |       [2006 entries](#2006)   |       [2011 entries](#2011)
 - [2012 entries](#2012) |       [2013 entries](#2013)   |       [2014 entries](#2014)   |       [2015 entries](#2015)
 - [2018 entries](#2018) |       [2019 entries](#2019)   |       [2020 entries](#2020)   |       [2024 entries](#2024)
+- [2025 entries](#2025)
 
 Jump to: [top](#)
 
@@ -4983,6 +4984,25 @@ For more information see the "**Large input size issues**" section of
 
 
 Jump to: [top](#)
+
+<hr style="width:10%;text-align:left;margin-left:0">
+<div id="2025">
+# 2025
+</div>
+<hr style="width:10%;text-align:left;margin-left:0">
+
+Jump to: [top](#)
+
+### STATUS: INABIAF - please **DO NOT** fix
+### Source code: [2025/ferguson/prog.c](%%REPO_URL%%/2025/ferguson/prog.c)
+### Information: [2025/ferguson/index.html](2025/ferguson/index.html)
+
+This program necessarily scales the arrows to a larger size for those who, like
+the author, cannot see them otherwise. This means that locations are a bit off
+**on the rendered map**, especially when coordinates are not on the edge of the
+map (even so it might or might not be that part of the arrow is in the 'right'
+place and in all cases obviously only a part of the arrow can be in the correct
+place).
 
 
 <hr style="width:10%;text-align:left;margin-left:0">


### PR DESCRIPTION
Slight format fix in prog.c.

Comments update in small.c. (which as the comments already stated it is NOT correct for all coordinates as it uses longs instead of floating points and that means negative zero will not work). This is an experiment and demonstration, as noted below.

Added INABIAF to bugs.html - telling about how the arrows are scaled up in size so on the map the arrows can be a bit off. That is necessary for people like me who have rubbish vision. It is by design. The small.c was an experiment and it is a demonstration of why floating point is necessary, plus it shows how smaller arrows are a bad idea.

Minor update to .entry.json - changed 'flat Earth' (part of the running joke in the code and remarks) to 'Flat Earth' to match the Flat Earthers (even though our Earth is really a flat triangular cuboctahedron).

Regenerated html files.