### PR TITLE
Typo fixes/improvements to IOCCC29 challenges

### DIFF
--- a/2025/challenge.html
+++ b/2025/challenge.html
@@ -462,77 +462,70 @@ IOCCC entry. Other fun challenges ask you to produce a variant of the
 <code>prog.c</code> program that has a different or enhanced behaviour. And still,
 other types of fun challenges may be posed.</p>
 <p><strong>NOTE</strong>: Some of these challenges are easier than others.</p>
-<p>See also the
+<p>See the
 FAQ on “<a href="../faq.html#what_fun_challenge">fun challenges</a>”
 and, to provide a solution, the
 FAQ on “<a href="../faq.html#solve_fun_challenge">submitting a solution to a fun
-challenge</a>”.</p>
+challenge</a>”,
+as well as the
+FAQ on “<a href="../faq.html#pull_request">opening a pull request</a>”.</p>
 <div id="ayu">
 <h2 id="fun-challenge-for-2025ayu">Fun challenge for <a href="ayu/index.html">2025/ayu</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/ayu</strong> is <strong>CLOSED</strong>.</p>
+<p>This fun challenge is <strong>CLOSED</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code allows for <code>N</code> to be
 defined for values larger than <code>11</code>, e.g., that works with <code>-DN=12</code>,
 and up to some reasonable limit.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ayu_solution">
 <h3 id="fun-challenge-solution-for-2025ayu">Fun challenge solution for <a href="ayu/index.html">2025/ayu</a></h3>
 </div>
 <p><a href="https://github.com/Master-Hash">Master-Hash</a> on <strong>2026 Jun 09</strong> presented this
 <a href="https://github.com/Master-Hash/ioccc--ayu-2025-fun-challenge">2025/ayu fun challenge solution</a>.</p>
 <div id="cable">
-<h2 id="fun-challenge-for-2025cable">Fun challenge for <a href="cable/index.html">2025/cable</a></h2>
+<h2 id="fun-challenges-for-2025cable">Fun challenges for <a href="cable/index.html">2025/cable</a></h2>
 </div>
 <div id="cable_0">
-<h3 id="fun-challenge-0">Fun challenge 0</h3>
+<h3 id="fun-challenge-0-for-2025cable">Fun challenge 0 for <a href="cable/index.html">2025/cable</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/cable</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Use the <a href="https://github.com/adriancable/eternal">toolchain</a> to compile your own
 software to run on this VM.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="cable_1">
-<h3 id="fun-challenge-1">Fun challenge 1</h3>
+<h3 id="fun-challenge-1-for-2025cable">Fun challenge 1 for <a href="cable/index.html">2025/cable</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/cable</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Produce a variant of the vmlinux bootimage that contains a C compiler for this
 VM.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="cesmoak">
 <h2 id="fun-challenge-for-2025cesmoak">Fun challenge for <a href="cesmoak/index.html">2025/cesmoak</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/cesmoak</strong> is still <strong>OPEN</strong>.</p>
-<p>Modify <code>prog.c</code> so that the code supports the FORTRAN <strong>READ</strong> statement.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
+<p>Modify <code>prog.c</code> so that the code supports the
+<a href="https://en.wikipedia.org/wiki/Fortran">FORTRAN</a> <code>READ</code> statement.</p>
 <div id="diels-grabsch">
 <h2 id="fun-challenge-for-2025diels-grabsch">Fun challenge for <a href="diels-grabsch/index.html">2025/diels-grabsch</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/diels-grabsch</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain the purpose of the constant <code>9018655</code> as used in <code>prog.c</code>.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="dogon">
-<h2 id="fun-challenge-for-2025dogon">Fun challenge for <a href="dogon/index.html">2025/dogon</a></h2>
+<h2 id="fun-challenges-for-2025dogon">Fun challenges for <a href="dogon/index.html">2025/dogon</a></h2>
 </div>
 <div id="dogon_0">
-<h3 id="fun-challenge-0-1">Fun challenge 0</h3>
+<h3 id="fun-challenge-0-for-2025dogon">Fun challenge 0 for <a href="dogon/index.html">2025/dogon</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/dogon</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain why <code>prog.c</code> prints the number of digits of the <strong>constant</strong> that it
 prints.</p>
 <div id="dogon_1">
-<h3 id="fun-challenge-1-1">Fun challenge 1</h3>
+<h3 id="fun-challenge-1-for-2025dogon">Fun challenge 1 for <a href="dogon/index.html">2025/dogon</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/dogon</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Given the “<em>constant</em>” that is printed, explain the last line of output:</p>
 <pre><code>    ./prog | tail -1</code></pre>
 <div id="dogon_2">
-<h3 id="fun-challenge-2">Fun challenge 2</h3>
+<h3 id="fun-challenge-2-for-2025dogon">Fun challenge 2 for <a href="dogon/index.html">2025/dogon</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/dogon</strong> is <strong>CLOSED</strong>.</p>
+<p>This fun challenge is <strong>CLOSED</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code that prints <strong>IOCCC 2025</strong> at
 the very end, in honor of the contest year in which it won, instead of
 <strong>IOCCC 2026</strong>. Of course, the digits printed beforehand should remain
@@ -543,9 +536,9 @@ the same.</p>
 <p><a href="https://github.com/psymar">Samantha Howard</a> on <strong>2026 Jun 09</strong> presented this
 <a href="https://github.com/psymar/IOCCC-dogon-2025-fun-challenge-2">2025/dogon fun challenge 2 solution</a>.</p>
 <div id="dogon_3">
-<h3 id="fun-challenge-3">Fun challenge 3</h3>
+<h3 id="fun-challenge-3-for-2025dogon">Fun challenge 3 for <a href="dogon/index.html">2025/dogon</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/dogon</strong> is <strong>CLOSED</strong>.</p>
+<p>This fun challenge is <strong>CLOSED</strong>.</p>
 <p>Additionally, observe the <a href="https://github.com/ioccc-src/winner/blob/master/2025/dogon/try.sh">try.sh</a> script uses the
 following display the program’s output:</p>
 <pre><code>    ./prog | cat</code></pre>
@@ -594,58 +587,56 @@ the standard output will be “normal”.</p>
 <div id="endoh1">
 <h2 id="fun-challenge-for-2025endoh1">Fun challenge for <a href="endoh1/index.html">2025/endoh1</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/endoh1</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code also works with UPPER CASE LETTERS.
 You would certainly have to
 <a href="https://en.wiktionary.org/wiki/embiggen#English">embiggen</a>
 the tube size to better distinguish individual letters and digits.
 Such code would be a <a href="https://en.wiktionary.org/wiki/cromulent#English">cromulent</a>
 addition to <a href="https://github.com/ioccc-src/winner/blob/master/2025/endoh1/index.html">2025/endoh1</a> code.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="endoh2">
 <h2 id="fun-challenge-for-2025endoh2">Fun challenge for <a href="endoh2/index.html">2025/endoh2</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/endoh2</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code prints a line instead of varying brightness of a yellow line,
 using <a href="https://color-palette.hexdocs.pm/ansi_color_codes.html">256 ANSI Color Codes</a>.
 Choose a colors/brightness palette to represent the charge intensity.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="endoh3">
 <h2 id="fun-challenge-for-2025endoh3">Fun challenge for <a href="endoh3/index.html">2025/endoh3</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/endoh3</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain why the <code>git-am</code> patch generator must be used about 25 times (see
 <a href="https://github.com/ioccc-src/winner/blob/master/2025/endoh3/try.sh">try.sh</a> for details) to produce a unified diff tool.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ferguson">
-<h2 id="fun-challenge-for-2025ferguson">Fun challenge for <a href="ferguson/index.html">2025/ferguson</a></h2>
+<h2 id="fun-challenges-for-2025ferguson">Fun challenges for <a href="ferguson/index.html">2025/ferguson</a></h2>
 </div>
 <div id="ferguson_0">
-<h3 id="fun-challenge-0-2">Fun challenge 0</h3>
+<h3 id="fun-challenge-0-for-2025ferguson">Fun challenge 0 for <a href="ferguson/index.html">2025/ferguson</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ferguson</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code
 allows for different <a href="https://en.wikipedia.org/wiki/List_of_map_projections">map projections</a>.
 Add <code>-p projection</code> as a command line option to change the default projection.
 Add this to a <code>debug.c</code> as well for extra points.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
+<p><strong>NOTE</strong>: you will want to provide <a href="https://en.wikipedia.org/wiki/Netpbm#File_formats">PPM
+images</a> for each type you
+work in. It would be preferable if it was scientific but as the author also
+provided an equirectangular of Flat Earth for fun, it need not be scientific if
+you cannot find one or you wish for some fun.</p>
+<p><strong>NOTE</strong>: the author did <strong>NOT</strong> use a library so you should make sure to do
+this as well (in fact trying to use the library would totally break the code and
+defeat the purpose of some of the obfuscation).</p>
 <div id="ferguson_1">
-<h3 id="fun-challenge-1-2">Fun challenge 1</h3>
+<h3 id="fun-challenge-1-for-2025ferguson">Fun challenge 1 for <a href="ferguson/index.html">2025/ferguson</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ferguson</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain why there are four args (in one invocation) but yet the value of argc, <code>g</code>, is
 only checked once, besides <code>g!= 3 &amp;&amp; g &lt; 5</code> (which should tell you the two forms of
 invocation).</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ferguson_2">
-<h3 id="fun-challenge-2-1">Fun challenge 2</h3>
+<h3 id="fun-challenge-2-for-2025ferguson">Fun challenge 2 for <a href="ferguson/index.html">2025/ferguson</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ferguson</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code renders smaller (or larger) sized
 arrows, making sure that coordinates at the edge of the map are placed
 correctly as well as the other coordinates. Add a <code>debug.alt3.c</code> with the same
@@ -653,42 +644,34 @@ updates.</p>
 <p><strong>Hint</strong>: To test that the arrows fit on the edge of the map, you should
 test coordinates such as <code>0 0</code>, <code>90 180</code>, <code>-90 0</code>, etc. (I.e., coordinates that
 cause the arrows to be at the very edge of a map).</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ferguson_3">
-<h3 id="fun-challenge-3-1">Fun challenge 3</h3>
+<h3 id="fun-challenge-3-for-2025ferguson">Fun challenge 3 for <a href="ferguson/index.html">2025/ferguson</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ferguson</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> the code that solves <a href="#ferguson_2">challenge 2</a>,
 with a <code>-p projection</code> option.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ferguson_4">
-<h3 id="fun-challenge-4">Fun challenge 4</h3>
+<h3 id="fun-challenge-4-for-2025ferguson">Fun challenge 4 for <a href="ferguson/index.html">2025/ferguson</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ferguson</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain why <code>d</code> has to start at <code>-1</code> (bonus: experiment with different values
 and explain what happens and specifically why) and why you can’t change
 the <code>!=1</code> in the code:</p>
 <pre><code>    if  (d=(c!=e==!d!=d!=d==1&amp;&amp;e!=c)!=1||/* NOW YOU KNOW d IS 1! */fread(c, -*(S[F])-d*3 ,
         b*j,q)^j *j *2)X;</code></pre>
 <p><strong>Hint</strong>: the above are related to each other.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="howe">
 <h2 id="fun-challenge-for-2025howe">Fun challenge for <a href="howe/index.html">2025/howe</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/howe</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code is
 slightly harder to play by allowing the closest invader to be killed.
 Compensate slightly for that difficulty increase by allowing the <strong>shift TAB</strong> key
 to cycle in the opposite direction of the <strong>TAB</strong> key.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="jhshrvdp">
 <h2 id="fun-challenge-for-2025jhshrvdp">Fun challenge for <a href="jhshrvdp/index.html">2025/jhshrvdp</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/jhshrvdp</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code that has an “<strong>Amulet of Yendor</strong>”.</p>
 <p>In particular, add an “<strong>Amulet of Yendor</strong>” (similar to the “<code>,</code>” comma character in the
 <a href="https://github.com/lcn2/rogue5.4">rogue 5.4</a> game) to floor 26. If the
@@ -696,60 +679,46 @@ player descends below floor 26 without the amulet, place it on that lower
 floor until the player eventually acquires it. Block the player’s ascent
 (to a lower floor number) unless they possess the amulet. If the player
 returns to the top floor 0 with the amulet, display a winning message, and exit.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="jingp49">
 <h2 id="fun-challenge-for-2025jingp49">Fun challenge for <a href="jingp49/index.html">2025/jingp49</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/jingp49</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code displays <strong>IOCCC 2025</strong> instead of <strong>DOCTOR WHO</strong>.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="kurdyukov">
 <h2 id="fun-challenge-for-2025kurdyukov">Fun challenge for <a href="kurdyukov/index.html">2025/kurdyukov</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/kurdyukov</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code allows for the use of numbers in the
 interval <code>[1, 2^31)</code>, or even the interval <code>[1, 2^63)</code>.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="mattpep">
 <h2 id="fun-challenge-for-2025mattpep">Fun challenge for <a href="mattpep/index.html">2025/mattpep</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/mattpep</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain how the argument to <code>./prog</code> determines if input is encoded or decoded.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ncw1">
 <h2 id="fun-challenge-for-2025ncw1">Fun challenge for <a href="ncw1/index.html">2025/ncw1</a></h2>
 </div>
 <div id="ncw1_0">
-<h3 id="fun-challenge-0-3">Fun challenge 0</h3>
+<h3 id="fun-challenge-0-for-2025ncw1">Fun challenge 0 for <a href="ncw1/index.html">2025/ncw1</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ncw1</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Create a 32K ROM file that tests if <code>2^p-1</code>, is a Mersenne prime using the
 <a href="https://en.wikipedia.org/wiki/Lucas–Lehmer_primality_test">Lucas–Lehmer primality test</a>.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ncw1_1">
-<h3 id="fun-challenge-1-3">Fun challenge 1</h3>
+<h3 id="fun-challenge-1-for-2025ncw1">Fun challenge 1 for <a href="ncw1/index.html">2025/ncw1</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/ncw1</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Create a 32K ROM file that tests if <code>h*2^n-1</code> is prime, using the
 <a href="https://en.wikipedia.org/wiki/Lucas–Lehmer–Riesel_test">Lucas–Lehmer–Riesel primality test</a>.
 You may find the pages related to the <strong>Riesel Test</strong> in the
 <a href="http://www.isthe.com/chongo/tech/math/prime/prime-tutorial.pdf">A Grand Coding Challenge</a>
 helpful.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ncw2">
 <h2 id="fun-challenge-for-2025ncw2">Fun challenge for <a href="ncw2/index.html">2025/ncw2</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/ncw2</strong> is <strong>CLOSED</strong>.</p>
+<p>This fun challenge is <strong>CLOSED</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code with a modified <code>p[]</code> array prints
 the string <code>IOCCC 2025</code> followed by a newline.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="ncw2_solution">
 <h3 id="fun-challenge-solution-for-2025ncw2">Fun challenge solution for <a href="ncw2/index.html">2025/ncw2</a></h3>
 </div>
@@ -758,79 +727,63 @@ FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solut
 <div id="ncw3">
 <h2 id="fun-challenge-for-2025ncw3">Fun challenge for <a href="ncw3/index.html">2025/ncw3</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/ncw3</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code draws a Julia set.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="tompng">
 <h2 id="fun-challenge-for-2025tompng">Fun challenge for <a href="tompng/index.html">2025/tompng</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/tompng</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain the purpose of the constant <code>.5</code>, used several times in <code>prog.c</code>.
 How does changing <code>.5</code> to a different value affect the generated sound?</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="uellenberg">
 <h2 id="fun-challenge-for-2025uellenberg">Fun challenge for <a href="uellenberg/index.html">2025/uellenberg</a></h2>
 </div>
 <div id="uellenberg_0">
-<h3 id="fun-challenge-0-4">Fun challenge 0</h3>
+<h3 id="fun-challenge-0-for-2025uellenberg">Fun challenge 0 for <a href="uellenberg/index.html">2025/uellenberg</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/uellenberg</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Write an alternate version of <code>try.sh</code> that detects when the quasi-quine,
 left to its own iterative devices, starts to repeat.</p>
 <p>If you do not attempt to move the paddle, and let the game run on its
 own, the game should “evolve” to other “modes”, and eventually cycle back
 to the original style of game play.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="uellenberg_1">
-<h3 id="fun-challenge-1-4">Fun challenge 1</h3>
+<h3 id="fun-challenge-1-for-2025uellenberg">Fun challenge 1 for <a href="uellenberg/index.html">2025/uellenberg</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/uellenberg</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Implement an additional game mode using only the original game objects
 (the ball and two paddles).</p>
 <p>For example, you could implement a “flappy bird” game using the ball
 as the bird and the paddles as the pipes.</p>
 <p>As an extra challenge, try to keep the original behavior of the program
 the same, with this new game mode added on top.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="uellenberg_2">
-<h3 id="fun-challenge-2-2">Fun challenge 2</h3>
+<h3 id="fun-challenge-2-for-2025uellenberg">Fun challenge 2 for <a href="uellenberg/index.html">2025/uellenberg</a></h3>
 </div>
-<p>This fun challenge for <strong>2025/uellenberg</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Create a version of the game that “plays itself”, running through all
 the gameplay without user input and returning to the exact source code
 it started with.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="yang1">
 <h2 id="fun-challenge-for-2025yang1">Fun challenge for <a href="yang1/index.html">2025/yang1</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/yang1</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code allows for integers, somewhat
 larger than <code>9999</code>, to be tested for primality.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="yang2">
 <h2 id="fun-challenge-for-2025yang2">Fun challenge for <a href="yang2/index.html">2025/yang2</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/yang2</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Modify <code>prog.c</code> so that the code implements the compression algorithm
 used in the entry as a standalone program outputting a bitstream, and
 compare its performance with <code>gzip -1</code>.</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.</p>
 <div id="yang3">
 <h2 id="fun-challenge-for-2025yang3">Fun challenge for <a href="yang3/index.html">2025/yang3</a></h2>
 </div>
-<p>This fun challenge for <strong>2025/yang3</strong> is still <strong>OPEN</strong>.</p>
+<p>This fun challenge is still <strong>OPEN</strong>.</p>
 <p>Explain the purpose of the constant <code>114</code> in <code>prog.c</code>.
 Are there any alternative values that could replace <code>114</code> without affecting the
-program’s functionality?</p>
-<p>See also the
-FAQ on “<a href="../faq.html#solve_fun_challenge">submit a fun challenge solution</a>”.
+program’s functionality?
 <!-- AFTER: last line of markdown file: 2025/challenge.md --></p>
 
 <!-- END: this line ends content for HTML phase 21 by: bin/pandoc-wrapper.sh via bin/md2html.sh -->

--- a/2025/challenge.md
+++ b/2025/challenge.md
@@ -12,26 +12,24 @@ other types of fun challenges may be posed.
 
 **NOTE**: Some of these challenges are easier than others.
 
-See also the
+See the
 FAQ on "[fun challenges](../faq.html#what_fun_challenge)"
 and, to provide a solution, the
 FAQ on "[submitting a solution to a fun
-challenge](../faq.html#solve_fun_challenge)".
+challenge](../faq.html#solve_fun_challenge)",
+as well as the
+FAQ on "[opening a pull request](../faq.html#pull_request)".
 
 
 <div id="ayu">
 ## Fun challenge for [2025/ayu](ayu/index.html)
 </div>
 
-This fun challenge for **2025/ayu** is **CLOSED**.
+This fun challenge is **CLOSED**.
 
 Modify `prog.c` so that the code allows for `N` to be
 defined for values larger than `11`, e.g., that works with `-DN=12`,
 and up to some reasonable limit.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="ayu_solution">
 ### Fun challenge solution for [2025/ayu](ayu/index.html)
@@ -42,80 +40,70 @@ FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="cable">
-## Fun challenge for [2025/cable](cable/index.html)
+## Fun challenges for [2025/cable](cable/index.html)
 </div>
 
 
 <div id="cable_0">
-### Fun challenge 0
+### Fun challenge 0 for [2025/cable](cable/index.html)
+
 </div>
 
-This fun challenge for **2025/cable** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Use the [toolchain](https://github.com/adriancable/eternal) to compile your own
 software to run on this VM.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="cable_1">
-### Fun challenge 1
+### Fun challenge 1 for [2025/cable](cable/index.html)
+
 </div>
 
-This fun challenge for **2025/cable** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Produce a variant of the vmlinux bootimage that contains a C compiler for this
 VM.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="cesmoak">
 ## Fun challenge for [2025/cesmoak](cesmoak/index.html)
 </div>
 
-This fun challenge for **2025/cesmoak** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
-Modify `prog.c` so that the code supports the FORTRAN **READ** statement.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
+Modify `prog.c` so that the code supports the
+[FORTRAN](https://en.wikipedia.org/wiki/Fortran) `READ` statement.
 
 
 <div id="diels-grabsch">
 ## Fun challenge for [2025/diels-grabsch](diels-grabsch/index.html)
 </div>
 
-This fun challenge for **2025/diels-grabsch** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain the purpose of the constant `9018655` as used in `prog.c`.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="dogon">
-## Fun challenge for [2025/dogon](dogon/index.html)
+## Fun challenges for [2025/dogon](dogon/index.html)
 </div>
 
 
 <div id="dogon_0">
-### Fun challenge 0
+### Fun challenge 0 for [2025/dogon](dogon/index.html)
 </div>
 
-This fun challenge for **2025/dogon** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain why `prog.c` prints the number of digits of the **constant** that it
 prints.
 
 
 <div id="dogon_1">
-### Fun challenge 1
+### Fun challenge 1 for [2025/dogon](dogon/index.html)
 </div>
 
-This fun challenge for **2025/dogon** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Given the "*constant*" that is printed, explain the last line of output:
 
@@ -125,10 +113,10 @@ Given the "*constant*" that is printed, explain the last line of output:
 
 
 <div id="dogon_2">
-### Fun challenge 2
+### Fun challenge 2 for [2025/dogon](dogon/index.html)
 </div>
 
-This fun challenge for **2025/dogon** is **CLOSED**.
+This fun challenge is **CLOSED**.
 
 Modify `prog.c` so that the code that prints **IOCCC 2025** at
 the very end, in honor of the contest year in which it won, instead of
@@ -145,10 +133,10 @@ the same.
 
 
 <div id="dogon_3">
-### Fun challenge 3
+### Fun challenge 3 for [2025/dogon](dogon/index.html)
 </div>
 
-This fun challenge for **2025/dogon** is **CLOSED**.
+This fun challenge is **CLOSED**.
 
 Additionally, observe the [try.sh](%%REPO_URL%%/2025/dogon/try.sh) script uses the
 following display the program's output:
@@ -238,7 +226,7 @@ When you compile `prog.fix.c` into `prog.fix`, the standard output will be "norm
 ## Fun challenge for [2025/endoh1](endoh1/index.html)
 </div>
 
-This fun challenge for **2025/endoh1** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code also works with UPPER CASE LETTERS.
 You would certainly have to
@@ -247,76 +235,67 @@ the tube size to better distinguish individual letters and digits.
 Such code would be a [cromulent](https://en.wiktionary.org/wiki/cromulent#English)
 addition to [2025/endoh1](%%REPO_URL%%/2025/endoh1/index.html) code.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="endoh2">
 ## Fun challenge for [2025/endoh2](endoh2/index.html)
 </div>
 
-This fun challenge for **2025/endoh2** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code prints a line instead of varying brightness of a yellow line,
 using [256 ANSI Color Codes](https://color-palette.hexdocs.pm/ansi_color_codes.html).
 Choose a colors/brightness palette to represent the charge intensity.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="endoh3">
 ## Fun challenge for [2025/endoh3](endoh3/index.html)
 </div>
 
-This fun challenge for **2025/endoh3** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain why the `git-am` patch generator must be used about 25 times (see
 [try.sh](%%REPO_URL%%/2025/endoh3/try.sh) for details) to produce a unified diff tool.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="ferguson">
-## Fun challenge for [2025/ferguson](ferguson/index.html)
+## Fun challenges for [2025/ferguson](ferguson/index.html)
 </div>
 
 
 <div id="ferguson_0">
-### Fun challenge 0
+### Fun challenge 0 for [2025/ferguson](ferguson/index.html)
 </div>
 
-This fun challenge for **2025/ferguson** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code
 allows for different [map projections](https://en.wikipedia.org/wiki/List_of_map_projections).
 Add `-p projection` as a command line option to change the default projection.
 Add this to a `debug.c` as well for extra points.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
+**NOTE**: you will want to provide [PPM
+images](https://en.wikipedia.org/wiki/Netpbm#File_formats) for each type you
+work in. It would be preferable if it was scientific but as the author also
+provided an equirectangular of Flat Earth for fun, it need not be scientific if
+you cannot find one or you wish for some fun.
 
+**NOTE**: the author did **NOT** use a library so you should make sure to do
+this as well (in fact trying to use the library would totally break the code and
+defeat the purpose of some of the obfuscation).
 
 <div id="ferguson_1">
-### Fun challenge 1
+### Fun challenge 1 for [2025/ferguson](ferguson/index.html)
 </div>
 
-This fun challenge for **2025/ferguson** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain why there are four args (in one invocation) but yet the value of argc, `g`, is
 only checked once, besides `g!= 3 && g < 5` (which should tell you the two forms of
 invocation).
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="ferguson_2">
-### Fun challenge 2
+### Fun challenge 2 for [2025/ferguson](ferguson/index.html)
 </div>
 
-This fun challenge for **2025/ferguson** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code renders smaller (or larger) sized
 arrows, making sure that coordinates at the edge of the map are placed
@@ -327,28 +306,21 @@ updates.
 test coordinates such as `0 0`, `90 180`, `-90 0`, etc. (I.e., coordinates that
 cause the arrows to be at the very edge of a map).
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="ferguson_3">
-### Fun challenge 3
+### Fun challenge 3 for [2025/ferguson](ferguson/index.html)
 </div>
 
-This fun challenge for **2025/ferguson** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` the code that solves [challenge 2](#ferguson_2),
 with a `-p projection` option.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="ferguson_4">
-### Fun challenge 4
+### Fun challenge 4 for [2025/ferguson](ferguson/index.html)
 </div>
 
-This fun challenge for **2025/ferguson** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain why `d` has to start at `-1` (bonus: experiment with different values
 and explain what happens and specifically why) and why you can't change
@@ -361,30 +333,24 @@ the `!=1` in the code:
 
 **Hint**: the above are related to each other.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="howe">
 ## Fun challenge for [2025/howe](howe/index.html)
 </div>
 
-This fun challenge for **2025/howe** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code is
 slightly harder to play by allowing the closest invader to be killed.
 Compensate slightly for that difficulty increase by allowing the **shift TAB** key
 to cycle in the opposite direction of the **TAB** key.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="jhshrvdp">
 ## Fun challenge for [2025/jhshrvdp](jhshrvdp/index.html)
 </div>
 
-This fun challenge for **2025/jhshrvdp** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code that has an "**Amulet of Yendor**".
 
@@ -395,45 +361,31 @@ floor until the player eventually acquires it. Block the player’s ascent
 (to a lower floor number) unless they possess the amulet. If the player
 returns to the top floor 0 with the amulet, display a winning message, and exit.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="jingp49">
 ## Fun challenge for [2025/jingp49](jingp49/index.html)
 </div>
 
-This fun challenge for **2025/jingp49** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code displays **IOCCC 2025** instead of **DOCTOR WHO**.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="kurdyukov">
 ## Fun challenge for [2025/kurdyukov](kurdyukov/index.html)
 </div>
 
-This fun challenge for **2025/kurdyukov** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code allows for the use of numbers in the
 interval `[1, 2^31)`, or even the interval `[1, 2^63)`.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="mattpep">
 ## Fun challenge for [2025/mattpep](mattpep/index.html)
 </div>
 
-This fun challenge for **2025/mattpep** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain how the argument to `./prog` determines if input is encoded or decoded.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="ncw1">
@@ -442,23 +394,19 @@ FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="ncw1_0">
-### Fun challenge 0
+### Fun challenge 0 for [2025/ncw1](ncw1/index.html)
 </div>
 
-This fun challenge for **2025/ncw1** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Create a 32K ROM file that tests if `2^p-1`, is a Mersenne prime using the
 [Lucas–Lehmer primality test](https://en.wikipedia.org/wiki/Lucas–Lehmer_primality_test).
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="ncw1_1">
-### Fun challenge 1
+### Fun challenge 1 for [2025/ncw1](ncw1/index.html)
 </div>
 
-This fun challenge for **2025/ncw1** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Create a 32K ROM file that tests if `h*2^n-1` is prime, using the
 [Lucas–Lehmer–Riesel primality test](https://en.wikipedia.org/wiki/Lucas–Lehmer–Riesel_test).
@@ -466,22 +414,15 @@ You may find the pages related to the **Riesel Test** in the
 [A Grand Coding Challenge](http://www.isthe.com/chongo/tech/math/prime/prime-tutorial.pdf)
 helpful.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="ncw2">
 ## Fun challenge for [2025/ncw2](ncw2/index.html)
 </div>
 
-This fun challenge for **2025/ncw2** is **CLOSED**.
+This fun challenge is **CLOSED**.
 
 Modify `prog.c` so that the code with a modified `p[]` array prints
 the string `IOCCC 2025` followed by a newline.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="ncw2_solution">
 ### Fun challenge solution for [2025/ncw2](ncw2/index.html)
@@ -495,26 +436,19 @@ FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 ## Fun challenge for [2025/ncw3](ncw3/index.html)
 </div>
 
-This fun challenge for **2025/ncw3** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code draws a Julia set.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="tompng">
 ## Fun challenge for [2025/tompng](tompng/index.html)
 </div>
 
-This fun challenge for **2025/tompng** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain the purpose of the constant `.5`, used several times in `prog.c`.
 How does changing `.5` to a different value affect the generated sound?
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="uellenberg">
 ## Fun challenge for [2025/uellenberg](uellenberg/index.html)
@@ -522,10 +456,10 @@ FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="uellenberg_0">
-### Fun challenge 0
+### Fun challenge 0 for [2025/uellenberg](uellenberg/index.html)
 </div>
 
-This fun challenge for **2025/uellenberg** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Write an alternate version of `try.sh` that detects when the quasi-quine,
 left to its own iterative devices, starts to repeat.
@@ -534,15 +468,11 @@ If you do not attempt to move the paddle, and let the game run on its
 own, the game should "evolve" to other "modes", and eventually cycle back
 to the original style of game play.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="uellenberg_1">
-### Fun challenge 1
+### Fun challenge 1 for [2025/uellenberg](uellenberg/index.html)
 </div>
 
-This fun challenge for **2025/uellenberg** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Implement an additional game mode using only the original game objects
 (the ball and two paddles).
@@ -553,60 +483,44 @@ as the bird and the paddles as the pipes.
 As an extra challenge, try to keep the original behavior of the program
 the same, with this new game mode added on top.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
 
 <div id="uellenberg_2">
-### Fun challenge 2
+### Fun challenge 2 for [2025/uellenberg](uellenberg/index.html)
 </div>
 
-This fun challenge for **2025/uellenberg** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Create a version of the game that "plays itself", running through all
 the gameplay without user input and returning to the exact source code
 it started with.
 
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
-
-
 <div id="yang1">
 ## Fun challenge for [2025/yang1](yang1/index.html)
 </div>
 
-This fun challenge for **2025/yang1** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code allows for integers, somewhat
 larger than `9999`, to be tested for primality.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="yang2">
 ## Fun challenge for [2025/yang2](yang2/index.html)
 </div>
 
-This fun challenge for **2025/yang2** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Modify `prog.c` so that the code implements the compression algorithm
 used in the entry as a standalone program outputting a bitstream, and
 compare its performance with `gzip -1`.
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".
 
 
 <div id="yang3">
 ## Fun challenge for [2025/yang3](yang3/index.html)
 </div>
 
-This fun challenge for **2025/yang3** is still **OPEN**.
+This fun challenge is still **OPEN**.
 
 Explain the purpose of the constant `114` in `prog.c`.
 Are there any alternative values that could replace `114` without affecting the
 program’s functionality?
-
-See also the
-FAQ on "[submit a fun challenge solution](../faq.html#solve_fun_challenge)".

--- a/faq.html
+++ b/faq.html
@@ -453,7 +453,7 @@
 
 <!-- BEFORE: 1st line of markdown file: faq.md -->
 <h1 id="ioccc-faq-table-of-contents">IOCCC FAQ Table of Contents</h1>
-<p>This is FAQ version <strong>29.07 2026-06-17</strong>.</p>
+<p>This is FAQ version <strong>29.08 2026-06-20</strong>.</p>
 <h2 id="entering-the-ioccc-the-bare-minimum-you-need-to-know">0. <a href="#enter_questions">Entering the IOCCC: the bare minimum you need to know</a></h2>
 <ul>
 <li><strong>Q 0.0</strong>: <a class="normal" href="#enter">How can I enter the IOCCC?</a></li>
@@ -6126,19 +6126,14 @@ repo</a>, simply update the <code>.date-range</code>
 files in the same directories where the changes are made: change the
 final year in the file to the current year. When the website is rebuilt,
 the proper copyright date range will be picked up.</p>
-<div id="history">
-<div id="ioccc_history">
-<h2 id="section-11-history-of-the-ioccc">Section 11: History of the IOCCC</h2>
-</div>
-</div>
 <p>Jump to: <a href="#">top</a></p>
 <div id="what_fun_challenge">
 <h3 id="q-10.13-what-is-a-fun-challenge">Q 10.13: What is a fun challenge?</h3>
 </div>
-<p>A “<strong>fun challenge</strong>” for a winning IOCCC entry is a puzzle or task
-that an <a href="judges.html">IOCCC judge</a> suggested people consider solving.
-After you figure out what a given winning entry does, we encourage you
-to attempt the fun challenge.</p>
+<p>A “<strong>fun challenge</strong>” for a winning IOCCC entry is a puzzle or task that an
+<a href="judges.html">IOCCC judge</a> suggested people consider solving on winning entries.</p>
+<p>After you figure out what a given winning entry does, we encourage you
+to attempt the fun challenge(s).</p>
 <p>Some “<strong>fun challenges</strong>” ask you to explain something about a winning
 IOCCC entry. Other fun challenges ask you to produce a variant of the
 <code>prog.c</code> program that has a different or enhanced behaviour. And still,
@@ -6146,9 +6141,10 @@ other types of fun challenges may be posed.</p>
 <p><strong>NOTE</strong>: Some of these challenges are easier than others.</p>
 <p>You may find the “<strong>fun challenges</strong>” for a given IOCCC year, by visiting
 a given year link on the <a href="years.html">IOCCC Winning Entries by Year</a>
-page, clicking in the <strong>About the Nth IOCCC ((YEAR))</strong> link, and then
-clicking on the <strong>fun challenges for IOCCC ((YEAR))</strong> link.</p>
-<p><strong>NOTE</strong>: “<strong>Fun challenges</strong>” are available only for year <strong>2025 and later</strong>.</p>
+page, clicking on the <strong>About the Nth IOCCC ((YYYY))</strong> link, and then
+clicking on the <strong>fun challenges for IOCCC ((YYYY))</strong> link.</p>
+<p><strong>NOTE</strong>: “<strong>Fun challenges</strong>” are available only for year <strong>2025 and later</strong>
+(IOCCC29 and onward).</p>
 <p><strong>SUGGESTION</strong>: For an example of a “<strong>fun challenges</strong>” set for a given IOCCC year, see:</p>
 <ul>
 <li><a href="2025/challenge.html">Fun challenges for IOCCC year 2025</a></li>
@@ -6168,9 +6164,10 @@ FAQ on “<a href="#solve_fun_challenge">submit a fun challenge solution</a>”.
 <p>Look at the given winning IOCCC entry’s “<strong>fun challenge</strong>” text for a
 given IOCCC year by visiting
 a given year link on the <a href="years.html">IOCCC Winning Entries by Year</a>
-page, clicking in the <strong>About the Nth IOCCC ((YEAR))</strong> link, and then
-clicking on the <strong>fun challenges for IOCCC ((YEAR))</strong> link.</p>
-<p><strong>NOTE</strong>: “<strong>Fun challenges</strong>” are available only for the year <strong>2025 and later</strong>.</p>
+page, clicking in the <strong>About the Nth IOCCC ((YYYY))</strong> link, and then
+clicking on the <strong>fun challenges for IOCCC ((YYYY))</strong> link.</p>
+<p><strong>NOTE</strong>: “<strong>Fun challenges</strong>” are available only for the year <strong>2025 and
+later</strong> (IOCCC29 and onward).</p>
 <p>If the “<strong>fun challenge</strong>” is listed as still <strong>OPEN</strong>, and
 you believe you have a solution to a “<strong>fun challenge</strong>”,
 we ask that you create a <a href="https://www.github.com">GitHub repo</a>
@@ -6192,13 +6189,15 @@ in your <a href="#pull_request">GitHub pull request</a>.</p>
 <p><strong>SUGGESTION</strong>: Look at the <a href="https://github.com/ioccc-src/winner/blob/master/2025/challenge.md">2025/challenge.md file</a>
 for an example of both the markdown form, as well a how a few solutions are presented.</p>
 <p><strong>NOTE</strong>: If the “<strong>fun challenge</strong>” is listed as <strong>CLOSED</strong>,
-and you believe your solution is <strong>substantially better</strong> than any of
+<strong>and</strong> you believe your solution is <strong>substantially better</strong> than any of
 the solution(s) listed, then please consider submitting your solution as well.
 Of course, even if it is not accepted, it is perfectly okay to keep it up for
-others to see, and you could certainly try and improve it more.</p>
+others to see, and you could certainly try and improve it more before trying
+again, just like some past IOCCC winning entries.</p>
 <p><strong>NOTE</strong>: If you have a suggestion for a “<strong>fun challenge</strong>” that is not already
-listed, please consider submitting it as an additional challenge.</p>
-<p><strong>NOTE</strong>: And to state the obvious: the <a href="judges.html">IOCCC judge</a> reserves
+listed, please consider submitting it as an additional challenge by making a
+pull request.</p>
+<p><strong>NOTE</strong>: And to state the obvious: the <a href="judges.html">IOCCC judges</a> reserve
 the right to request modifications to your pull request, linked content,
 or to reject your pull request altogether.</p>
 <p><strong>NOTE</strong>: if you are the author of the winning entry in question, we kindly ask
@@ -6217,6 +6216,12 @@ as well as the <a href="markdown.html">IOCCC markdown guidelines</a>.</p>
 <p>Jump to: <a href="#">top</a></p>
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
+<div id="history">
+<div id="ioccc_history">
+<h2 id="section-11-history-of-the-ioccc">Section 11: History of the IOCCC</h2>
+</div>
+</div>
+<p>Jump to: <a href="#">top</a></p>
 <div id="ioccc_start">
 <div id="stormy_night">
 <div id="beginning">

--- a/faq.md
+++ b/faq.md
@@ -1,6 +1,6 @@
 # IOCCC FAQ Table of Contents
 
-This is FAQ version **29.07 2026-06-17**.
+This is FAQ version **29.08 2026-06-20**.
 
 
 ## 0. [Entering the IOCCC: the bare minimum you need to know](#enter_questions)
@@ -7872,28 +7872,20 @@ files in the same directories where the changes are made: change the
 final year in the file to the current year.  When the website is rebuilt,
 the proper copyright date range will be picked up.
 
-
-<div id="history">
-<div id="ioccc_history">
-## Section 11: History of the IOCCC
-</div>
-</div>
-
-
 Jump to: [top](#)
-
 
 <div id="what_fun_challenge">
 ### Q 10.13: What is a fun challenge?
 </div>
 
-A "**fun challenge**" for a winning IOCCC entry is a puzzle or task
-that an [IOCCC judge](judges.html) suggested people consider solving.
+A "**fun challenge**" for a winning IOCCC entry is a puzzle or task that an
+[IOCCC judge](judges.html) suggested people consider solving on winning entries.
+
 After you figure out what a given winning entry does, we encourage you
-to attempt the fun challenge.
+to attempt the fun challenge(s).
 
 Some "**fun challenges**" ask you to explain something about a winning
-IOCCC entry.  Other fun challenges ask you to produce a variant of the
+IOCCC entry. Other fun challenges ask you to produce a variant of the
 `prog.c` program that has a different or enhanced behaviour.  And still,
 other types of fun challenges may be posed.
 
@@ -7901,10 +7893,11 @@ other types of fun challenges may be posed.
 
 You may find the "**fun challenges**" for a given IOCCC year, by visiting
 a given year link on the [IOCCC Winning Entries by Year](years.html)
-page, clicking in the **About the Nth IOCCC ((YEAR))** link, and then
-clicking on the **fun challenges for IOCCC ((YEAR))** link.
+page, clicking on the **About the Nth IOCCC ((YYYY))** link, and then
+clicking on the **fun challenges for IOCCC ((YYYY))** link.
 
-**NOTE**: "**Fun challenges**" are available only for year **2025 and later**.
+**NOTE**: "**Fun challenges**" are available only for year **2025 and later**
+(IOCCC29 and onward).
 
 **SUGGESTION**: For an example of a "**fun challenges**" set for a given IOCCC year, see:
 
@@ -7930,10 +7923,11 @@ Jump to: [top](#)
 Look at the given winning IOCCC entry's "**fun challenge**" text for a
 given IOCCC year by visiting
 a given year link on the [IOCCC Winning Entries by Year](years.html)
-page, clicking in the **About the Nth IOCCC ((YEAR))** link, and then
-clicking on the **fun challenges for IOCCC ((YEAR))** link.
+page, clicking in the **About the Nth IOCCC ((YYYY))** link, and then
+clicking on the **fun challenges for IOCCC ((YYYY))** link.
 
-**NOTE**: "**Fun challenges**" are available only for the year **2025 and later**.
+**NOTE**: "**Fun challenges**" are available only for the year **2025 and
+later** (IOCCC29 and onward).
 
 If the "**fun challenge**" is listed as still **OPEN**, and
 you believe you have a solution to a "**fun challenge**",
@@ -7960,15 +7954,17 @@ in your [GitHub pull request](#pull_request).
 for an example of both the markdown form, as well a how a few solutions are presented.
 
 **NOTE**: If the "**fun challenge**" is listed as **CLOSED**,
-and you believe your solution is **substantially better** than any of
+**and** you believe your solution is **substantially better** than any of
 the solution(s) listed, then please consider submitting your solution as well.
 Of course, even if it is not accepted, it is perfectly okay to keep it up for
-others to see, and you could certainly try and improve it more.
+others to see, and you could certainly try and improve it more before trying
+again, just like some past IOCCC winning entries.
 
 **NOTE**: If you have a suggestion for a "**fun challenge**" that is not already
-listed, please consider submitting it as an additional challenge.
+listed, please consider submitting it as an additional challenge by making a
+pull request.
 
-**NOTE**: And to state the obvious: the [IOCCC judge](judges.html) reserves
+**NOTE**: And to state the obvious: the [IOCCC judges](judges.html) reserve
 the right to request modifications to your pull request, linked content,
 or to reject your pull request altogether.
 
@@ -7995,6 +7991,18 @@ Jump to: [top](#)
 
 <hr style="width:50%;text-align:left;margin-left:0">
 <hr style="width:50%;text-align:left;margin-left:0">
+
+
+
+<div id="history">
+<div id="ioccc_history">
+## Section 11: History of the IOCCC
+</div>
+</div>
+
+
+Jump to: [top](#)
+
 
 
 <div id="ioccc_start">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -15994,11 +15994,11 @@
 </url>
 <url>
     <loc>https://www.ioccc.org/2025/challenge.html</loc>
-    <lastmod>2026-06-18T03:08:18+00:00</lastmod>
+    <lastmod>2026-06-20T18:51:49+00:00</lastmod>
 </url>
 <url>
     <loc>https://www.ioccc.org/2025/challenge.md</loc>
-    <lastmod>2026-06-18T03:07:59+00:00</lastmod>
+    <lastmod>2026-06-20T18:45:11+00:00</lastmod>
 </url>
 <url>
     <loc>https://www.ioccc.org/2025/diels-grabsch/2025_diels-grabsch.tar.bz2</loc>
@@ -18158,11 +18158,11 @@
 </url>
 <url>
     <loc>https://www.ioccc.org/faq.html</loc>
-    <lastmod>2026-06-18T03:14:51+00:00</lastmod>
+    <lastmod>2026-06-20T18:45:11+00:00</lastmod>
 </url>
 <url>
     <loc>https://www.ioccc.org/faq.md</loc>
-    <lastmod>2026-06-18T03:14:47+00:00</lastmod>
+    <lastmod>2026-06-20T18:45:11+00:00</lastmod>
 </url>
 <url>
     <loc>https://www.ioccc.org/inc/index.html</loc>
@@ -18342,7 +18342,7 @@
 </url>
 <url>
     <loc>https://www.ioccc.org/status.html</loc>
-    <lastmod>2026-06-18T02:19:25+00:00</lastmod>
+    <lastmod>2026-06-20T18:52:21+00:00</lastmod>
 </url>
 <url>
     <loc>https://www.ioccc.org/status.json</loc>


### PR DESCRIPTION
Besides typo fixes some changes involve removing redundant (duplicated in fact) text (some still could be done in the FAQ though, see below) as in the past many people have been plagued by long text (partly my fault) and it was unnecessary to repeat.

Added links to the respective entries in the headers '...fun challenge [0-9] for ...'.

The above helps with the shortening of 'this fun challenge for YYYY/entry is still open': now it just says 'this fun challenge is still OPEN' (or 'this fun challenge is CLOSED').

In the FAQ the two items related to the fun challenges were in section 11 rather than the end of section 10. I did notice that the second FAQ (the providing a solution one) essentially (if not entirely) repeats the beginning of the previous question and that might (or might not) want to be fixed.

I also observe that we could (whether it should be done is another question) link to the FAQ at the top of the challenge.html file rather than repeat the same thing as the FAQ itself.

# Making a pull request

Please see the FAQ on "[making a pull request](faq.html#pull_request)".
