### PR TITLE
Fix typos in 2025/cesmoak README.md (and regenerated index.html)

### DIFF
--- a/2025/cesmoak/README.md
+++ b/2025/cesmoak/README.md
@@ -31,7 +31,7 @@ Award: Retro space award
 
     ./try_tools.sh
 
-    # NOTE: try.sh might might take 9 - 18 hours
+    # NOTE: try.sh might take 9 - 18 hours
 
     ./try.sh
 ```
@@ -40,7 +40,7 @@ Award: Retro space award
 ## Judges' remarks:
 
 Black holes are known to distort space and time.  Fortran depends on
-character spaces, and stool the test of time.  And with this marvelous
+character spaces, and stood the test of time.  And with this marvelous
 entry, you experience both, and more!
 
 Since the age of 4, back in 1964, one of the
@@ -52,7 +52,7 @@ many more of them too.
 
 Do you know your [punch card extended character
 set](https://en.wikipedia.org/wiki/Punched_card#/media/File:Blue-punch-card-front-horiz.png)?
-If might help you decode some of the intermediate output without having to compile.  ;-)
+It might help you decode some of the intermediate output without having to compile.  ;-)
 
 
 ### A fun challenge
@@ -75,7 +75,7 @@ To see what it may produce, see:
 
 * download mandelbrot.ppm as out.mandelbrot.ppm ==> [2025/cesmoak/out.mandelbrot.ppm](out.mandelbrot.ppm)
 * download march.ppm as out.march.ppm ==> [2025/cesmoak/out.march.ppm](out.march.ppm)
-* download tracer.ppm as out.tracer.pgm.tracer.ppm ==> [2025/cesmoak/out.tracer.pgm](out.tracer.pgm)
+* download tracer.pgm as out.tracer.pgm ==> [2025/cesmoak/out.tracer.pgm](out.tracer.pgm)
 
 View the downloaded ppm files with your favorite image viewer.
 
@@ -88,7 +88,7 @@ To see what it may produce, see:
 
 * view prog.deck ==> [2025/cesmoak/out.prog.deck](%%REPO_URL%%/2025/cesmoak/out.prog.deck)
 * download paper.pgm as out.paper.pgm ==> [2025/cesmoak/out.paper.pgm](out.paper.pgm)
-* download print.pgm as out.print.ppm ==> [2025/cesmoak/out.print.pgm](out.print.pgm)
+* download print.pgm as out.print.pgm ==> [2025/cesmoak/out.print.pgm](out.print.pgm)
 
 View the downloaded ppm files with your favorite image viewer.
 
@@ -111,14 +111,14 @@ To see what it may produce, see:
 * download render_60x30.pgm as out.render_60x30.pgm ==> [2025/cesmoak/out.render_60x30.pgm](out.render_60x30.pgm)
 * download print_160x80.pgm as out.print_160x80.pgm ==> [2025/cesmoak/out.print_160x80.pgm](out.print_160x80.pgm)
 * download print_480x240.pgm as out.print_480x240.pgm ==> [2025/cesmoak/out.print_480x240.pgm](out.print_480x240.pgm)
-* download print_1200x600.pgm as out_1200x600.pgm ==> [2025/cesmoak/out.print_1200x600.pgm](out.print_1200x600.pgm)
+* download print_1200x600.pgm as out.print_1200x600.pgm ==> [2025/cesmoak/out.print_1200x600.pgm](out.print_1200x600.pgm)
 
 View the downloaded pgm files with your favorite image viewer.
 
 
 ### A fun challenge
 
-Write a "textual Fortran" program to to something else interesting,
+Write a "textual Fortran" program to do something else interesting,
 such as to print a fractal curve, print the value of pi to 1000
 decimal places, or count the number of months ending in Tuesday
 for a given century.
@@ -268,6 +268,7 @@ flux program. Tools have been provided to convert to/from decks and to
 interpret (using the punch card meaning, i.e., annotate with text) decks.
 
 Supported features:
+
 - `REAL`, `COMPLEX`, and `LOGICAL` types
 - Variables and assignment statements (only the first 3 characters of variable names are significant)
 - Arithmetic operators: binary `+`,  `-`,  `*`,  `/`,  `**` (integer divide is not supported), and unary `-` (unary `+` is not supported)
@@ -294,7 +295,7 @@ Notable FORTRAN 66 features that have been faithfully replicated for your enjoym
 
 Missing from FORTRAN III.5: `READ`, `FUNCTION`, `SUBROUTINE`, arrays, `DATA` blocks, `INTEGER` type, etc.
 
-Fortran has a several unique behaviors:
+Fortran has several unique behaviors:
 
 - Unary `-` has an unusual precedence compared with most languages: it is lower precedence than `**`, and `*`, `/`
 - The spec says that `**` doesn't support left- or right-association and is not allowed to be chained without parentheses. This processor uses left-association for all operators and allows them to be chained.

--- a/2025/cesmoak/index.html
+++ b/2025/cesmoak/index.html
@@ -493,12 +493,12 @@ Location: <a href="../../location.html#US">US</a> - <em>United States of America
 
     ./try_tools.sh
 
-    # NOTE: try.sh might might take 9 - 18 hours
+    # NOTE: try.sh might take 9 - 18 hours
 
     ./try.sh</code></pre>
 <h2 id="judges-remarks">Judges’ remarks:</h2>
 <p>Black holes are known to distort space and time. Fortran depends on
-character spaces, and stool the test of time. And with this marvelous
+character spaces, and stood the test of time. And with this marvelous
 entry, you experience both, and more!</p>
 <p>Since the age of 4, back in 1964, one of the
 judges has fond memories of playing at an
@@ -508,7 +508,7 @@ cards made excellent card towers: much better than playing cards, and
 many more of them too.</p>
 <p>Do you know your <a href="https://en.wikipedia.org/wiki/Punched_card#/media/File:Blue-punch-card-front-horiz.png">punch card extended character
 set</a>?
-If might help you decode some of the intermediate output without having to compile. ;-)</p>
+It might help you decode some of the intermediate output without having to compile. ;-)</p>
 <h3 id="a-fun-challenge">A fun challenge</h3>
 <p>Generate an alternative version of <a href="https://github.com/ioccc-src/winner/blob/master/2025/cesmoak/prog.c">prog.c</a>, named <code>prog.alt.c</code>,
 that supports the FORTRAN <strong>READ</strong> statement.</p>
@@ -522,7 +522,7 @@ To see what it may produce, see:</p>
 <ul>
 <li>download mandelbrot.ppm as out.mandelbrot.ppm ==&gt; <a href="out.mandelbrot.ppm">2025/cesmoak/out.mandelbrot.ppm</a></li>
 <li>download march.ppm as out.march.ppm ==&gt; <a href="out.march.ppm">2025/cesmoak/out.march.ppm</a></li>
-<li>download tracer.ppm as out.tracer.pgm.tracer.ppm ==&gt; <a href="out.tracer.pgm">2025/cesmoak/out.tracer.pgm</a></li>
+<li>download tracer.pgm as out.tracer.pgm ==&gt; <a href="out.tracer.pgm">2025/cesmoak/out.tracer.pgm</a></li>
 </ul>
 <p>View the downloaded ppm files with your favorite image viewer.</p>
 <h4 id="try_rpg.sh">try_rpg.sh</h4>
@@ -532,7 +532,7 @@ To see what it may produce, see:</p>
 <ul>
 <li>view prog.deck ==&gt; <a href="https://github.com/ioccc-src/winner/blob/master/2025/cesmoak/out.prog.deck">2025/cesmoak/out.prog.deck</a></li>
 <li>download paper.pgm as out.paper.pgm ==&gt; <a href="out.paper.pgm">2025/cesmoak/out.paper.pgm</a></li>
-<li>download print.pgm as out.print.ppm ==&gt; <a href="out.print.pgm">2025/cesmoak/out.print.pgm</a></li>
+<li>download print.pgm as out.print.pgm ==&gt; <a href="out.print.pgm">2025/cesmoak/out.print.pgm</a></li>
 </ul>
 <p>View the downloaded ppm files with your favorite image viewer.</p>
 <h4 id="try_tools.sh">try_tools.sh</h4>
@@ -550,11 +550,11 @@ To see what it may produce, see:</p>
 <li>download render_60x30.pgm as out.render_60x30.pgm ==&gt; <a href="out.render_60x30.pgm">2025/cesmoak/out.render_60x30.pgm</a></li>
 <li>download print_160x80.pgm as out.print_160x80.pgm ==&gt; <a href="out.print_160x80.pgm">2025/cesmoak/out.print_160x80.pgm</a></li>
 <li>download print_480x240.pgm as out.print_480x240.pgm ==&gt; <a href="out.print_480x240.pgm">2025/cesmoak/out.print_480x240.pgm</a></li>
-<li>download print_1200x600.pgm as out_1200x600.pgm ==&gt; <a href="out.print_1200x600.pgm">2025/cesmoak/out.print_1200x600.pgm</a></li>
+<li>download print_1200x600.pgm as out.print_1200x600.pgm ==&gt; <a href="out.print_1200x600.pgm">2025/cesmoak/out.print_1200x600.pgm</a></li>
 </ul>
 <p>View the downloaded pgm files with your favorite image viewer.</p>
 <h3 id="a-fun-challenge-1">A fun challenge</h3>
-<p>Write a “textual Fortran” program to to something else interesting,
+<p>Write a “textual Fortran” program to do something else interesting,
 such as to print a fractal curve, print the value of pi to 1000
 decimal places, or count the number of months ending in Tuesday
 for a given century.</p>
@@ -636,22 +636,24 @@ provided as a deck of punch cards. Several programs have been included
 for demonstration purposes, including a pre-obfuscation version of the
 flux program. Tools have been provided to convert to/from decks and to
 interpret (using the punch card meaning, i.e., annotate with text) decks.</p>
-<p>Supported features:
-- <code>REAL</code>, <code>COMPLEX</code>, and <code>LOGICAL</code> types
-- Variables and assignment statements (only the first 3 characters of variable names are significant)
-- Arithmetic operators: binary <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>**</code> (integer divide is not supported), and unary <code>-</code> (unary <code>+</code> is not supported)
-- Arithmetic -&gt; Logical operators: <code>.LT.</code>, <code>.LE.</code>, <code>.GT.</code>, <code>.GE.</code>, <code>.EQ.</code>, <code>.NE.</code>
-- Logical operators: <code>.AND.</code>, <code>.OR.</code>, <code>.NOT.</code>
-- Operator precedence is as expected
-- A standard library of <em>several</em> functions: <code>ABS(x)</code>, <code>ALOG(x)</code>, <code>AMOD(x,y)</code>, <code>SIN(x)</code>, <code>COS(x)</code>, <code>CMPLX(r,i)</code>, <code>REAL(c)</code>, <code>AIMAG(c)</code>, <code>CABS(c)</code> (This is a selection of intrinsic and external functions from the specification.)
-- <code>GOTO</code> with a single numeric label
-- <code>ASSIGN</code> <code>TO</code>
-- Logical <code>IF</code>
-- <code>DO</code> loops with optional step, and support for extended range loops (<code>GOTO</code> out of a loop and then back into it)
-- <code>WRITE</code> statements (file argument is ignored, will always write to <code>stdout</code>)
-- <code>FORMAT</code> statements with support for outputting integers <code>In</code>, reals <code>Fn.m</code>, spaces <code>nX</code>, and Hollerith constants <code>nHx</code> (<code>m</code> is single-digit only; Hollerith constants do not support space – use <code>nX</code> for this; no repeat counts, no grouping parentheses, no <code>/</code>, arguments do not loop if fewer than number of arguments in a corresponding <code>WRITE</code>)
-- Comments (line starts with <code>C</code>)
-- <code>CONTINUE</code></p>
+<p>Supported features:</p>
+<ul>
+<li><code>REAL</code>, <code>COMPLEX</code>, and <code>LOGICAL</code> types</li>
+<li>Variables and assignment statements (only the first 3 characters of variable names are significant)</li>
+<li>Arithmetic operators: binary <code>+</code>, <code>-</code>, <code>*</code>, <code>/</code>, <code>**</code> (integer divide is not supported), and unary <code>-</code> (unary <code>+</code> is not supported)</li>
+<li>Arithmetic -&gt; Logical operators: <code>.LT.</code>, <code>.LE.</code>, <code>.GT.</code>, <code>.GE.</code>, <code>.EQ.</code>, <code>.NE.</code></li>
+<li>Logical operators: <code>.AND.</code>, <code>.OR.</code>, <code>.NOT.</code></li>
+<li>Operator precedence is as expected</li>
+<li>A standard library of <em>several</em> functions: <code>ABS(x)</code>, <code>ALOG(x)</code>, <code>AMOD(x,y)</code>, <code>SIN(x)</code>, <code>COS(x)</code>, <code>CMPLX(r,i)</code>, <code>REAL(c)</code>, <code>AIMAG(c)</code>, <code>CABS(c)</code> (This is a selection of intrinsic and external functions from the specification.)</li>
+<li><code>GOTO</code> with a single numeric label</li>
+<li><code>ASSIGN</code> <code>TO</code></li>
+<li>Logical <code>IF</code></li>
+<li><code>DO</code> loops with optional step, and support for extended range loops (<code>GOTO</code> out of a loop and then back into it)</li>
+<li><code>WRITE</code> statements (file argument is ignored, will always write to <code>stdout</code>)</li>
+<li><code>FORMAT</code> statements with support for outputting integers <code>In</code>, reals <code>Fn.m</code>, spaces <code>nX</code>, and Hollerith constants <code>nHx</code> (<code>m</code> is single-digit only; Hollerith constants do not support space – use <code>nX</code> for this; no repeat counts, no grouping parentheses, no <code>/</code>, arguments do not loop if fewer than number of arguments in a corresponding <code>WRITE</code>)</li>
+<li>Comments (line starts with <code>C</code>)</li>
+<li><code>CONTINUE</code></li>
+</ul>
 <p>Notable FORTRAN 66 features that have been faithfully replicated for your enjoyment:</p>
 <ul>
 <li>The simplicity of ALL CAPS and a full 47 character set!</li>
@@ -660,7 +662,7 @@ interpret (using the punch card meaning, i.e., annotate with text) decks.</p>
 </ul>
 <p><code>END</code>, <code>PROGRAM</code>, and some other statements are silently ignored.</p>
 <p>Missing from FORTRAN III.5: <code>READ</code>, <code>FUNCTION</code>, <code>SUBROUTINE</code>, arrays, <code>DATA</code> blocks, <code>INTEGER</code> type, etc.</p>
-<p>Fortran has a several unique behaviors:</p>
+<p>Fortran has several unique behaviors:</p>
 <ul>
 <li>Unary <code>-</code> has an unusual precedence compared with most languages: it is lower precedence than <code>**</code>, and <code>*</code>, <code>/</code></li>
 <li>The spec says that <code>**</code> doesn’t support left- or right-association and is not allowed to be chained without parentheses. This processor uses left-association for all operators and allows them to be chained.</li>


### PR DESCRIPTION
- judges' remarks: "stool" -> "stood"; "If might help" -> "It might help"
- Try section: "try.sh might might take" -> "might take"
- fun challenge: "program to to something" -> "program to do something"
- Fortran processor: "Fortran has a several" -> "several"
- For-the-impatient lists: correct the download filenames to match the links (out.tracer.pgm, out.print.pgm, out.print_1200x600.pgm)
