### PR TITLE
Update 2025/uellenberg docs

### DIFF
--- a/2025/uellenberg/.entry.json
+++ b/2025/uellenberg/.entry.json
@@ -49,9 +49,9 @@
             "file_path" : "prog.int",
             "inventory_order" : 100,
             "OK_to_edit" : true,
-            "display_as" : "java",
+            "display_as" : "javascript",
             "display_via_github" : true,
-            "entry_text" : "java source code"
+            "entry_text" : "human-readable source code"
         },
         {
             "file_path" : "try.alt.sh",

--- a/2025/uellenberg/README.md
+++ b/2025/uellenberg/README.md
@@ -48,12 +48,38 @@ IOCCC submission.
 
 ### A fun challenge
 
+
+#### Fun challenge 0
+
 Write alternate version of [try.sh](https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/try.sh)
 that detects when the quasi-quine, left to its own iterative devices, starts to repeat.
 
 If you do not attempt to move the paddle, and let the game run on its
 own, the game will "evolve" to other "modes", and eventually cycle back
 to the original style of game play.
+
+The above fun challenge is **still open**.
+See the "[Fun challenge Info](../index.html#fun_challenge_info)" section for details.
+
+#### Fun challenge 1
+
+Implement an additional game mode using only the original game objects
+(the ball and two paddles).
+For example, you could implement a "flappy bird" game using the ball
+as the bird and the paddles as the pipes.
+
+As an extra challenge, try to keep the original behavior of the program
+the same, with this new game mode added on top.
+
+The above fun challenge is **still open**.
+See the "[Fun challenge Info](../index.html#fun_challenge_info)" section for details.
+
+
+#### Fun challenge 2
+
+Create a version of the game that "plays itself", running through all
+the gameplay without user input and returning to the exact source code
+it started with.
 
 The above fun challenge is **still open**.
 See the "[Fun challenge Info](../index.html#fun_challenge_info)" section for details.
@@ -89,7 +115,7 @@ and compile-time evaluation. And the best part? There's a source file
 out there, just waiting to be read. Comprehendible variable names,
 comments explaining the justification for every block of code, and not
 a magic number in sight (well, maybe a few - no one's perfect). Imagine
-that! Don't believe me? [Let me show you](./prog.int).
+that! Don't believe me? [Let me show you](%%REPO_URL%%/2025/uellenberg/prog.int).
 
 If you want to take a closer look at the code, [prog.c](%%REPO_URL%%/2025/uellenberg/prog.c)
 is the obfuscated version of the code, [prog.alt.c](%%REPO_URL%%/2025/uellenberg/prog.alt.c) is

--- a/2025/uellenberg/index.html
+++ b/2025/uellenberg/index.html
@@ -490,11 +490,27 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 <p>Nevertheless, please resist the urge to write “Quine Doom” as a next year’s
 IOCCC submission.</p>
 <h3 id="a-fun-challenge">A fun challenge</h3>
+<h4 id="fun-challenge-0">Fun challenge 0</h4>
 <p>Write alternate version of <a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/try.sh">try.sh</a>
 that detects when the quasi-quine, left to its own iterative devices, starts to repeat.</p>
 <p>If you do not attempt to move the paddle, and let the game run on its
 own, the game will “evolve” to other “modes”, and eventually cycle back
 to the original style of game play.</p>
+<p>The above fun challenge is <strong>still open</strong>.
+See the “<a href="../index.html#fun_challenge_info">Fun challenge Info</a>” section for details.</p>
+<h4 id="fun-challenge-1">Fun challenge 1</h4>
+<p>Implement an additional game mode using only the original game objects
+(the ball and two paddles).
+For example, you could implement a “flappy bird” game using the ball
+as the bird and the paddles as the pipes.</p>
+<p>As an extra challenge, try to keep the original behavior of the program
+the same, with this new game mode added on top.</p>
+<p>The above fun challenge is <strong>still open</strong>.
+See the “<a href="../index.html#fun_challenge_info">Fun challenge Info</a>” section for details.</p>
+<h4 id="fun-challenge-2">Fun challenge 2</h4>
+<p>Create a version of the game that “plays itself”, running through all
+the gameplay without user input and returning to the exact source code
+it started with.</p>
 <p>The above fun challenge is <strong>still open</strong>.
 See the “<a href="../index.html#fun_challenge_info">Fun challenge Info</a>” section for details.</p>
 <h2 id="authors-remarks">Author’s remarks:</h2>
@@ -521,7 +537,7 @@ and compile-time evaluation. And the best part? There’s a source file
 out there, just waiting to be read. Comprehendible variable names,
 comments explaining the justification for every block of code, and not
 a magic number in sight (well, maybe a few - no one’s perfect). Imagine
-that! Don’t believe me? <a href="./prog.int">Let me show you</a>.</p>
+that! Don’t believe me? <a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.int">Let me show you</a>.</p>
 <p>If you want to take a closer look at the code, <a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.c">prog.c</a>
 is the obfuscated version of the code, <a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.alt.c">prog.alt.c</a> is
 a version with indentation and newlines and without define compression
@@ -808,7 +824,7 @@ leaving it on hold for now.</p>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/Makefile">Makefile</a> - entry Makefile</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.alt.c">prog.alt.c</a> - alternate source code</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.orig.c">prog.orig.c</a> - original source code</li>
-<li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.int">prog.int</a> - java source code</li>
+<li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/prog.int">prog.int</a> - human-readable source code</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/try.alt.sh">try.alt.sh</a> - script to try alternate code</li>
 <li><a href="https://github.com/ioccc-src/winner/blob/master/2025/uellenberg/try.sh">try.sh</a> - script to try entry</li>
 </ul>


### PR DESCRIPTION
* Changed prog.int's name to be more clear, and to javascript since it resembles the actual language the closest out of all options.
* Added two new fun challenges.
* Fixed the first link to prog.int, which prompted the user to download when pressed and was inconsistent with the rest of the links.