### PR TITLE
Make "original source code" unique for all .entry.json

### DIFF
--- a/1992/westley/.entry.json
+++ b/1992/westley/.entry.json
@@ -51,7 +51,7 @@
             "OK_to_edit" : true,
             "display_as" : "c",
             "display_via_github" : true,
-            "entry_text" : "original source code"
+            "entry_text" : "original alternate source code"
         },
         {
             "file_path" : "westley.orig.c",


### PR DESCRIPTION
`1992/westley/.entry.json` is unique in that it's the only `.entry.json` that mentions "original source code" twice in the manifest.  All other 365 `.entry.json` files has one unique reference for the main program.  The original intended description was likely "the original version of westley.alt.c", hence this change.