### PR TITLE
Fix 2025/jhshrvdp to include curses.h instead of ncurses.h; Ncurses

### DIFF
--- a/2025/jhshrvdp/prog.c
+++ b/2025/jhshrvdp/prog.c
@@ -2,7 +2,7 @@
                                           #define m 1920
                                               #include<time.h>
                                                #include<stdlib.h>
-                                              # include <ncurses.h>
+                                              # include <curses.h>
                                            #define J for(i=l;i<m;++i)
                                         #define X i=N(),x=i %(l),y=i/l
                                 #define B(y,x) ((mvinch((y),(x))&255))

--- a/2025/jhshrvdp/prog.orig.c
+++ b/2025/jhshrvdp/prog.orig.c
@@ -2,7 +2,7 @@
                                           #define m 1920
                                               #include<time.h>
                                                #include<stdlib.h>
-                                              # include <ncurses.h>
+                                              # include <curses.h>
                                            #define J for(i=l;i<m;++i)
                                         #define X i=N(),x=i %(l),y=i/l
                                 #define B(y,x) ((mvinch((y),(x))&255))


### PR DESCRIPTION
supports curses.h as an alternative name and for backwards compatibility.