### PR TITLE
For BSDs do NOT set MAKE macro; make will set it according to how

### DIFF
--- a/2025/var.mk
+++ b/2025/var.mk
@@ -162,7 +162,8 @@ LZLESS= lzless
 LZMA= lzma
 LZMORE= lzmore
 M4= m4
-MAKE= make
+# DO NOT SET.  Make assigns this variable as "make" or "gmake"
+#MAKE= make
 MAN= man
 MANDOC= mandoc
 MANPATH= manpath


### PR DESCRIPTION
it is invoked (make or gmake).