### PR TITLE
Fix header image style on mobile

### DIFF
--- a/ioccc.css
+++ b/ioccc.css
@@ -1134,7 +1134,7 @@ blockquote {
 	font-size: 0.9em;
     }
     .header img {
-	visibility: none;
+	display: none;
 	width: 0;
 	border: 0;
 	padding: 0;


### PR DESCRIPTION
Sorry, this is fixing a regression I introduced with the previous PR. This media query section was never updated, so the header was showing up on mobile when it wasn't meant to. `visibility: none` isn't valid CSS, so I just swapped it with display (which was probably the original intention).